### PR TITLE
Minor spelling correction in documentation

### DIFF
--- a/lib/nokogiri/xml/sax/document.rb
+++ b/lib/nokogiri/xml/sax/document.rb
@@ -36,7 +36,7 @@ module Nokogiri
     #   parser.parse(File.read(ARGV[0], 'rb'))
     #
     # Now my document handler will be called when each node starts, and when
-    # then document ends.  To see what kinds of events are available, take
+    # the document ends.  To see what kinds of events are available, take
     # a look at Nokogiri::XML::SAX::Document.
     #
     # Two SAX parsers for XML are available, a parser that reads from a string


### PR DESCRIPTION
"your" should be "you"
