### PR TITLE
".." as a bit of valid XPath

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -103,7 +103,7 @@ module Nokogiri
 
         xpath(*(paths.map { |path|
           path = path.to_s
-          path =~ /^(\.\/|\/)/ ? path : CSS.xpath_for(
+          path =~ /^(\.\/|\/|\.\.)/ ? path : CSS.xpath_for(
             path,
             :prefix => prefix,
             :ns     => ns

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -699,6 +699,15 @@ module Nokogiri
         assert_equal('/staff/employee[1]', node.path)
       end
 
+      def test_parent_xpath
+        assert set = @xml.search('//employee')
+        assert node = set.first
+        assert parent_set = node.search('..')
+        assert parent_node = parent_set.first
+        assert_equal '/staff', parent_node.path
+        assert_equal node.parent, parent_node
+      end
+
       def test_search_by_symbol
         assert set = @xml.search(:employee)
         assert 5, set.length


### PR DESCRIPTION
Currently, when you do Node#search(".."), Nokogiri interprets this as needing to be converted from CSS into XPath and therefore throws an error. I modified the matchers to skip the CSS-conversion of this selector to make it easy to search for your parent.
