### PR TITLE
Support for libxml XML_PARSE_HUGE

### DIFF
--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -37,6 +37,8 @@ module Nokogiri
       NOCDATA     = 1 << 14
       # do not generate XINCLUDE START/END nodes
       NOXINCNODE  = 1 << 15
+      # relax any hardcoded limit from the parser
+      HUGE        = 1 << 19
 
       # the default options used for parsing XML documents
       DEFAULT_XML  = RECOVER


### PR DESCRIPTION
Since version 2.7.3 libxml has a maximum size of a single textnode by 10 MB.
There is a Parser-Flag, which will disable the limit. It will be good, if nokogiri
would support this option. libxml-ruby supports it. This fork will support the flag.

(I have made an issue with the same subject: 430 and closed it, beacuse I have
learned the pull request.)
