### PR TITLE
Nokogiri#parse html expression too greedy

### DIFF
--- a/lib/nokogiri.rb
+++ b/lib/nokogiri.rb
@@ -66,7 +66,7 @@ module Nokogiri
     def parse string, url = nil, encoding = nil, options = nil
       doc =
         if string.respond_to?(:read) ||
-          string =~ /^\s*<[^Hh>]*html/i # Probably html
+          string.index(/^[^<]*\<(!doctype\s)?html(>|\s)/i) == 0 # Probably html
           Nokogiri.HTML(
             string,
             url,

--- a/test/files/staff.xml
+++ b/test/files/staff.xml
@@ -54,6 +54,7 @@
   <position>Computer Specialist</position>
   <salary>90,000</salary>
   <gender>male</gender>
+  <email format="html">robert@example.com</email>
   <address street="Yes">1821 Nordic. Road, Irving Texas 98558</address>
  </employee>
  </staff>

--- a/test/test_nokogiri.rb
+++ b/test/test_nokogiri.rb
@@ -1,6 +1,11 @@
 require "helper"
 
 class TestNokogiri < Nokogiri::TestCase
+  def test_html_in_xml_attribute
+    assert !Nokogiri.parse('<?xml version="1.0">
+<root attr="html" />').html?
+  end
+
   def test_versions
     version_match = /\d+\.\d+\.\d+/
     assert_match version_match, Nokogiri::VERSION


### PR DESCRIPTION
The current html expression matches for the text "html" being present in the first element of any line in the document.
    /^\s_<[^Hh>]_html/i
Resulting in something like:
    Nokogiri.parse("<?xml version='1.0'?><root>
    <node v='html' /></root>");
getting interpreted as html.

I modified the expression to detect "<!doctype html" or "<html", requiring one of these to be the first element found for the html parser to kick in.
