### PR TITLE
Verifing that we have a document or file before validating

### DIFF
--- a/lib/nokogiri/xml/schema.rb
+++ b/lib/nokogiri/xml/schema.rb
@@ -43,7 +43,13 @@ module Nokogiri
       # Nokogiri::XML::SyntaxError objects found while validating the
       # +thing+ is returned.
       def validate thing
-        thing.is_a?(Nokogiri::XML::Document) ? validate_document(thing) : validate_file(thing)
+        if thing.is_a?(Nokogiri::XML::Document) 
+          validate_document(thing) 
+        elsif File.file?(thing)
+          validate_file(thing)
+        else
+          raise ArgumentError, "Must provide Nokogiri::Xml::Document or the name of an existing file"
+        end
       end
 
       ###

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -74,6 +74,11 @@ module Nokogiri
         assert_equal 2, errors.length
       end
 
+      def test_validate_non_document
+        string = File.read(PO_XML_FILE)
+        assert_raise(ArgumentError) {@xsd.validate(string)}
+      end
+
       def test_valid?
         valid_doc = Nokogiri::XML(File.read(PO_XML_FILE))
 


### PR DESCRIPTION
Patch for an issue that tripped me up: I passed in my rendered XML as a string to Nokogiri::XML::Schema#validate, and it simply returned an empty list of errors as if all was well. Now it will throw an ArgumentError in that case.
# Commit message follows.

Nokogiri::XML::Schema#validate throws error if not given a Nokogiri::XML::Document or the path of an existing file.

Previously, passing in any other string would fail silently. For example, if rendered XML was passed in as a string, it would simply return an empty list of errors. Now an ArgumentError will be thrown.
