### PR TITLE
Don't return the first chunk twice when parsing an HTML file with unknown

### DIFF
--- a/lib/nokogiri/html/document.rb
+++ b/lib/nokogiri/html/document.rb
@@ -193,9 +193,6 @@ module Nokogiri
             if encoding = EncodingReader.detect_encoding(@firstchunk)
               raise EncodingFoundException, encoding
             end
-
-            # This chunk is stored for the next read in retry.
-            return @firstchunk
           end
 
           ret = @firstchunk.slice!(0, len)


### PR DESCRIPTION
Don't return the first chunk twice when parsing an HTML file with unknown encoding. Fixes issue #488.
