### PR TITLE
Added code to nicely initialise the NokogiriXsltErrorListener

### DIFF
--- a/ext/java/nokogiri/internals/NokogiriXsltErrorListener.java
+++ b/ext/java/nokogiri/internals/NokogiriXsltErrorListener.java
@@ -42,14 +42,15 @@ import javax.xml.transform.TransformerException;
  */
 public class NokogiriXsltErrorListener implements ErrorListener {
     public enum ErrorType {
+        SUCCESS,
         WARNING,
         ERROR,
         FATAL
     }
 
-    private ErrorType type;
-    private String errorMessage;
-    private Exception exception;
+    private ErrorType type = ErrorType.SUCCESS;
+    private String errorMessage = null;
+    private Exception exception = null;
 
     public void warning(TransformerException ex) throws TransformerException {
         type = ErrorType.WARNING;


### PR DESCRIPTION
Hi,

  I've recently updated my code to use the latest version of the Java Nokogiri gem and for some reason I'm getting null pointer exceptions after executing and stylesheet transformations.  I tracked it down to the NokogiriXsltErrorListener class not initialising correctly.  The really odd thing is that all the tests pass with or without the changes included in this pull request, but my application fails every time without this fix.

Daniel
