### PR TITLE
Fix a memory leak when XSLT.parse fails

### DIFF
--- a/test/test_xslt_transforms.rb
+++ b/test/test_xslt_transforms.rb
@@ -175,10 +175,7 @@ encoding="iso-8859-1" indent="yes"/>
   </xsl:template>
 </xsl:stylesheet>}
       EOX
-      old_verbose = $VERBOSE
-      $VERBOSE = false
       assert_raises(RuntimeError) { Nokogiri::XSLT.parse(xslt_str) }
-      $VERBOSE = old_verbose
     end
 
     def test_passing_a_non_document_to_transform


### PR DESCRIPTION
Here is a quick way to see this memory leak in action:
$ ruby -Ilib -Itest -e "require 'test_xslt_transforms.rb'; loop{ MiniTest::Unit.new.run }"

In xslt_stylesheet.c, the method parse_stylesheet_doc() gives libxslt an error
callback and then invokes xsltParseStylesheetDoc.

Nokogiri's error callback invokes rb_exc_raise() which prevents the function
from returning to the caller. As a result libxslt never cleans up after itself
and we leak memory.

Additionally, xsltParseStylesheetDoc requires that the caller frees the XML
document on failure.

This commit fixes both of the above issues. Note one side effect -- we no longer
provide the exact reason for the parser failure in the exception. I added
rb_warning() to the error callback so that the error can be seen when Ruby is
running with $VERBOSE.

I wrote up description of how I found and fixed this leak at:
http://holymonkey.com/how-to-find-and-fix-a-memory-leak-in-a-ruby-c-extension.html
