### PR TITLE
Plug memory leak in XML::Text.new

### DIFF
--- a/ext/nokogiri/xml_text.c
+++ b/ext/nokogiri/xml_text.c
@@ -22,6 +22,8 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
   node = xmlNewText((xmlChar *)StringValuePtr(string));
   node->doc = doc->doc;
 
+  NOKOGIRI_ROOT_NODE(node);
+
   rb_node = Nokogiri_wrap_xml_node(klass, node) ;
   rb_obj_call_init(rb_node, argc, argv);
 


### PR DESCRIPTION
XML text nodes were not being registered and never got freed and the following will eat up all memory:

```
loop {
    doc = Nokogiri.XML "<r></r>"
    Nokogiri::XML::Text.new('hello', doc)
}
```
