### PR TITLE
Plug a memory leak in XML::Node#replace

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -170,6 +170,8 @@ static VALUE reparent_node_with(VALUE pivot_obj, VALUE reparentee_obj, pivot_rep
     rb_raise(rb_eRuntimeError, "Could not reparent node");
   }
 
+  NOKOGIRI_ROOT_NODE(pivot);
+
   /*
    *  make sure the ruby object is pointed at the just-reparented node, which
    *  might be a duplicate (see above) or might be the result of merging


### PR DESCRIPTION
Any kind of XML node was not being freed properly after being replaced and the following will eat all memory:

```
loop {
    doc = Nokogiri.XML "<root><a1>First node</a1><a2>Second node</a2><a3>Third <bx />node</a3></root>"
    n =  XML::CDATA.new(doc, "hello")
    doc.at_xpath("/root/a3/bx").replace n
}
```
