### PR TITLE
Disable the node cache when we are using an XML Reader

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1232,7 +1232,7 @@ VALUE Nokogiri_wrap_xml_node(VALUE klass, xmlNodePtr node)
   VALUE document = Qnil ;
   VALUE node_cache = Qnil ;
   VALUE rb_node = Qnil ;
-  int node_has_a_document = 0 ;
+  nokogiriTuplePtr node_has_a_document;
   void (*mark_method)(xmlNodePtr) = NULL ;
 
   assert(node);
@@ -1240,7 +1240,13 @@ VALUE Nokogiri_wrap_xml_node(VALUE klass, xmlNodePtr node)
   if(node->type == XML_DOCUMENT_NODE || node->type == XML_HTML_DOCUMENT_NODE)
       return DOC_RUBY_OBJECT(node->doc);
 
-  if(NULL != node->_private) return (VALUE)node->_private;
+  /* It's OK if the node doesn't have a fully-realized document (as in XML::Reader). */
+  /* see https://github.com/tenderlove/nokogiri/issues/95 */
+  /* and https://github.com/tenderlove/nokogiri/issues/439 */
+  node_has_a_document = DOC_RUBY_OBJECT_TEST(node->doc);
+
+  if(node->_private && node_has_a_document)
+    return (VALUE)node->_private;
 
   if(!RTEST(klass)) {
     switch(node->type)
@@ -1286,10 +1292,6 @@ VALUE Nokogiri_wrap_xml_node(VALUE klass, xmlNodePtr node)
     }
   }
 
-  /* It's OK if the node doesn't have a fully-realized document (as in XML::Reader). */
-  /* see https://github.com/tenderlove/nokogiri/issues/95 */
-  /* and https://github.com/tenderlove/nokogiri/issues/439 */
-  node_has_a_document = (DOC_RUBY_OBJECT_TEST(node->doc) && DOC_RUBY_OBJECT(node->doc)) ? 1 : 0 ;
   mark_method = node_has_a_document ? mark : NULL ;
 
   rb_node = Data_Wrap_Struct(klass, mark_method, debug_node_dealloc, node) ;

--- a/test/xml/test_reader_encoding.rb
+++ b/test/xml/test_reader_encoding.rb
@@ -120,6 +120,22 @@ module Nokogiri
             assert_equal @reader.encoding, name.encoding.name
           end
         end
+
+        def test_value_lookup_segfault
+          skip("JRuby doesn't do GC.") if Nokogiri.jruby?
+          old_stress = GC.stress
+
+          begin
+            GC.stress = true
+
+            while node = @reader.read
+              nodes = node.send(:attr_nodes)
+              nodes.first.name if nodes.first
+            end
+          ensure
+            GC.stress = old_stress
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes a segfault with XML Readers when GC happens at the wrong time.

I came across this segfault with GC stress disabled, but the test temporarily enables GC stress in order to consistently trigger it.

My initial reaction was to [disable the node cache entirely](https://github.com/ender672/nokogiri/tree/reader_segfault) but I backed away from that because it would probably stir up a much bigger debate.

This commit disables the node cache only for nodes generated by an XML Reader object.

I don't feel that the ability to define singleton methods on nodes is worth the costs:
- Increased odds for GC segfaults such as this one
- Requires that we prevent GC on all associated Ruby objects until the document goes away.
- Added complexity -- you have to make sure to add nodes to the cache whenever created (or, in the case of this solution, disable the node cache for edge cases).
