### PR TITLE
Prevent potential segfault when an attribute node is replaced

### DIFF
--- a/test/xml/test_node_attributes.rb
+++ b/test/xml/test_node_attributes.rb
@@ -29,6 +29,24 @@ module Nokogiri
         assert node.namespaced_key?('foo', nil)
         assert !node.namespaced_key?('foo', 'foo')
       end
+
+      def test_set_attribute_frees_nodes # testing a segv
+        document = Nokogiri::XML.parse("<foo></foo>")
+
+        node = document.root
+        node['visible'] = 'foo'
+        attribute = node.attribute('visible')
+        text = Nokogiri::XML::Text.new 'bar', document
+        attribute.add_child(text)
+
+        begin
+          gc_previous = GC.stress
+          GC.stress = true
+          node['visible'] = 'attr'
+        ensure
+          GC.stress = gc_previous
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When we replace an attribute node, libxml frees all children of the attribute. If we had a ruby object pointing to one of those children then this results in a segfault. Prevent this from happening by unlinking the children prior to replacing the attribute.

This should fix the problem described in Issue #513. Unfortunately, github doesn't allow me to attach the pull request directly to the issue yet.
