### PR TITLE
Plug memory leak when an xpath returns namespaces

### DIFF
--- a/ext/nokogiri/xml_node_set.h
+++ b/ext/nokogiri/xml_node_set.h
@@ -6,4 +6,9 @@ void init_xml_node_set();
 
 extern VALUE cNokogiriXmlNodeSet ;
 VALUE Nokogiri_wrap_xml_node_set(xmlNodeSetPtr node_set, VALUE document) ;
+
+typedef struct _nokogiriNodeSetTuple {
+  xmlNodeSetPtr node_set;
+  st_table     *namespaces;
+} nokogiriNodeSetTuple;
 #endif

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -59,6 +59,7 @@ static void ruby_funcall(xmlXPathParserContextPtr ctx, int nargs)
   xmlNodeSetPtr xml_node_set = NULL;
   xmlXPathObjectPtr obj;
   int i;
+  nokogiriNodeSetTuple *node_set_tuple;
 
   assert(ctx);
   assert(ctx->context);
@@ -135,13 +136,15 @@ static void ruby_funcall(xmlXPathParserContextPtr ctx, int nargs)
 	args[0] = doc;
 	args[1] = result;
         node_set = rb_class_new_instance(2, args, cNokogiriXmlNodeSet);
-        Data_Get_Struct(node_set, xmlNodeSet, xml_node_set);
+        Data_Get_Struct(node_set, nokogiriNodeSetTuple, node_set_tuple);
+	xml_node_set = node_set_tuple->node_set;
         xmlXPathReturnNodeSet(ctx, xmlXPathNodeSetMerge(NULL, xml_node_set));
       }
       break;
     case T_DATA:
       if(rb_obj_is_kind_of(result, cNokogiriXmlNodeSet)) {
-        Data_Get_Struct(result, xmlNodeSet, xml_node_set);
+        Data_Get_Struct(result, nokogiriNodeSetTuple, node_set_tuple);
+	xml_node_set = node_set_tuple->node_set;
         /* Copy the node set, otherwise it will get GC'd. */
         xmlXPathReturnNodeSet(ctx, xmlXPathNodeSetMerge(NULL, xml_node_set));
         break;

--- a/test/test_memory_leak.rb
+++ b/test/test_memory_leak.rb
@@ -26,7 +26,7 @@ class TestMemoryLeak < Nokogiri::TestCase
       io = File.open SNUGGLES_FILE
       Nokogiri::XML.parse(io)
 
-      (10**10).times do
+      loop do
         Nokogiri::XML.parse(BadIO.new) rescue nil
         doc.write BadIO.new rescue nil
       end
@@ -58,6 +58,14 @@ class TestMemoryLeak < Nokogiri::TestCase
         assert((count_end - count_start) <= 2, "memory leak detected")
       rescue LoadError
         puts "\ndike is not installed, skipping memory leak test"
+      end
+    end
+
+    def test_node_set_namespace_mem_leak
+      xml = Nokogiri::XML "<foo></foo>"
+      ctx = Nokogiri::XML::XPathContext.new(xml)
+      loop do
+        ctx.evaluate("//namespace::*")
       end
     end
   end # if NOKOGIRI_GC


### PR DESCRIPTION
When evaluating an xpath, we get a set of nodes and, potentially,
namespaces. The nodes are pointers to document nodes which will be
freed automatically at document deallocation.

The namespaces, however, belong to the xpath evaluation and it is
our responsibility to free them. At deallocation time we don't
know whether the document has been freed already, and it is unsafe
to traverse the node list to free our namespaces.

This fixes the issue by creating a separate list of namespaces and
freeing them at deallocation time.

An attempt at plugging this leak was made with commit dbda52b and
reverted with commit eacd089
