### PR TITLE
Don't override gcc optimize flag in extconf.rb

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -30,7 +30,8 @@ if RbConfig::MAKEFILE_CONFIG['CC'] =~ /mingw/
 end
 
 if RbConfig::MAKEFILE_CONFIG['CC'] =~ /gcc/
-  $CFLAGS << " -O3 -Wall -Wcast-qual -Wwrite-strings -Wconversion -Wmissing-noreturn -Winline"
+  $CFLAGS << " -O3" unless $CFLAGS[/-O\d/]
+  $CFLAGS << " -Wall -Wcast-qual -Wwrite-strings -Wconversion -Wmissing-noreturn -Winline"
 end
 
 if RbConfig::CONFIG['target_os'] =~ /mswin32/


### PR DESCRIPTION
This change allows me to compile Nokogiri with:

```
$ rake compile CFLAGS="-O0"
```

For easier debugging.
