### PR TITLE
fix ArgumentError exception: not_found should have no arguments

### DIFF
--- a/lib/nokogiri/html/document.rb
+++ b/lib/nokogiri/html/document.rb
@@ -142,7 +142,7 @@ module Nokogiri
             throw @jumptag, encoding
           end
 
-          def not_found(encoding)
+          def not_found
             found nil
           end
 


### PR DESCRIPTION
My first use of GitHub edit-in-place feature :) There's a missing test for this, but this is beyond my free time ;) Trying to focus on migrating Gitorious to Devise and Rails 3 right now :)

I found this bug while debugging why save_and_open_page from Capybara wasn't working while writing an integration test for OpenID and Gitorious integration... :D
