### PR TITLE
Fix EmptyStackException thrown by elements with xlink:href attributes and no base_uri.

### DIFF
--- a/ext/java/nokogiri/internals/ReaderNode.java
+++ b/ext/java/nokogiri/internals/ReaderNode.java
@@ -396,6 +396,7 @@ public abstract class ReaderNode {
                     else return base.concat("/").concat(v);
                 }
             } else if ("xlink:href".equals(n)) {
+                if (xmlBaseStack.isEmpty()) return v;
                 String base = xmlBaseStack.peek();
                 if (base.endsWith("/")) return base.concat(v);
                 else return base.concat("/").concat(v);

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -399,6 +399,45 @@ class TestReader < Nokogiri::TestCase
                   reader.map {|n| n.base_uri })
   end
 
+  def test_xlink_href_with_base_uri
+    reader = Nokogiri::XML::Reader(<<-eoxml)
+      <x xml:base="http://base.example.org/base/"
+         xmlns:xlink="http://www.w3.org/1999/xlink">
+        <link xlink:href="#other">Link</link>
+        <other id="other">Linked Element</other>
+      </x>
+    eoxml
+
+    reader.each do |node|
+      if node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+        if node.name == 'link'
+          assert_equal node.base_uri, "http://base.example.org/base/#other"
+        else
+          assert_equal node.base_uri, "http://base.example.org/base/"
+        end
+      end
+    end
+  end
+
+  def test_xlink_href_without_base_uri
+    reader = Nokogiri::XML::Reader(<<-eoxml)
+      <x xmlns:xlink="http://www.w3.org/1999/xlink">
+        <link xlink:href="#other">Link</link>
+        <other id="other">Linked Element</other>
+      </x>
+    eoxml
+
+    reader.each do |node|
+      if node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+        if node.name == 'link'
+          assert_equal node.base_uri, "#other"
+        else
+          assert_nil node.base_uri, "Node #{node.name} not nil"
+        end
+      end
+    end
+  end
+
   def test_read_from_memory
     called = false
     reader = Nokogiri::XML::Reader.from_memory('<foo>bar</foo>')


### PR DESCRIPTION
Nokogiri::XML::Reader required elements with xlink:href attributes to be contained by elements with xml:base attributes.  ReaderNode would throw an EmptyStackException if this wasn't the case.

The xlink spec is ambiguous about whether that situation is allowed, but a few online xlink examples and our real-world data have xlink:href attributes with no xml:base.

Nokogiri uses xlink:href to compute the base_uri attribute, but I didn't see any tests for this, so I wrote two.  The second one fails without my fix.
