### PR TITLE
Prevent segfault when removing namespaces on a document with XML entities

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -53,7 +53,7 @@ static void recursively_remove_namespaces_from_node(xmlNodePtr node)
     node->nsDef = NULL;
   }
 
-  if (node->properties != NULL) {
+  if (node->type == XML_ELEMENT_NODE && node->properties != NULL) {
     property = node->properties ;
     while (property != NULL) {
       if (property->ns) property->ns = NULL ;

--- a/test/xml/test_namespace.rb
+++ b/test/xml/test_namespace.rb
@@ -65,6 +65,11 @@ module Nokogiri
         ns = @xml.root.add_namespace_definition('baz', 'bar')
         assert_equal 'baz', ns.prefix
       end
+
+      def test_remove_entity_namespace
+        s = %q{<?xml version='1.0'?><!DOCTYPE schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" [<!ENTITY % p ''>]>}
+        Nokogiri::XML(s).remove_namespaces!
+      end
     end
   end
 end


### PR DESCRIPTION
When we call remove_namespaces! on a node with XML entity references nokogiri will segfault.

This should fix the problem described in Issue #538
