### PR TITLE
Fix meta_encoding with empty or broken Content-Type header.

### DIFF
--- a/lib/nokogiri/html/document.rb
+++ b/lib/nokogiri/html/document.rb
@@ -19,7 +19,9 @@ module Nokogiri
 
       def meta_content_type
         css('meta[@http-equiv]').find { |node|
-          node['http-equiv'] =~ /\AContent-Type\z/i
+          node['http-equiv'] =~ /\AContent-Type\z/i and
+            !node['content'].nil? and
+            !node['content'].empty?
         }
       end
       private :meta_content_type

--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -199,6 +199,32 @@ eohtml
         assert_nil html.meta_encoding
       end
 
+      def test_meta_encoding_with_empty_content_type
+        html = Nokogiri::HTML(<<-eohtml)
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="">
+  </head>
+  <body>
+    foo
+  </body>
+</html>
+        eohtml
+        assert_nil html.meta_encoding
+
+        html = Nokogiri::HTML(<<-eohtml)
+<html>
+  <head>
+    <meta http-equiv="Content-Type">
+  </head>
+  <body>
+    foo
+  </body>
+</html>
+        eohtml
+        assert_nil html.meta_encoding
+      end
+
       def test_root_node_parent_is_document
         parent = @html.root.parent
         assert_equal @html, parent


### PR DESCRIPTION
This fixes the following error if the document has a broken or empty Content-Type meta header.

```
NoMethodError: undefined method `[]' for nil:NilClass
   meta_encoding at vendor/bundle/jruby/1.8/gems/nokogiri-1.5.0-java/lib/nokogiri/html/document.rb:8
```
