### PR TITLE
fix for issue 550 (prevent siblings from being added to root)

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -291,6 +291,8 @@ module Nokogiri
       #
       # Also see related method +before+.
       def add_previous_sibling node_or_tags
+        raise ArgumentError.new("A document may not have multiple root nodes.") if parent.is_a?(XML::Document)
+
         node_or_tags = coerce(node_or_tags)
         if node_or_tags.is_a?(XML::NodeSet)
           if text?
@@ -315,6 +317,8 @@ module Nokogiri
       #
       # Also see related method +after+.
       def add_next_sibling node_or_tags
+        raise ArgumentError.new("A document may not have multiple root nodes.") if parent.is_a?(XML::Document)
+        
         node_or_tags = coerce(node_or_tags)
         if node_or_tags.is_a?(XML::NodeSet)
           if text?

--- a/test/xml/test_unparented_node.rb
+++ b/test/xml/test_unparented_node.rb
@@ -223,6 +223,30 @@ module Nokogiri
         right_space.add_next_sibling(left_space)
         assert_equal left_space, right_space
       end
+      
+      def test_add_next_sibling_to_root_raises_exception
+        xml = Nokogiri::XML(<<-eoxml)
+        <root />
+        eoxml
+        
+        node = Nokogiri::XML::Node.new 'child', xml
+
+        assert_raise(ArgumentError) do
+          xml.root.add_next_sibling(node)
+        end
+      end
+
+      def test_add_previous_sibling_to_root_raises_exception
+        xml = Nokogiri::XML(<<-eoxml)
+        <root />
+        eoxml
+        
+        node = Nokogiri::XML::Node.new 'child', xml
+
+        assert_raise(ArgumentError) do
+          xml.root.add_previous_sibling(node)
+        end
+      end
 
       def test_find_by_css_with_tilde_eql
         xml = Nokogiri::XML.parse(<<-eoxml)


### PR DESCRIPTION
This fixes issue 550 by raising an exception if an attempt is made to add siblings to the root node.
