### PR TITLE
Adding a relaxNG validator into the cli

### DIFF
--- a/bin/nokogiri
+++ b/bin/nokogiri
@@ -27,6 +27,10 @@ opts = OptionParser.new do |opts|
     encoding = v
   end
 
+  opts.on("--rng <uri|path>", "Validate using this rng file.") do |v|
+    @rng = open(v) {|f| Nokogiri::XML::RelaxNG(f)}
+  end
+
   opts.on_tail("-?", "--help", "Show this message") do
     puts opts
     exit
@@ -48,6 +52,10 @@ end
 
 @doc = parse_class.parse(open(uri).read, nil, encoding)
 
-puts "Your document is stored in @doc..."
-IRB.start
+if @rng
+  puts @rng.validate(@doc)
+else
+  puts "Your document is stored in @doc..."
+  IRB.start
+end
 


### PR DESCRIPTION
This adds a --rng option to the cli,
we needed a quick way to validate files against an rng file and this has done the job.
