### PR TITLE
Downgrade to hoe-debugging 1.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source :gemcutter
 
 
 gem "hoe-bundler", ">=1.1", :group => [:development, :test]
-gem "hoe-debugging", ">=1.0.2", :group => [:development, :test]
+gem "hoe-debugging", "=1.0.1", :group => [:development, :test]
 gem "hoe-gemspec", ">=1.0", :group => [:development, :test]
 gem "hoe-git", ">=1.4", :group => [:development, :test]
 gem "mini_portile", ">=0.2.2", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ HOE = Hoe.spec 'nokogiri' do
 
   self.extra_dev_deps += [
     ["hoe-bundler",     ">= 1.1"],
-    ["hoe-debugging",   ">= 1.0.2"],
+    ["hoe-debugging",   "= 1.0.1"],
     ["hoe-gemspec",     ">= 1.0"],
     ["hoe-git",         ">= 1.4"],
     ["mini_portile",    ">= 0.2.2"],


### PR DESCRIPTION
1.0.2 causes `rake` to fail:

https://github.com/jbarnette/hoe-debugging/issues/1
