### PR TITLE
Add rbx-18mode to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ rvm:
   - rbx-2.0
   - ree
   - jruby
+  - rbx-18mode


### PR DESCRIPTION
`rake test` is green on Rubinius 1.8 mode.

It looks like nokogiri isn't actually on Travis yet though. Any plans?
