### PR TITLE
#include "ruby/util.h" if available

### DIFF
--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -35,8 +35,12 @@ void vasprintf_free (void *p)
 }
 #endif
 
+#ifdef HAVE_RUBY_UTIL_H
+#include "ruby/util.h"
+#else
 #ifndef __MACRUBY__
 #include "util.h"
+#endif
 #endif
 
 void Init_nokogiri()


### PR DESCRIPTION
Fixes a compile warning.
