### PR TITLE
Fix segfault when invoking custom XPath function without arguments

### DIFF
--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -76,27 +76,29 @@ static void ruby_funcall(xmlXPathParserContextPtr ctx, int nargs)
 
   doc = DOC_RUBY_OBJECT(ctx->context->doc);
 
-  i = nargs - 1;
-  do {
-    obj = valuePop(ctx);
-    switch(obj->type) {
-      case XPATH_STRING:
-        argv[i] = NOKOGIRI_STR_NEW2(obj->stringval);
-        break;
-      case XPATH_BOOLEAN:
-        argv[i] = obj->boolval == 1 ? Qtrue : Qfalse;
-        break;
-      case XPATH_NUMBER:
-        argv[i] = rb_float_new(obj->floatval);
-        break;
-      case XPATH_NODESET:
-        argv[i] = Nokogiri_wrap_xml_node_set(obj->nodesetval, doc);
-        break;
-      default:
-        argv[i] = NOKOGIRI_STR_NEW2(xmlXPathCastToString(obj));
-    }
-    xmlXPathFreeNodeSetList(obj);
-  } while(i-- > 0);
+  if (nargs > 0) {
+    i = nargs - 1;
+    do {
+      obj = valuePop(ctx);
+      switch(obj->type) {
+        case XPATH_STRING:
+          argv[i] = NOKOGIRI_STR_NEW2(obj->stringval);
+          break;
+        case XPATH_BOOLEAN:
+          argv[i] = obj->boolval == 1 ? Qtrue : Qfalse;
+          break;
+        case XPATH_NUMBER:
+          argv[i] = rb_float_new(obj->floatval);
+          break;
+        case XPATH_NODESET:
+          argv[i] = Nokogiri_wrap_xml_node_set(obj->nodesetval, doc);
+          break;
+        default:
+          argv[i] = NOKOGIRI_STR_NEW2(xmlXPathCastToString(obj));
+      }
+      xmlXPathFreeNodeSetList(obj);
+    } while(i-- > 0);
+  }
 
   result = rb_funcall2(
       xpath_handler,

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -58,6 +58,10 @@ module Nokogiri
           def saves_node_set node_set
             @things = node_set
           end
+
+          def value
+            123.456
+          end
         }.new
       end
 
@@ -231,6 +235,15 @@ module Nokogiri
         xpath = xpath.join(',')
 
         assert_equal doc.xpath("//tool[@name='hammer']"), doc.xpath(xpath, tool_inspector)
+      end
+
+      def test_custom_xpath_without_arguments
+        if Nokogiri.uses_libxml?
+          value = @xml.xpath('value()', @handler)
+        else
+          value = @xml.xpath('nokogiri:value()', @ns, @handler)
+        end
+        assert_equal 123.456, value
       end
     end
   end


### PR DESCRIPTION
Currently this produces a segmentation fault:

``` ruby
x = Nokogiri::XML('<root/>')
ctx = Class.new {
  def foo(x)
    "FOO"
  end
}.new

x.xpath('foo(x)', ctx)
```

The problem seems to be in `ruby_funcall` function that tries to initalize the arguments without checking.
