### PR TITLE
doc.css("a[class='bar']") doesn't work if the XML document has default namespace

### DIFF
--- a/lib/nokogiri/css/parser.y
+++ b/lib/nokogiri/css/parser.y
@@ -88,7 +88,7 @@ rule
     |
     ;
   attrib
-    : LSQUARE namespaced_ident attrib_val_0or1 RSQUARE {
+    : LSQUARE attrib_name attrib_val_0or1 RSQUARE {
         result = Node.new(:ATTRIBUTE_CONDITION,
           [val[1]] + (val[2] || [])
         )
@@ -103,6 +103,18 @@ rule
         result = Node.new(:PSEUDO_CLASS,
           [Node.new(:FUNCTION, ['nth-child(', val[1]])]
         )
+      }
+    ;
+  attrib_name
+    : namespace '|' IDENT {
+        result = Node.new(:ELEMENT_NAME,
+          [[val.first, val.last].compact.join(':')]
+        )
+      }
+    | IDENT {
+        # Default namespace is not applied to attributes.
+        # So we don't add prefix "xmlns:" as in namespaced_ident.
+        result = Node.new(:ELEMENT_NAME, [val.first])
       }
     ;
   function

--- a/test/css/test_parser.rb
+++ b/test/css/test_parser.rb
@@ -6,6 +6,10 @@ module Nokogiri
       def setup
         super
         @parser = Nokogiri::CSS::Parser.new
+        @parser_with_ns = Nokogiri::CSS::Parser.new({
+          "xmlns" => "http://default.example.com/",
+          "hoge" => "http://hoge.example.com/",
+        })
       end
 
       def test_extra_single_quote
@@ -290,6 +294,13 @@ module Nokogiri
         ###
         # TODO: should we make this work?
         # assert_xpath ['//x/y', '//y/z'], @parser.parse('x > y | y > z')
+      end
+
+      def test_attributes_with_namespace
+        ## Default namespace is not applied to attributes.
+        ## So this must be @class, not @xmlns:class.
+        assert_xpath "//xmlns:a[@class = 'bar']", @parser_with_ns.parse("a[class='bar']")
+        assert_xpath "//xmlns:a[@hoge:class = 'bar']", @parser_with_ns.parse("a[hoge|class='bar']")
       end
 
       def assert_xpath expecteds, asts


### PR DESCRIPTION
This code:

```
require "nokogiri"

xml = <<EOS
  <feed xmlns="http://www.w3.org/2005/Atom">
    <entry>
      <link rel="hoge">fuga</link>
    </entry>
  </feed>
EOS

doc = Nokogiri.XML(xml)
p doc.css("link[rel='hoge']").size
```

should output 1 (I believe) but outputs 0 in Nokogiri 1.5.2. It outputs 1 correctly in Nokogiri 1.5.0.

The CSS selector above is converted to this XPath: "//xmlns:link[@xmlns:rel = 'hoge']"
But it seems default namespace is not applied to attribute names in XML.
http://www.w3.org/TR/selectors/#attrnmsp
So the XPath doesn't match. This pull request converts to "//xmlns:link[@rel = 'hoge']" instead, which works as expected.

```
p doc.xpath("//xmlns:link[@xmlns:rel = 'hoge']", {"xmlns" => "http://www.w3.org/2005/Atom"}).size
# => 0
p doc.xpath("//xmlns:link[@rel = 'hoge']", {"xmlns" => "http://www.w3.org/2005/Atom"}).size
# => 1
```
