### PR TITLE
fix #617: Nokogiri::XML::Reader#outer_xml is broken in JRuby

### DIFF
--- a/ext/java/nokogiri/XmlReader.java
+++ b/ext/java/nokogiri/XmlReader.java
@@ -229,7 +229,10 @@ public class XmlReader extends RubyObject {
         StringBuffer sb = new StringBuffer();
         int currentDepth = (Integer)current.depth;
         for (ReaderNode node : nodeQueue) {
-            if (((Integer)node.depth) > currentDepth) sb.append(node.getString());
+            if (((Integer)node.depth) > currentDepth) {
+                sb.append(node.getString());
+                break;
+            }
         }
         return new String(sb);
     }
@@ -244,7 +247,10 @@ public class XmlReader extends RubyObject {
         StringBuffer sb = new StringBuffer();
         int initialDepth = (Integer)current.depth - 1;
         for (ReaderNode node : nodeQueue) {
-            if (((Integer)node.depth) > initialDepth) sb.append(node.getString());
+            if (((Integer)node.depth) > initialDepth) {
+                sb.append(node.getString());
+                break;
+            }
         }
         return new String(sb);
     }

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -422,4 +422,33 @@ class TestReader < Nokogiri::TestCase
     end
   end
 
+  def test_correct_outer_html_inclusion
+    xml = Nokogiri::XML::Reader.from_io(StringIO.new(<<-eoxml))
+      <root-element>
+        <children>
+          <child n="1">
+            <field>child-1</field>
+          </child>
+          <child n="1">
+            <field>child-2</field>
+          </child>
+        </children>
+      </root-element>
+    eoxml
+
+    nodelengths = []
+    has_child2 = []
+
+    xml.each do |node|
+      if node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT and node.name == "child"
+        nodelengths << node.outer_xml.length
+        has_child2 << !!(node.outer_xml =~ /child-2/)
+      end
+    end
+
+    assert_equal(nodelengths[0], nodelengths[1])
+    assert(has_child2[1])
+    assert(!has_child2[0])
+  end
+
 end


### PR DESCRIPTION
It returns the first inner/outer element found in the queue, so I'm assuming it's the right one.

I've also added the test case provided to the suite.

@yokolet, can you confirm that the patch fix the issue?

@tenderlove, I've heard something about bounties to pay Yoko's travel to RailsConf :smile:
