### PR TITLE
add optional fallback encoding to HTML::Document.parse w/ autodetect

### DIFF
--- a/lib/nokogiri/html/document.rb
+++ b/lib/nokogiri/html/document.rb
@@ -79,6 +79,14 @@ module Nokogiri
         # is a number that sets options in the parser, such as
         # Nokogiri::XML::ParseOptions::RECOVER.  See the constants in
         # Nokogiri::XML::ParseOptions.
+        #
+        # If encoding is +nil+ Nokogiri will try to autodetect an encoding from document meta tags,
+        # and the fallback to letting libxml guess it.
+        # If you want to provide a forced fallback encoding you can pass an option hash, with key 
+        # +autodetect_fallback+ e.g.:
+        #   
+        #   +{:autodetect_fallback => 'utf-8'}+
+        #
         def parse string_or_io, url = nil, encoding = nil, options = XML::ParseOptions::DEFAULT_HTML
 
           options = Nokogiri::XML::ParseOptions.new(options) if Fixnum === options
@@ -93,7 +101,11 @@ module Nokogiri
 
           if string_or_io.respond_to?(:read)
             url ||= string_or_io.respond_to?(:path) ? string_or_io.path : nil
-            if !encoding
+            if !encoding || encoding.is_a?(Hash)
+              if encoding
+                fallback_encoding = encoding[:autodetect_fallback]
+                encoding = fallback_encoding
+              end
               # Libxml2's parser has poor support for encoding
               # detection.  First, it does not recognize the HTML5
               # style meta charset declaration.  Secondly, even if it

--- a/test/files/noencoding_utf8.html
+++ b/test/files/noencoding_utf8.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>doc</title>
+<p>We Don’t have an encoding</p>

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,6 +22,7 @@ module Nokogiri
     METACHARSET_FILE    = File.join(ASSETS_DIR, 'metacharset.html')
     NICH_FILE           = File.join(ASSETS_DIR, '2ch.html')
     NOENCODING_FILE     = File.join(ASSETS_DIR, 'noencoding.html')
+    NOENCODING_UTF8_FILE= File.join(ASSETS_DIR, 'noencoding_utf8.html')
     PO_SCHEMA_FILE      = File.join(ASSETS_DIR, 'po.xsd')
     PO_XML_FILE         = File.join(ASSETS_DIR, 'po.xml')
     SHIFT_JIS_HTML      = File.join(ASSETS_DIR, 'shift_jis.html')

--- a/test/html/test_document_encoding.rb
+++ b/test/html/test_document_encoding.rb
@@ -133,6 +133,23 @@ module Nokogiri
           assert_equal(evil, ary_from_file)
         }
       end
+
+      def test_document_wrongly_detected_as_iso88591
+        if Nokogiri.jruby? 
+          mangled_string = "We Don\342\200\231t have an encoding"
+        else
+          mangled_string = "We Donâ\u0080\u0099t have an encoding"
+        end
+        doc = Nokogiri::HTML.parse(binopen(NOENCODING_UTF8_FILE))
+        assert_equal(mangled_string, doc.at('p').text)
+
+        correct_string = 'We Don’t have an encoding'
+        doc = Nokogiri::HTML.parse(binopen(NOENCODING_UTF8_FILE), nil, 'utf-8')
+        assert_equal(correct_string, doc.at('p').text)
+
+        doc = Nokogiri::HTML.parse(binopen(NOENCODING_UTF8_FILE), nil, {:autodetect_fallback =>'utf-8'})
+        assert_equal(correct_string, doc.at('p').text)
+      end
     end
   end
 end


### PR DESCRIPTION
add an escape hatch to pass a default encoding to HTML::Document.parse even when we want Nokogiri's
autodetect to happen.

Sending pull request as discussed in the mailing list.
