### PR TITLE
adding better validation error reporting to the --rng option

### DIFF
--- a/bin/nokogiri
+++ b/bin/nokogiri
@@ -53,7 +53,9 @@ end
 @doc = parse_class.parse(open(uri).read, nil, encoding)
 
 if @rng
-  puts @rng.validate(@doc)
+  @rng.validate(@doc).each do |error|
+    puts error.message
+  end
 else
   puts "Your document is stored in @doc..."
   IRB.start


### PR DESCRIPTION
The error when an xml file didn't validate wasn't verbose enough to tell you what was wrong. This patch tells you the violations.
