### PR TITLE
Test for fragment node before assuming a node doc pointer is a doc.

### DIFF
--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -43,6 +43,26 @@ void vasprintf_free (void *p)
 #endif
 #endif
 
+void nokogiri_root_node(xmlNodePtr node)
+{
+  xmlDocPtr doc;
+  nokogiriTuplePtr tuple;
+
+  doc = node->doc;
+  if (doc->type == XML_DOCUMENT_FRAG_NODE) doc = doc->doc;
+  tuple = (nokogiriTuplePtr)doc->_private;
+  st_insert(tuple->unlinkedNodes, (st_data_t)node, (st_data_t)node);
+}
+
+void nokogiri_root_nsdef(xmlNsPtr ns, xmlDocPtr doc)
+{
+  nokogiriTuplePtr tuple;
+
+  if (doc->type == XML_DOCUMENT_FRAG_NODE) doc = doc->doc;
+  tuple = (nokogiriTuplePtr)doc->_private;
+  st_insert(tuple->unlinkedNodes, (st_data_t)ns, (st_data_t)ns);
+}
+
 void Init_nokogiri()
 {
 #ifndef __MACRUBY__

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -120,11 +120,8 @@ extern VALUE mNokogiriHtml ;
 extern VALUE mNokogiriHtmlSax ;
 extern VALUE mNokogiriXslt ;
 
-#define NOKOGIRI_ROOT_NODE(_node) \
-  st_insert(((nokogiriTuplePtr)(_node)->doc->_private)->unlinkedNodes, (st_data_t)(_node), (st_data_t)(_node))
-
-#define NOKOGIRI_ROOT_NSDEF(_nsDef, _doc)     \
-  st_insert(((nokogiriTuplePtr)(_doc)->_private)->unlinkedNodes, (st_data_t)(_nsDef), (st_data_t)(_nsDef))
+void nokogiri_root_node(xmlNodePtr);
+void nokogiri_root_nsdef(xmlNsPtr, xmlDocPtr);
 
 #ifdef DEBUG
 

--- a/ext/nokogiri/xml_attr.c
+++ b/ext/nokogiri/xml_attr.c
@@ -65,7 +65,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
       NULL
   );
 
-  NOKOGIRI_ROOT_NODE((xmlNodePtr)node);
+  nokogiri_root_node((xmlNodePtr)node);
 
   rb_node = Nokogiri_wrap_xml_node(klass, (xmlNodePtr)node);
   rb_obj_call_init(rb_node, argc, argv);

--- a/ext/nokogiri/xml_cdata.c
+++ b/ext/nokogiri/xml_cdata.c
@@ -25,7 +25,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
       NIL_P(content) ? 0 : (int)RSTRING_LEN(content)
   );
 
-  NOKOGIRI_ROOT_NODE(node);
+  nokogiri_root_node(node);
 
   rb_node = Nokogiri_wrap_xml_node(klass, node);
   rb_obj_call_init(rb_node, argc, argv);

--- a/ext/nokogiri/xml_comment.c
+++ b/ext/nokogiri/xml_comment.c
@@ -27,7 +27,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
   rb_node = Nokogiri_wrap_xml_node(klass, node);
   rb_obj_call_init(rb_node, argc, argv);
 
-  NOKOGIRI_ROOT_NODE(node);
+  nokogiri_root_node(node);
 
   if(rb_block_given_p()) rb_yield(rb_node);
 

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -102,7 +102,7 @@ static VALUE set_root(VALUE self, VALUE root)
 
     if(old_root) {
       xmlUnlinkNode(old_root);
-      NOKOGIRI_ROOT_NODE(old_root);
+      nokogiri_root_node(old_root);
     }
 
     return root;
@@ -121,7 +121,7 @@ static VALUE set_root(VALUE self, VALUE root)
   }
 
   xmlDocSetRootElement(doc, new_root);
-  if(old_root) NOKOGIRI_ROOT_NODE(old_root);
+  if(old_root) nokogiri_root_node(old_root);
   return root;
 }
 

--- a/ext/nokogiri/xml_document_fragment.c
+++ b/ext/nokogiri/xml_document_fragment.c
@@ -20,7 +20,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
 
   node = xmlNewDocFragment(xml_doc->doc);
 
-  NOKOGIRI_ROOT_NODE(node);
+  nokogiri_root_node(node);
 
   rb_node = Nokogiri_wrap_xml_node(klass, node);
   rb_obj_call_init(rb_node, argc, argv);

--- a/ext/nokogiri/xml_entity_reference.c
+++ b/ext/nokogiri/xml_entity_reference.c
@@ -24,7 +24,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
       (const xmlChar *)StringValuePtr(name)
   );
 
-  NOKOGIRI_ROOT_NODE(node);
+  nokogiri_root_node(node);
 
   rb_node = Nokogiri_wrap_xml_node(klass, node);
   rb_obj_call_init(rb_node, argc, argv);

--- a/ext/nokogiri/xml_processing_instruction.c
+++ b/ext/nokogiri/xml_processing_instruction.c
@@ -27,7 +27,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
       (const xmlChar *)StringValuePtr(content)
   );
 
-  NOKOGIRI_ROOT_NODE(node);
+  nokogiri_root_node(node);
 
   rb_node = Nokogiri_wrap_xml_node(klass, node);
   rb_obj_call_init(rb_node, argc, argv);

--- a/ext/nokogiri/xml_text.c
+++ b/ext/nokogiri/xml_text.c
@@ -22,7 +22,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
   node = xmlNewText((xmlChar *)StringValuePtr(string));
   node->doc = doc->doc;
 
-  NOKOGIRI_ROOT_NODE(node);
+  nokogiri_root_node(node);
 
   rb_node = Nokogiri_wrap_xml_node(klass, node) ;
   rb_obj_call_init(rb_node, argc, argv);

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -176,6 +176,11 @@ module Nokogiri
         assert fragment.children.respond_to?(:awesome!), fragment.children.class
       end
 
+      def test_add_node_to_doc_fragment_segfault
+        frag = Nokogiri::XML::DocumentFragment.new(@xml, '<p>hello world</p>')
+        Nokogiri::XML::Comment.new(frag,'moo')
+      end
+
       if Nokogiri.uses_libxml?
         def test_for_libxml_in_context_fragment_parsing_bug_workaround
           10.times do


### PR DESCRIPTION
The doc pointer on an xmlNode is not always an xmlDoc. The child of a document
fragment will point to the document fragment, which does not behave exactly
like an xmlDoc and doesn't have a nokogiriTuple.

This changeset tests for XML_DOCUMENT_FRAG_NODE before assuming that the doc
pointer is an xmlDoc.

This changes the NOKOGIRI_ROOT_NODE and NOKOGIRI_ROOT_NSDEF macros to functions
which test for this case.

Also check for this case in Nokogiri_wrap_xml_node.

This changeset adds a unit test which was copied from Kristi's bug report, #677

Reported-by: Kristi kristi.dev@gmail.com
