### PR TITLE
Bugfix in Jruby that cause xpath with 'xmlns:' to return empty results

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -151,6 +151,7 @@ module Nokogiri
           ctx = XPathContext.new(self)
           ctx.register_namespaces(ns)
           path = path.gsub(/\/xmlns:/,'/:') unless Nokogiri.uses_libxml?
+          path = path.gsub(/xmlns:/, ' :') unless Nokogiri.uses_libxml?
 
           binds.each do |key,value|
             ctx.register_variable key.to_s, value

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -263,6 +263,19 @@ module Nokogiri
           }.new)
         assert_equal foo, doc.xpath("//foo")
       end
+      
+      def test_very_specific_xml_xpath_making_problems_in_jruby
+        xml_string = %q{<?xml version="1.0" encoding="UTF-8"?>
+        <ONIXMessage xmlns:elibri="http://elibri.com.pl/ns/extensions" release="3.0" xmlns="http://www.editeur.org/onix/3.0/reference">
+          <Product>
+            <RecordReference>a</RecordReference>
+          </Product>
+        </ONIXMessage>}
+        
+        xml_doc = Nokogiri::XML(xml_string)
+        onix = xml_doc.children.first
+        assert_equal 'a', onix.at_xpath('xmlns:Product').at_xpath('xmlns:RecordReference').text
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

this commit will fix different behaviour in MRI and JRuby when dealing with namespaces.

In current Nokogiri version xpath starting with 'xmlns:' on JRuby will result in empty node and on MRI it will provide normal results.

This commit fix this.
