### PR TITLE
Fix JRuby thread safety bugs causes by shared Xpath object [#682]

### DIFF
--- a/ext/java/nokogiri/NokogiriService.java
+++ b/ext/java/nokogiri/NokogiriService.java
@@ -569,16 +569,8 @@ public class NokogiriService implements BasicLibraryService {
     };
 
     public static ObjectAllocator XML_XPATHCONTEXT_ALLOCATOR = new ObjectAllocator() {
-        private XmlXpathContext xmlXpathContext = null;
         public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-            if (xmlXpathContext == null) xmlXpathContext = new XmlXpathContext(runtime, klazz);
-            try {
-                XmlXpathContext clone  = (XmlXpathContext) xmlXpathContext.clone();
-                clone.setMetaClass(klazz);
-                return clone;
-            } catch (CloneNotSupportedException e) {
-                return new XmlXpathContext(runtime, klazz);
-            }
+	         return new XmlXpathContext(runtime, klazz);
         }
     };
 

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -72,10 +72,11 @@ import org.w3c.dom.NodeList;
 @JRubyClass(name="Nokogiri::XML::XPathContext")
 public class XmlXpathContext extends RubyObject {
     private XmlNode context;
-    private static final XPath xpath = XPathFactory.newInstance().newXPath();;
+    private XPath xpath;
     
     public XmlXpathContext(Ruby ruby, RubyClass rubyClass) {
         super(ruby, rubyClass);
+        xpath = XPathFactory.newInstance().newXPath();
     }
     
     public void setNode(XmlNode node) {


### PR DESCRIPTION
This pull request fixes #682.

First in XmlXpathContext.java, each XmlXpathContext object should have
it's own XPath object, instead of sharing one across the class. XPath
objects are not thread-safe as documented in the official Java
documentation.

Secondly, NokogiriService was giving Nokogiri::XML::XPathContext
objects their XmlXpathContext by cloning a single XmlXpathContext
object. Since this is a shallow clone, all those context objects shared
a reference to a single underlying XPath object. This change has the
NokogiriService create a new XmlXpathContext from scratch rather than
cloning an existing one.
