### PR TITLE
Documentation update

### DIFF
--- a/lib/nokogiri/xml/sax/document.rb
+++ b/lib/nokogiri/xml/sax/document.rb
@@ -33,7 +33,7 @@ module Nokogiri
     #   parser = Nokogiri::XML::SAX::Parser.new(MyDocument.new)
     #
     #   # Feed the parser some XML
-    #   parser.parse(File.read(ARGV[0], 'rb'))
+    #   parser.parse(File.open(ARGV[0]))
     #
     # Now my document handler will be called when each node starts, and when
     # then document ends.  To see what kinds of events are available, take

--- a/lib/nokogiri/xml/sax/parser.rb
+++ b/lib/nokogiri/xml/sax/parser.rb
@@ -25,7 +25,7 @@ module Nokogiri
       #   parser = Nokogiri::XML::SAX::Parser.new(MyDoc.new)
       #
       #   # Send some XML to the parser
-      #   parser.parse(File.read(ARGV[0]))
+      #   parser.parse(File.open(ARGV[0]))
       #
       # For more information about SAX parsers, see Nokogiri::XML::SAX.  Also
       # see Nokogiri::XML::SAX::Document for the available events.


### PR DESCRIPTION
Replaces File.read with File.open, avoiding the loading of the whole file into ram (which is usually the point of using the SAX parser).
