### PR TITLE
Try using pkg-config for libraries when possible

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -99,7 +99,8 @@ def asplode(lib)
   abort "-----\n#{lib} is missing.  please visit http://nokogiri.org/tutorials/installing_nokogiri.html for help with installing dependencies.\n-----"
 end
 
-pkg_config('libxslt') if RUBY_PLATFORM =~ /mingw/
+pkg_config('libxslt')
+pkg_config('libxml-2.0')
 
 asplode "libxml2"  unless find_header('libxml/parser.h')
 asplode "libxslt"  unless find_header('libxslt/xslt.h')


### PR DESCRIPTION
Related to issue #584. Not quite the wanted solution but this one is simple two lines patch. Allows installation on DragonFly BSD (yes, really) without specifying extra parameters (the libraries are installed under /usr/pkg).

This allows for non-standard location of those libraries by using
pkg-config when possible, removing the need to specify
--with-$LIB-{include,lib} when building the gem.
