### PR TITLE
Treat '.' as xpath in at() and search()

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -103,7 +103,7 @@ module Nokogiri
 
         xpath(*(paths.map { |path|
           path = path.to_s
-          path =~ /^(\.\/|\/|\.\.)/ ? path : CSS.xpath_for(
+          path =~ /^(\.\/|\/|\.\.|\.$)/ ? path : CSS.xpath_for(
             path,
             :prefix => prefix,
             :ns     => ns

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -79,7 +79,7 @@ module Nokogiri
 
         paths.each do |path|
           sub_set += send(
-            path =~ /^(\.\/|\/)/ ? :xpath : :css,
+            path =~ /^(\.\/|\/|\.\.|\.$)/ ? :xpath : :css,
             *(paths + [ns, handler]).compact
           )
         end

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -454,6 +454,11 @@ module Nokogiri
         assert_equal node, @xml.xpath('//address').first
       end
 
+      def test_at_self
+        node = @xml.at('address')
+        assert_equal node, node.at('.')
+      end
+
       def test_at_xpath
         node = @xml.at_xpath('//address')
         nodes = @xml.xpath('//address')
@@ -738,6 +743,11 @@ module Nokogiri
         assert parent_node = parent_set.first
         assert_equal '/staff', parent_node.path
         assert_equal node.parent, parent_node
+      end
+
+      def test_search_self
+        node = @xml.at('//employee')
+        assert_equal node.search('.').to_a, [node]
       end
 
       def test_search_by_symbol

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -146,6 +146,11 @@ module Nokogiri
         assert_equal @xml.xpath('//employee'), custom_employees
       end
 
+      def test_search_self
+        set = @xml.xpath('//staff')
+        assert_equal set.to_a, set.search('.').to_a
+      end
+
       def test_search_with_custom_object
         set = @xml.xpath('//staff')
         custom_employees = set.search('//*[awesome(.)]', Class.new {


### PR DESCRIPTION
Right now, `node.search('.')` will raise a CSS error. It should instead treat `'.'` as xpath.
