### PR TITLE
Issue with doctype of xhtml files, when parsing as xml in jruby

### DIFF
--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -368,6 +368,21 @@ eohtml
         node = html.xpath('//div').first
         assert_equal('Hello world!', node.inner_text.strip)
       end
+      
+      def test_doc_type
+        html = Nokogiri::HTML(<<-eohtml)
+        <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+          <html xmlns="http://www.w3.org/1999/xhtml">
+            <body>
+              <p>Rainbow Dash</p>
+            </body>
+          </html>
+        eohtml
+        assert_equal "html", html.internal_subset.name
+        assert_equal "-//W3C//DTD XHTML 1.1//EN", html.internal_subset.external_id
+        assert_equal "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd", html.internal_subset.system_id
+        assert_equal "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">", html.to_s[0,97]
+      end
 
       def test_find_by_xpath
         found = @html.xpath('//div/a')


### PR DESCRIPTION
Hi,

in this pull request you will find failing testcase (only in jruby - passing in other implementations) for doctype problem inside xhtml files.

Steps to reproduce error:
1. Run irb in jruby
2. load nokogiri
3. parse using Nokogiri::HTML this kind of file:
 `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
          <html xmlns="http://www.w3.org/1999/xhtml">
            <body>
              <p>Rainbow Dash</p>
            </body>
          </html>`
4. html.internal_subset.name should be 'html' is nil in jruby
5. (other asserts in tests)
6. when trying to put html to string inside jruby, calling html.to_s will get you different doctype then input file (HTML 4.01 Transitional instead of XHTML 1.1)
