### PR TITLE
Save the URI the user passes in bin/nokogiri.

### DIFF
--- a/bin/nokogiri
+++ b/bin/nokogiri
@@ -50,7 +50,7 @@ if uri.to_s.strip.empty?
   exit 1
 end
 
-@doc = parse_class.parse(open(uri).read, nil, encoding)
+@doc = parse_class.parse(open(uri).read, uri, encoding)
 
 if @rng
   @rng.validate(@doc).each do |error|


### PR DESCRIPTION
It’s awkward not to store the URI the user gives. Also awkward to not have tests…should probably add some. But I’ll do that after/if this change is deemed appropriate at all.
