### PR TITLE
Raise an ArgumentError when invalid encoding is specified

### DIFF
--- a/lib/nokogiri/xml/sax/parser.rb
+++ b/lib/nokogiri/xml/sax/parser.rb
@@ -68,6 +68,7 @@ module Nokogiri
 
         # Create a new Parser with +doc+ and +encoding+
         def initialize doc = Nokogiri::XML::SAX::Document.new, encoding = 'UTF-8'
+          check_encoding(encoding)
           @encoding = encoding
           @document = doc
           @warned   = false
@@ -87,6 +88,7 @@ module Nokogiri
         ###
         # Parse given +io+
         def parse_io io, encoding = 'ASCII'
+          check_encoding(encoding)
           @encoding = encoding
           ctx = ParserContext.io(io, ENCODINGS[encoding])
           yield ctx if block_given?
@@ -108,6 +110,11 @@ module Nokogiri
           ctx = ParserContext.memory data
           yield ctx if block_given?
           ctx.parse_with self
+        end
+
+        private
+        def check_encoding(encoding)
+          raise ArgumentError.new("'#{encoding}' is not a valid encoding") unless ENCODINGS[encoding]
         end
       end
     end

--- a/test/xml/sax/test_parser.rb
+++ b/test/xml/sax/test_parser.rb
@@ -250,6 +250,11 @@ module Nokogiri
           assert_raises(ArgumentError) { @parser.parse_memory(nil) }
         end
 
+        def test_bad_encoding_args
+          assert_raises(ArgumentError) { XML::SAX::Parser.new(Doc.new, 'not an encoding') }
+          assert_raises(ArgumentError) { @parser.parse_io(StringIO.new('<root/>'), 'not an encoding')}
+        end
+
         def test_ctag
           @parser.parse_memory(<<-eoxml)
             <p id="asdfasdf">


### PR DESCRIPTION
Currently if you specify an invalid encoding you get the rather mysterious error:

Class: <TypeError>
Message: <"no implicit conversion from nil to integer">
