### PR TITLE
parse_io should respect @encoding when no encoding is passed to it

### DIFF
--- a/lib/nokogiri/xml/sax/parser.rb
+++ b/lib/nokogiri/xml/sax/parser.rb
@@ -68,8 +68,7 @@ module Nokogiri
 
         # Create a new Parser with +doc+ and +encoding+
         def initialize doc = Nokogiri::XML::SAX::Document.new, encoding = 'UTF-8'
-          check_encoding(encoding)
-          @encoding = encoding
+          @encoding = check_encoding(encoding)
           @document = doc
           @warned   = false
         end
@@ -87,9 +86,9 @@ module Nokogiri
 
         ###
         # Parse given +io+
-        def parse_io io, encoding = 'ASCII'
-          check_encoding(encoding)
-          @encoding = encoding
+        def parse_io io, encoding = nil
+          encoding ||= @encoding
+          @encoding = check_encoding(encoding)
           ctx = ParserContext.io(io, ENCODINGS[encoding])
           yield ctx if block_given?
           ctx.parse_with self
@@ -115,6 +114,7 @@ module Nokogiri
         private
         def check_encoding(encoding)
           raise ArgumentError.new("'#{encoding}' is not a valid encoding") unless ENCODINGS[encoding]
+          encoding
         end
       end
     end

--- a/test/xml/sax/test_parser.rb
+++ b/test/xml/sax/test_parser.rb
@@ -43,6 +43,15 @@ module Nokogiri
           assert_equal [['foo', [['a', '&b']]]], doc.start_elements
         end
 
+        def test_parser_respects_encoding_ivar
+          doc = Doc.new
+          parser = XML::SAX::Parser.new doc, 'SHIFT-JIS'
+          File.open(SHIFT_JIS_XML) do |io|
+            parser.parse(io)
+            assert_equal(['This is a Shift_JIS File', 'こんにちは'], @parser.document.data)
+          end
+        end
+
         def test_xml_decl
           {
             ''          => nil,

--- a/test/xml/sax/test_parser.rb
+++ b/test/xml/sax/test_parser.rb
@@ -43,15 +43,6 @@ module Nokogiri
           assert_equal [['foo', [['a', '&b']]]], doc.start_elements
         end
 
-        def test_parser_respects_encoding_ivar
-          doc = Doc.new
-          parser = XML::SAX::Parser.new doc, 'SHIFT-JIS'
-          File.open(SHIFT_JIS_XML) do |io|
-            parser.parse(io)
-            assert_equal(['This is a Shift_JIS File', 'こんにちは'], @parser.document.data)
-          end
-        end
-
         def test_xml_decl
           {
             ''          => nil,
@@ -166,6 +157,15 @@ module Nokogiri
         def test_parser_sets_encoding
           parser = XML::SAX::Parser.new(Doc.new, 'UTF-8')
           assert_equal 'UTF-8', parser.encoding
+        end
+
+        def test_parser_respects_encoding_ivar
+          doc = Doc.new
+          parser = XML::SAX::Parser.new doc, 'SHIFT-JIS'
+          File.open(SHIFT_JIS_XML) do |io|
+            parser.parse(io)
+            assert_includes(parser.document.data, 'こんにちは')
+          end
         end
 
         def test_errors_set_after_parsing_bad_dom


### PR DESCRIPTION
I assumed that #756 would not be controversial (which is why this pull request is based on that branch).

This change may be slightly more controversial since it changes existing functioning behavior from always defaulting to ASCII (and never using @encoding) to using @encoding by default (and @encoding defaults to UTF-8).

The existing behavior doesn't make sense to me and is not what I would expect, hence this separate pull request. One small issue remains here, existing behavior is that calling parse_io with an encoding has the side-effect of changing the encoding for all uses of the Parser instance, and I did not address that.