### PR TITLE
Fixes #762 - corrects dead link in docs to tenderlove's blog

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -367,7 +367,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
  *
  *  For more information on why this probably is *not* a good thing in general,
  *  please direct your browser to
- *  http://tenderlovemaking.com/2009/04/23/namespaces-in-xml/
+ *  http://tenderlovemaking.com/2009/04/23/namespaces-in-xml.html
  */
 VALUE remove_namespaces_bang(VALUE self)
 {


### PR DESCRIPTION
I searched for tenderlovemaking and didn't see any other links in the documentation to tenderlove's blog that might have been dead, so this should be the only occurrence.
