### PR TITLE
Allow rbx to fail in 1.9 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ rvm:
   - rbx-19mode
 matrix:
   allow_failures:
-    - rvm rbx-19mode
+    - rvm: rbx-19mode


### PR DESCRIPTION
Down to a few failing tests. https://gist.github.com/4061584

In support of rubinius/rubinius#2006
