### PR TITLE
Fix EmptyStackException thrown by nokogiri-java when an xlink:href attribute shows up with an empty XmlBaseStack

### DIFF
--- a/ext/java/nokogiri/internals/ReaderNode.java
+++ b/ext/java/nokogiri/internals/ReaderNode.java
@@ -397,9 +397,12 @@ public abstract class ReaderNode {
                     else return base.concat("/").concat(v);
                 }
             } else if ("xlink:href".equals(n)) {
+							if (v.startsWith("http://")) {
+								return v;
+							} else if (!xmlBaseStack.isEmpty()) {
                 String base = xmlBaseStack.peek();
-                if (base.endsWith("/")) return base.concat(v);
-                else return base.concat("/").concat(v);
+								return base;
+							}
             }
             return null;
         }

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -399,6 +399,39 @@ class TestReader < Nokogiri::TestCase
                   reader.map {|n| n.base_uri })
   end
 
+  def test_xlink_href_without_base_uri
+    reader = Nokogiri::XML::Reader(<<-eoxml)
+      <x xmlns:xlink="http://www.w3.org/1999/xlink">
+        <link xlink:href="#other">Link</link>
+        <other id="other">Linked Element</other>
+      </x>
+    eoxml
+  
+    reader.each do |node|
+      if node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+        if node.name == 'link'
+          assert_nil node.base_uri
+        end
+      end
+    end
+  end
+  
+  def test_xlink_href_with_base_uri
+    reader = Nokogiri::XML::Reader(<<-eoxml)
+      <x xml:base="http://base.example.org/base/"
+         xmlns:xlink="http://www.w3.org/1999/xlink">
+        <link xlink:href="#other">Link</link>
+        <other id="other">Linked Element</other>
+      </x>
+    eoxml
+  
+    reader.each do |node|
+      if node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+        assert_equal node.base_uri, "http://base.example.org/base/"
+      end
+    end
+  end
+
   def test_read_from_memory
     called = false
     reader = Nokogiri::XML::Reader.from_memory('<foo>bar</foo>')


### PR DESCRIPTION
This is a revision of the PR posted by @bilts

https://github.com/sparklemotion/nokogiri/pull/534

The test now appears to pass in both MRI 1.9.3 and jruby-head 1.9.2. The assumption is:

If a node has an xml:base or inherits one, the xlink:href will not affect the node's xml base.

If the node doesn't have an xml:base or inherit one, AND the xlink:href attribute begins with 'http://', the xlink:href will set the node's xml base.
