### PR TITLE
UTF-8 downcase

### DIFF
--- a/lib/nokogiri/xml/sax/parser.rb
+++ b/lib/nokogiri/xml/sax/parser.rb
@@ -90,7 +90,7 @@ module Nokogiri
         def parse_io io, encoding = 'ASCII'
           check_encoding(encoding)
           @encoding = encoding
-          ctx = ParserContext.io(io, ENCODINGS[encoding])
+          ctx = ParserContext.io(io, ENCODINGS[encoding.upcase])
           yield ctx if block_given?
           ctx.parse_with self
         end
@@ -114,7 +114,7 @@ module Nokogiri
 
         private
         def check_encoding(encoding)
-          raise ArgumentError.new("'#{encoding}' is not a valid encoding") unless ENCODINGS[encoding]
+          raise ArgumentError.new("'#{encoding}' is not a valid encoding") unless ENCODINGS[encoding.upcase]
         end
       end
     end


### PR DESCRIPTION
Hi! :)

I had, recently, problems with webservice's UTF-8 in XML. When it came in downcase, I had to turn it into upcase letters so the parse would work properly with nokogiri gem.
