### PR TITLE
Add feature that the ':only-child' pseudo class should work even though it's in ':not' pseudo class.

### DIFF
--- a/lib/nokogiri/css/xpath_visitor.rb
+++ b/lib/nokogiri/css/xpath_visitor.rb
@@ -109,6 +109,7 @@ module Nokogiri
           when "last", "last-child" then "position() = last()"
           when "first-of-type" then "position() = 1"
           when "last-of-type" then "position() = last()"
+          when "only-child" then "last() = 1"
           when "only-of-type" then "last() = 1"
           when "empty" then "not(node())"
           when "parent" then "node()"

--- a/test/css/test_xpath_visitor.rb
+++ b/test/css/test_xpath_visitor.rb
@@ -17,6 +17,11 @@ module Nokogiri
           @parser.parse('ol > *:not(:last-child)'))
       end
 
+      def test_not_only_child
+        assert_xpath('//ol/*[not(last() = 1)]',
+          @parser.parse('ol > *:not(:only-child)'))
+      end
+
       def test_function_calls_allow_at_params
         assert_xpath("//a[foo(., @href)]", @parser.parse('a:foo(@href)'))
         assert_xpath("//a[foo(., @a, b)]", @parser.parse('a:foo(@a, b)'))


### PR DESCRIPTION
cite: [6.6.7. The negation pseudo-class](http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#negation) in specification

> The negation pseudo-class, :not(X), is a functional notation taking a simple selector (excluding the negation pseudo-class itself) as an argument. It represents an element that is not represented by its argument.

Also contain a `:only-child` pseudo class.
