### PR TITLE
Allow use of a prefixed namespace on a root node using Nokogiri::XML::Builder

### DIFF
--- a/lib/nokogiri/xml/builder.rb
+++ b/lib/nokogiri/xml/builder.rb
@@ -318,7 +318,9 @@ module Nokogiri
       # Build a tag that is associated with namespace +ns+.  Raises an
       # ArgumentError if +ns+ has not been defined higher in the tree.
       def [] ns
-        @ns = @parent.namespace_definitions.find { |x| x.prefix == ns.to_s }
+        if @parent != @doc
+          @ns = @parent.namespace_definitions.find { |x| x.prefix == ns.to_s }
+        end
         return self if @ns
 
         @parent.ancestors.each do |a|

--- a/test/namespaces/test_additional_namespaces_in_builder_doc.rb
+++ b/test/namespaces/test_additional_namespaces_in_builder_doc.rb
@@ -1,0 +1,14 @@
+require "helper"
+
+module Nokogiri
+  module XML
+    class TestAdditionalNamespacesInBuilderDoc < Nokogiri::TestCase
+      def test_builder_namespaced_root_node_ns
+        b = Nokogiri::XML::Builder.new do |x|
+          x[:foo].RDF(:'xmlns:foo' => 'http://foo.io')
+        end
+        assert_equal 'http://foo.io', b.doc.root.namespace.href
+      end
+    end
+  end
+end


### PR DESCRIPTION
Nokogiri 1.5.7 included code to allow Builder to predefine namespace prefixes the same way XML does, e.g.:

`xml[:meat].bacon(:'xmlns:meat' => 'info:mmm/mmm/good')`

But it didn't work on root nodes. This commit fixes that (and adds a test for it, natch).
