### PR TITLE
Use rb_ary_entry instead of RARRAY_PTR

### DIFF
--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -209,7 +209,7 @@ static void * initFunc(xsltTransformContextPtr ctxt, const xmlChar *uri)
     int i;
 
     for(i = 0; i < RARRAY_LEN(methods); i++) {
-	VALUE method_name = rb_obj_as_string(RARRAY_PTR(methods)[i]);
+	VALUE method_name = rb_obj_as_string(rb_ary_entry(methods, i));
 	xsltRegisterExtFunction(ctxt,
           (unsigned char *)StringValuePtr(method_name), uri, method_caller);
     }


### PR DESCRIPTION
For MRI, this doesn't make a difference, but on Rubinius this prevents
having to setup a backing store for copying over the internal array
pointers. This was the only case where RARRAY_PTR was used, other places
already use rb_ary_entry, so it should be a good change for consistency
as well.
