### PR TITLE
Add support for bare and multiple :not() functions in selectors

### DIFF
--- a/lib/nokogiri/css/parser.rb
+++ b/lib/nokogiri/css/parser.rb
@@ -14,96 +14,104 @@ module Nokogiri
 ##### State transition tables begin ###
 
 racc_action_table = [
-    21,     4,     5,     7,    29,     4,     5,     7,    30,    19,
-   -26,     6,    21,     9,     8,     6,    29,     9,     8,    22,
-    31,    19,    20,    21,    23,    15,    17,    29,    24,    83,
-    31,    22,    19,    84,    20,    21,    23,    15,    17,    29,
-    24,    92,    22,    85,    19,    20,    21,    23,    15,    17,
-    20,    24,    82,    90,    22,    59,    24,    20,    89,    23,
-    15,    17,    21,    24,    88,    22,    29,     4,     5,     7,
-    23,    19,    71,    29,    91,    29,    86,     6,    19,     9,
-     8,    22,    29,    29,    20,    89,    23,    15,    17,    35,
-    24,    20,    29,    20,    15,    17,    15,    24,    35,    24,
-    20,    20,    29,    15,    15,    93,    24,    24,    21,    64,
-    20,    95,    29,    15,    97,    96,    24,    43,   -26,    46,
-    20,    52,    53,    15,    51,    98,    24,    22,    79,    80,
-    20,    99,    23,    15,    48,    42,    24,    79,    80,    75,
-    76,    77,   101,    78,    87,    86,    41,    74,    75,    76,
-    77,    35,    78,   104,    52,    56,    74,    55,    52,    56,
-   105,    55,    52,    56,   nil,    55,    52,    56,   nil,    55 ]
+    21,    31,    20,    32,    30,     4,     5,     7,    24,    19,
+    92,    21,    90,    32,    95,     6,    91,     9,     8,    22,
+    62,    90,    20,    85,    23,    15,    17,    21,    24,   -23,
+    47,    30,     4,     5,     7,    23,    19,    52,    84,    21,
+    56,    89,     6,    30,     9,     8,    22,    83,    19,    20,
+    21,    23,    15,    17,    30,    24,    98,    97,    22,    19,
+    68,    20,    21,    23,    15,    17,    30,    24,    86,    22,
+    87,    19,    20,    93,    23,    15,    17,    30,    24,    30,
+    82,    22,    52,    84,    20,    56,    23,    15,    17,   -23,
+    24,    30,    35,    30,    35,    20,    19,    20,    15,    96,
+    15,    24,   -23,    24,    30,    99,    35,    21,    35,    20,
+   100,    20,    15,    17,    15,    24,    42,    24,    45,    35,
+    30,    30,    20,    88,    87,    15,    47,    90,    24,    71,
+   102,    23,    30,    40,    41,    35,    35,   105,    20,    20,
+   106,    15,    15,   nil,    24,    24,   nil,    35,   nil,   nil,
+    20,    79,    80,    15,    30,   nil,    24,   nil,    52,    54,
+   nil,    56,    75,    76,    77,   nil,    78,   nil,   nil,    35,
+    74,   nil,    20,    79,    80,    15,    17,   nil,    24,   nil,
+    52,    53,   nil,    51,    75,    76,    77,   nil,    78,     4,
+     5,     7,    74,    48,    52,    84,   nil,    56,   nil,     6,
+   nil,     9,     8,    52,    84,   nil,    56 ]
 
 racc_action_check = [
-     0,    14,    14,    14,     0,     0,     0,     0,     1,     0,
-    43,    14,    40,    14,    14,     0,    40,     0,     0,     0,
-     1,    40,     0,    31,     0,     0,     0,    31,     0,    47,
-    57,    40,    31,    49,    40,    13,    40,    40,    40,    13,
-    40,    57,    31,    50,    13,    31,    24,    31,    31,    31,
-    11,    31,    46,    53,    13,    24,    11,    13,    53,    13,
-    13,    13,    23,    13,    52,    24,    23,    23,    23,    23,
-    24,    23,    42,    35,    54,    28,    55,    23,    35,    23,
-    23,    23,    27,    10,    23,    56,    23,    23,    23,    33,
-    23,    35,    26,    28,    35,    35,    28,    35,    10,    28,
-    27,    10,    25,    27,    10,    67,    27,    10,    20,    30,
-    26,    72,    68,    26,    73,    73,    26,    20,    19,    20,
-    25,    21,    21,    25,    21,    81,    25,    20,    45,    45,
-    68,    83,    20,    68,    21,    18,    68,    44,    44,    45,
-    45,    45,    87,    45,    51,    51,    15,    45,    44,    44,
-    44,    12,    44,    90,    89,    89,    44,    89,    86,    86,
-   101,    86,    88,    88,   nil,    88,    22,    22,   nil,    22 ]
+     0,     1,    11,    60,     0,     0,     0,     0,    11,     0,
+    55,    24,    54,     1,    60,     0,    53,     0,     0,     0,
+    24,    53,     0,    49,     0,     0,     0,    23,     0,    54,
+    24,    23,    23,    23,    23,    24,    23,    89,    89,    13,
+    89,    52,    23,    13,    23,    23,    23,    46,    13,    23,
+    39,    23,    23,    23,    39,    23,    73,    73,    13,    39,
+    31,    13,    32,    13,    13,    13,    32,    13,    50,    39,
+    56,    32,    39,    57,    39,    39,    39,    27,    39,    28,
+    45,    32,    47,    47,    32,    47,    32,    32,    32,    19,
+    32,    35,    27,    10,    28,    27,    35,    28,    27,    72,
+    28,    27,    42,    28,    29,    81,    35,    20,    10,    35,
+    83,    10,    35,    35,    10,    35,    20,    10,    20,    29,
+    26,    58,    29,    51,    51,    29,    20,    84,    29,    41,
+    88,    20,    25,    15,    18,    26,    58,    91,    26,    58,
+   102,    26,    58,   nil,    26,    58,   nil,    25,   nil,   nil,
+    25,    43,    43,    25,    22,   nil,    25,   nil,    22,    22,
+   nil,    22,    43,    43,    43,   nil,    43,   nil,   nil,    22,
+    43,   nil,    22,    44,    44,    22,    22,   nil,    22,   nil,
+    21,    21,   nil,    21,    44,    44,    44,   nil,    44,    14,
+    14,    14,    44,    21,    87,    87,   nil,    87,   nil,    14,
+   nil,    14,    14,    90,    90,   nil,    90 ]
 
 racc_action_pointer = [
-    -2,     8,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    77,    26,   130,    33,    -6,   135,   nil,   nil,   106,    89,
-   106,   111,   156,    60,    44,    96,    86,    76,    69,   nil,
-   109,    21,   nil,    68,   nil,    67,   nil,   nil,   nil,   nil,
-    10,   nil,    61,   -19,   134,   125,    27,     0,   nil,    10,
-    20,   133,    52,    46,    51,    64,    73,    18,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,    82,   106,   nil,
-   nil,   nil,    86,   104,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   100,   nil,   120,   nil,   nil,   148,   135,   152,   144,
-   140,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   147,   nil,   nil,   nil,   nil ]
+    -2,     1,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+    87,   -22,   nil,    37,   182,   122,   nil,   nil,   105,    60,
+   105,   170,   148,    25,     9,   126,   114,    71,    73,    98,
+   nil,    60,    60,   nil,   nil,    85,   nil,   nil,   nil,    48,
+   nil,   118,    73,   148,   170,    55,    18,    72,   nil,     0,
+    45,   112,    29,     9,     0,   -13,    58,    50,   115,   nil,
+    -9,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    74,    46,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,    80,   nil,    99,   115,   nil,   nil,   184,   123,    27,
+   193,   124,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   127,   nil,   nil,   nil,   nil ]
 
 racc_action_default = [
-   -27,   -74,    -2,    -3,    -4,    -5,    -6,    -7,    -8,    -9,
-   -50,   -13,   -17,   -27,   -20,   -74,   -22,   -23,   -74,   -25,
-   -27,   -74,   -74,   -27,   -74,   -55,   -56,   -57,   -58,   -59,
-   -74,   -27,   -10,   -49,   -12,   -27,   -14,   -15,   -16,   -18,
-   -27,   -21,   -74,   -32,   -62,   -62,   -74,   -74,   -33,   -74,
-   -74,   -41,   -42,   -43,   -74,   -41,   -43,   -74,   -47,   -48,
-   -51,   -52,   -53,   -54,   106,    -1,   -11,   -74,   -71,   -73,
-   -19,   -24,   -74,   -74,   -63,   -64,   -65,   -66,   -67,   -68,
-   -69,   -74,   -30,   -74,   -34,   -35,   -74,   -46,   -74,   -74,
-   -74,   -36,   -37,   -70,   -72,   -28,   -60,   -61,   -29,   -31,
-   -38,   -74,   -39,   -40,   -45,   -44 ]
+   -24,   -73,    -2,    -3,    -4,    -5,    -6,    -7,    -8,    -9,
+   -47,   -11,   -14,   -24,   -17,   -73,   -19,   -20,   -73,   -22,
+   -24,   -73,   -24,   -24,   -73,   -53,   -54,   -55,   -56,   -57,
+   -58,   -73,   -24,   -10,   -46,   -24,   -12,   -13,   -15,   -24,
+   -18,   -73,   -29,   -61,   -61,   -73,   -73,   -73,   -30,   -73,
+   -73,   -38,   -39,   -40,   -22,   -73,   -38,   -73,   -70,   -72,
+   -73,   -44,   -45,   -48,   -49,   -50,   -51,   -52,   107,    -1,
+   -16,   -21,   -73,   -73,   -62,   -63,   -64,   -65,   -66,   -67,
+   -68,   -73,   -27,   -73,   -40,   -31,   -32,   -73,   -43,   -73,
+   -73,   -73,   -33,   -69,   -71,   -34,   -25,   -59,   -60,   -26,
+   -28,   -35,   -73,   -36,   -37,   -42,   -41 ]
 
 racc_goto_table = [
-    49,    54,    33,    39,    36,     1,    34,    45,    38,    72,
-    81,    58,    32,    37,    47,    44,    68,    60,    61,    62,
-    63,    65,    40,    50,    67,   nil,   nil,    69,    57,    66,
-    70,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+    49,    34,    38,    44,     1,    72,    81,    61,    37,    58,
+    36,    46,    43,    59,    33,    39,    63,    64,    65,    66,
+    67,    69,    58,    50,   nil,   nil,    59,    60,    70,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    94,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    94,   nil,   nil,   nil,   nil,   100,   nil,   102,   103 ]
+   nil,   nil,   nil,   nil,   nil,   nil,   101,   nil,   103,   104 ]
 
 racc_goto_check = [
-    18,    18,     8,     2,    11,     1,     9,    10,     9,    17,
-    17,    10,     7,    12,    15,    16,     6,     8,     8,     8,
-     8,     2,     4,    19,    22,   nil,   nil,     8,     1,     9,
-     2,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+    17,    11,     2,     8,     1,    16,    16,     8,    10,     6,
+     9,    14,    15,    11,     7,     4,    11,    11,    11,    11,
+    11,     2,     6,    18,   nil,   nil,    11,     1,     2,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    11,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-     8,   nil,   nil,   nil,   nil,    18,   nil,    18,    18 ]
+   nil,   nil,   nil,   nil,   nil,   nil,    17,   nil,    17,    17 ]
 
 racc_goto_pointer = [
-   nil,     5,   -10,   nil,     8,   nil,   -19,     2,    -8,    -4,
-   -13,    -7,     2,   nil,   nil,    -6,    -5,   -35,   -21,     2,
-   nil,   nil,   -11 ]
+   nil,     4,   -11,   nil,     1,   nil,   -13,     4,   -17,    -1,
+    -3,    -9,   nil,   nil,    -9,    -8,   -38,   -21,     2,   nil,
+   nil,   nil,   nil ]
 
 racc_goto_default = [
-   nil,   nil,     3,     2,    13,    14,    10,   nil,    12,   nil,
-    11,    28,    27,    26,    16,    18,   nil,   nil,   nil,   nil,
-    25,    73,   nil ]
+   nil,   nil,     3,     2,    13,    14,    10,   nil,    11,    28,
+    27,    12,    26,    16,    18,   nil,   nil,    55,   nil,    25,
+    29,    73,    57 ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -117,73 +125,72 @@ racc_reduce_table = [
   1, 35, :_reduce_8,
   1, 35, :_reduce_9,
   2, 36, :_reduce_10,
-  3, 36, :_reduce_11,
-  2, 36, :_reduce_12,
   1, 36, :_reduce_none,
-  2, 36, :_reduce_14,
-  2, 36, :_reduce_15,
-  2, 36, :_reduce_16,
-  1, 36, :_reduce_17,
-  2, 34, :_reduce_18,
-  3, 33, :_reduce_19,
+  2, 36, :_reduce_12,
+  2, 36, :_reduce_13,
+  1, 36, :_reduce_14,
+  2, 34, :_reduce_15,
+  3, 33, :_reduce_16,
   1, 33, :_reduce_none,
-  2, 44, :_reduce_21,
+  2, 43, :_reduce_18,
   1, 37, :_reduce_none,
-  1, 37, :_reduce_23,
-  3, 45, :_reduce_24,
-  1, 45, :_reduce_25,
-  1, 46, :_reduce_26,
-  0, 46, :_reduce_none,
-  4, 43, :_reduce_28,
-  4, 43, :_reduce_29,
-  3, 43, :_reduce_30,
-  3, 47, :_reduce_31,
-  1, 47, :_reduce_32,
-  2, 41, :_reduce_33,
-  3, 41, :_reduce_34,
-  3, 41, :_reduce_35,
-  3, 41, :_reduce_36,
-  3, 41, :_reduce_37,
-  3, 49, :_reduce_38,
-  3, 49, :_reduce_39,
-  3, 49, :_reduce_40,
-  1, 49, :_reduce_none,
-  1, 49, :_reduce_none,
-  1, 49, :_reduce_43,
-  4, 50, :_reduce_44,
-  3, 50, :_reduce_45,
-  2, 50, :_reduce_46,
-  2, 42, :_reduce_47,
-  2, 42, :_reduce_48,
+  1, 37, :_reduce_20,
+  3, 44, :_reduce_21,
+  1, 44, :_reduce_22,
+  1, 45, :_reduce_23,
+  0, 45, :_reduce_none,
+  4, 41, :_reduce_25,
+  4, 41, :_reduce_26,
+  3, 41, :_reduce_27,
+  3, 46, :_reduce_28,
+  1, 46, :_reduce_29,
+  2, 39, :_reduce_30,
+  3, 39, :_reduce_31,
+  3, 39, :_reduce_32,
+  3, 39, :_reduce_33,
+  3, 39, :_reduce_34,
+  3, 48, :_reduce_35,
+  3, 48, :_reduce_36,
+  3, 48, :_reduce_37,
+  1, 48, :_reduce_none,
+  1, 48, :_reduce_none,
+  1, 48, :_reduce_40,
+  4, 49, :_reduce_41,
+  3, 49, :_reduce_42,
+  2, 49, :_reduce_43,
+  2, 40, :_reduce_44,
+  2, 40, :_reduce_45,
   1, 38, :_reduce_none,
   0, 38, :_reduce_none,
-  2, 39, :_reduce_51,
-  2, 39, :_reduce_52,
-  2, 39, :_reduce_53,
-  2, 39, :_reduce_54,
-  1, 39, :_reduce_none,
-  1, 39, :_reduce_none,
-  1, 39, :_reduce_none,
-  1, 39, :_reduce_none,
-  1, 51, :_reduce_59,
-  2, 48, :_reduce_60,
-  2, 48, :_reduce_61,
-  0, 48, :_reduce_none,
+  2, 42, :_reduce_48,
+  2, 42, :_reduce_49,
+  2, 42, :_reduce_50,
+  2, 42, :_reduce_51,
+  2, 42, :_reduce_52,
+  1, 42, :_reduce_none,
+  1, 42, :_reduce_none,
+  1, 42, :_reduce_none,
+  1, 42, :_reduce_none,
+  1, 42, :_reduce_none,
+  1, 50, :_reduce_58,
+  2, 47, :_reduce_59,
+  2, 47, :_reduce_60,
+  0, 47, :_reduce_none,
+  1, 52, :_reduce_62,
   1, 52, :_reduce_63,
   1, 52, :_reduce_64,
   1, 52, :_reduce_65,
   1, 52, :_reduce_66,
   1, 52, :_reduce_67,
   1, 52, :_reduce_68,
-  1, 52, :_reduce_69,
-  3, 40, :_reduce_70,
+  3, 51, :_reduce_69,
   1, 53, :_reduce_none,
   2, 53, :_reduce_none,
   1, 53, :_reduce_none ]
 
-racc_reduce_n = 74
+racc_reduce_n = 73
 
-racc_shift_n = 106
+racc_shift_n = 107
 
 racc_token_table = {
   false => 0,
@@ -278,11 +285,10 @@ Racc_token_to_s_table = [
   "simple_selector",
   "element_name",
   "hcap_0toN",
-  "hcap_1toN",
-  "negation",
   "function",
   "pseudo",
   "attrib",
+  "hcap_1toN",
   "class",
   "namespaced_ident",
   "namespace",
@@ -291,6 +297,7 @@ Racc_token_to_s_table = [
   "expr",
   "nth",
   "attribute_id",
+  "negation",
   "eql_incl_dash",
   "negation_arg" ]
 
@@ -356,16 +363,7 @@ def _reduce_10(val, _values, result)
     result
 end
 
-def _reduce_11(val, _values, result)
-        result = Node.new(:CONDITIONAL_SELECTOR,
-          [
-            val.first,
-            Node.new(:COMBINATOR, [val[1], val.last])
-          ]
-        )
-      
-    result
-end
+# reduce 11 omitted
 
 def _reduce_12(val, _values, result)
         result = Node.new(:CONDITIONAL_SELECTOR, val)
@@ -373,32 +371,13 @@ def _reduce_12(val, _values, result)
     result
 end
 
-# reduce 13 omitted
+def _reduce_13(val, _values, result)
+        result = Node.new(:CONDITIONAL_SELECTOR, val)
+      
+    result
+end
 
 def _reduce_14(val, _values, result)
-        result = Node.new(:CONDITIONAL_SELECTOR, val)
-      
-    result
-end
-
-def _reduce_15(val, _values, result)
-        result = Node.new(:CONDITIONAL_SELECTOR, val)
-      
-    result
-end
-
-def _reduce_16(val, _values, result)
-        result = Node.new(:CONDITIONAL_SELECTOR,
-          [
-            Node.new(:ELEMENT_NAME, ['*']),
-            Node.new(:COMBINATOR, val)
-          ]
-        )
-      
-    result
-end
-
-def _reduce_17(val, _values, result)
         result = Node.new(:CONDITIONAL_SELECTOR,
           [Node.new(:ELEMENT_NAME, ['*']), val.first]
         )
@@ -406,33 +385,33 @@ def _reduce_17(val, _values, result)
     result
 end
 
-def _reduce_18(val, _values, result)
+def _reduce_15(val, _values, result)
         result = Node.new(val.first, [nil, val.last])
       
     result
 end
 
-def _reduce_19(val, _values, result)
+def _reduce_16(val, _values, result)
         result = Node.new(val[1], [val.first, val.last])
       
     result
 end
 
-# reduce 20 omitted
+# reduce 17 omitted
 
-def _reduce_21(val, _values, result)
+def _reduce_18(val, _values, result)
  result = Node.new(:CLASS_CONDITION, [val[1]]) 
     result
 end
 
-# reduce 22 omitted
+# reduce 19 omitted
 
-def _reduce_23(val, _values, result)
+def _reduce_20(val, _values, result)
  result = Node.new(:ELEMENT_NAME, val) 
     result
 end
 
-def _reduce_24(val, _values, result)
+def _reduce_21(val, _values, result)
         result = Node.new(:ELEMENT_NAME,
           [[val.first, val.last].compact.join(':')]
         )
@@ -440,21 +419,21 @@ def _reduce_24(val, _values, result)
     result
 end
 
-def _reduce_25(val, _values, result)
+def _reduce_22(val, _values, result)
         name = @namespaces.key?('xmlns') ? "xmlns:#{val.first}" : val.first
         result = Node.new(:ELEMENT_NAME, [name])
       
     result
 end
 
-def _reduce_26(val, _values, result)
+def _reduce_23(val, _values, result)
  result = val[0] 
     result
 end
 
-# reduce 27 omitted
+# reduce 24 omitted
 
-def _reduce_28(val, _values, result)
+def _reduce_25(val, _values, result)
         result = Node.new(:ATTRIBUTE_CONDITION,
           [val[1]] + (val[2] || [])
         )
@@ -462,7 +441,7 @@ def _reduce_28(val, _values, result)
     result
 end
 
-def _reduce_29(val, _values, result)
+def _reduce_26(val, _values, result)
         result = Node.new(:ATTRIBUTE_CONDITION,
           [val[1]] + (val[2] || [])
         )
@@ -470,7 +449,7 @@ def _reduce_29(val, _values, result)
     result
 end
 
-def _reduce_30(val, _values, result)
+def _reduce_27(val, _values, result)
         # Non standard, but hpricot supports it.
         result = Node.new(:PSEUDO_CLASS,
           [Node.new(:FUNCTION, ['nth-child(', val[1]])]
@@ -479,7 +458,7 @@ def _reduce_30(val, _values, result)
     result
 end
 
-def _reduce_31(val, _values, result)
+def _reduce_28(val, _values, result)
         result = Node.new(:ELEMENT_NAME,
           [[val.first, val.last].compact.join(':')]
         )
@@ -487,7 +466,7 @@ def _reduce_31(val, _values, result)
     result
 end
 
-def _reduce_32(val, _values, result)
+def _reduce_29(val, _values, result)
         # Default namespace is not applied to attributes.
         # So we don't add prefix "xmlns:" as in namespaced_ident.
         result = Node.new(:ELEMENT_NAME, [val.first])
@@ -495,8 +474,26 @@ def _reduce_32(val, _values, result)
     result
 end
 
-def _reduce_33(val, _values, result)
+def _reduce_30(val, _values, result)
         result = Node.new(:FUNCTION, [val.first.strip])
+      
+    result
+end
+
+def _reduce_31(val, _values, result)
+        result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
+      
+    result
+end
+
+def _reduce_32(val, _values, result)
+        result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
+      
+    result
+end
+
+def _reduce_33(val, _values, result)
+        result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
       
     result
 end
@@ -508,43 +505,25 @@ def _reduce_34(val, _values, result)
 end
 
 def _reduce_35(val, _values, result)
-        result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
-      
+ result = [val.first, val.last] 
     result
 end
 
 def _reduce_36(val, _values, result)
-        result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
-      
+ result = [val.first, val.last] 
     result
 end
 
 def _reduce_37(val, _values, result)
-        result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
-      
-    result
-end
-
-def _reduce_38(val, _values, result)
  result = [val.first, val.last] 
     result
 end
 
-def _reduce_39(val, _values, result)
- result = [val.first, val.last] 
-    result
-end
+# reduce 38 omitted
+
+# reduce 39 omitted
 
 def _reduce_40(val, _values, result)
- result = [val.first, val.last] 
-    result
-end
-
-# reduce 41 omitted
-
-# reduce 42 omitted
-
-def _reduce_43(val, _values, result)
         if val[0] == 'even'
           val = ["2","n","+","0"]
           result = Node.new(:NTH, val)
@@ -562,7 +541,7 @@ def _reduce_43(val, _values, result)
     result
 end
 
-def _reduce_44(val, _values, result)
+def _reduce_41(val, _values, result)
         if val[1] == 'n'
           result = Node.new(:NTH, val)
         else
@@ -572,7 +551,7 @@ def _reduce_44(val, _values, result)
     result
 end
 
-def _reduce_45(val, _values, result)
+def _reduce_42(val, _values, result)
                # n+3, -n+3
         if val[0] == 'n'
           val.unshift("1")
@@ -588,7 +567,7 @@ def _reduce_45(val, _values, result)
     result
 end
 
-def _reduce_46(val, _values, result)
+def _reduce_43(val, _values, result)
                     # 5n, -5n, 10n-1
         n = val[1]
         if n[0, 2] == 'n-'
@@ -608,20 +587,38 @@ def _reduce_46(val, _values, result)
     result
 end
 
-def _reduce_47(val, _values, result)
+def _reduce_44(val, _values, result)
         result = Node.new(:PSEUDO_CLASS, [val[1]])
       
     result
 end
 
-def _reduce_48(val, _values, result)
+def _reduce_45(val, _values, result)
  result = Node.new(:PSEUDO_CLASS, [val[1]]) 
     result
 end
 
-# reduce 49 omitted
+# reduce 46 omitted
 
-# reduce 50 omitted
+# reduce 47 omitted
+
+def _reduce_48(val, _values, result)
+        result = Node.new(:COMBINATOR, val)
+      
+    result
+end
+
+def _reduce_49(val, _values, result)
+        result = Node.new(:COMBINATOR, val)
+      
+    result
+end
+
+def _reduce_50(val, _values, result)
+        result = Node.new(:COMBINATOR, val)
+      
+    result
+end
 
 def _reduce_51(val, _values, result)
         result = Node.new(:COMBINATOR, val)
@@ -635,17 +632,9 @@ def _reduce_52(val, _values, result)
     result
 end
 
-def _reduce_53(val, _values, result)
-        result = Node.new(:COMBINATOR, val)
-      
-    result
-end
+# reduce 53 omitted
 
-def _reduce_54(val, _values, result)
-        result = Node.new(:COMBINATOR, val)
-      
-    result
-end
+# reduce 54 omitted
 
 # reduce 55 omitted
 
@@ -653,10 +642,13 @@ end
 
 # reduce 57 omitted
 
-# reduce 58 omitted
+def _reduce_58(val, _values, result)
+ result = Node.new(:ID, val) 
+    result
+end
 
 def _reduce_59(val, _values, result)
- result = Node.new(:ID, val) 
+ result = [val.first, val[1]] 
     result
 end
 
@@ -665,59 +657,54 @@ def _reduce_60(val, _values, result)
     result
 end
 
-def _reduce_61(val, _values, result)
- result = [val.first, val[1]] 
-    result
-end
+# reduce 61 omitted
 
-# reduce 62 omitted
-
-def _reduce_63(val, _values, result)
+def _reduce_62(val, _values, result)
  result = :equal 
     result
 end
 
-def _reduce_64(val, _values, result)
+def _reduce_63(val, _values, result)
  result = :prefix_match 
     result
 end
 
-def _reduce_65(val, _values, result)
+def _reduce_64(val, _values, result)
  result = :suffix_match 
     result
 end
 
-def _reduce_66(val, _values, result)
+def _reduce_65(val, _values, result)
  result = :substring_match 
     result
 end
 
-def _reduce_67(val, _values, result)
+def _reduce_66(val, _values, result)
  result = :not_equal 
     result
 end
 
-def _reduce_68(val, _values, result)
+def _reduce_67(val, _values, result)
  result = :includes 
     result
 end
 
-def _reduce_69(val, _values, result)
+def _reduce_68(val, _values, result)
  result = :dash_match 
     result
 end
 
-def _reduce_70(val, _values, result)
+def _reduce_69(val, _values, result)
         result = Node.new(:NOT, [val[1]])
       
     result
 end
 
+# reduce 70 omitted
+
 # reduce 71 omitted
 
 # reduce 72 omitted
-
-# reduce 73 omitted
 
 def _reduce_none(val, _values, result)
   val[0]

--- a/lib/nokogiri/css/parser.y
+++ b/lib/nokogiri/css/parser.y
@@ -28,31 +28,12 @@ rule
                     Node.new(:CONDITIONAL_SELECTOR, [val.first, val[1]])
                   end
       }
-    | element_name hcap_1toN negation {
-        result = Node.new(:CONDITIONAL_SELECTOR,
-          [
-            val.first,
-            Node.new(:COMBINATOR, [val[1], val.last])
-          ]
-        )
-      }
-    | element_name negation {
-        result = Node.new(:CONDITIONAL_SELECTOR, val)
-      }
     | function
     | function pseudo {
         result = Node.new(:CONDITIONAL_SELECTOR, val)
       }
     | function attrib {
         result = Node.new(:CONDITIONAL_SELECTOR, val)
-      }
-    | hcap_1toN negation {
-        result = Node.new(:CONDITIONAL_SELECTOR,
-          [
-            Node.new(:ELEMENT_NAME, ['*']),
-            Node.new(:COMBINATOR, val)
-          ]
-        )
       }
     | hcap_1toN {
         result = Node.new(:CONDITIONAL_SELECTOR,
@@ -224,10 +205,14 @@ rule
     | pseudo hcap_1toN {
         result = Node.new(:COMBINATOR, val)
       }
+    | negation hcap_1toN {
+        result = Node.new(:COMBINATOR, val)
+      }
     | attribute_id
     | class
     | attrib
     | pseudo
+    | negation
     ;
   attribute_id
     : HASH { result = Node.new(:ID, val) }

--- a/test/css/test_parser.rb
+++ b/test/css/test_parser.rb
@@ -284,6 +284,11 @@ module Nokogiri
                       @parser.parse('foo .awesome')
       end
 
+      def test_bare_not
+        assert_xpath "//*[not(contains(concat(' ', normalize-space(@class), ' '), ' a '))]",
+                     @parser.parse(':not(.a)')
+      end
+
       def test_not_so_simple_not
         assert_xpath "//*[@id = 'p' and not(contains(concat(' ', normalize-space(@class), ' '), ' a '))]",
                      @parser.parse('#p:not(.a)')
@@ -291,6 +296,11 @@ module Nokogiri
                      @parser.parse('p.a:not(.b)')
         assert_xpath "//p[@a = 'foo' and not(contains(concat(' ', normalize-space(@class), ' '), ' b '))]",
                      @parser.parse("p[a='foo']:not(.b)")
+      end
+
+      def test_multiple_not
+        assert_xpath "//p[not(contains(concat(' ', normalize-space(@class), ' '), ' a ')) and not(contains(concat(' ', normalize-space(@class), ' '), ' b ')) and not(contains(concat(' ', normalize-space(@class), ' '), ' c '))]",
+                    @parser.parse("p:not(.a):not(.b):not(.c)")
       end
 
       def test_ident


### PR DESCRIPTION
This enables parsing of `.flash:not(.error):not(.warning)` and `:not(p)`.

This entailed a huge change to the parser, but I think the parser should be a bit more robust now by not declaring `:not` a special case. :8ball: 
