### PR TITLE
NodeSet#each should return self

### DIFF
--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -238,6 +238,7 @@ module Nokogiri
         0.upto(length - 1) do |x|
           yield self[x]
         end
+        self
       end
 
       ###


### PR DESCRIPTION
NodeSet#each currently returns `0`, making it unusable for method chaining. This patch changes the return value to self.
