### PR TITLE
exchange string and regexp in assert_match tests

### DIFF
--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -47,7 +47,7 @@ module Nokogiri
         root << txt
         root << ent
         d << root
-        assert_match d.to_html, /&#8217;/
+        assert_match /&#8217;/, d.to_html
       end
 
       def test_document_with_initial_space

--- a/test/xml/test_entity_reference.rb
+++ b/test/xml/test_entity_reference.rb
@@ -26,7 +26,7 @@ EOF
         doc = Nokogiri::XML xml
         lf_node = Nokogiri::XML::EntityReference.new(doc, "#xa")
         doc.xpath('/item').first.add_child(lf_node)
-        assert_match doc.to_xml, /&#xa;/
+        assert_match /&#xa;/, doc.to_xml
       end
     end
 

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -830,7 +830,7 @@ b"></div>
         ne = d1.root.xpath('//a').first.dup(1)
         ne.content += "& < & > \" &"
         d2.root << ne
-        assert_match d2.to_s, /<a>&amp;&amp; &lt; &amp; &gt; " &amp;<\/a>/
+        assert_match /<a>&amp;&amp; &lt; &amp; &gt; " &amp;<\/a>/, d2.to_s
       end
 
       def test_content_after_appending_text


### PR DESCRIPTION
Hi!

MiniTest gem raises a TypeError
 TypeError: can't convert Regexp to String
when in assert_match the first argument is a string and the second a
regular expression, as the first argument is always converted to RegExp.

Note that this does not happen with the version of minitest shipped with ruby1.9.3, and has occured with the gem since the following commit in minitest:
https://github.com/seattlerb/minitest/commit/46a2bc313abd96accd786b64c8f928f30327169e

This patch changes the order so that in assert_match, at least one of the operands in =~ is a String.

Cheers,

Cédric
