### PR TITLE
[BUG] Nested builder parentage doesn't work

### DIFF
--- a/lib/nokogiri/xml/builder.rb
+++ b/lib/nokogiri/xml/builder.rb
@@ -266,8 +266,13 @@ module Nokogiri
       def initialize options = {}, root = nil, &block
 
         if root
-          @doc    = root.document
-          @parent = root
+          if root.is_a?(Nokogiri::XML::Builder)
+            @doc    = root.doc
+            @parent = root.parent
+          else
+            @doc    = root.document
+            @parent = root
+          end
         else
           namespace     = self.class.name.split('::')
           namespace[-1] = 'Document'

--- a/test/xml/test_builder.rb
+++ b/test/xml/test_builder.rb
@@ -297,7 +297,7 @@ module Nokogiri
       end
 
       def test_builder_inside_builder
-        Nokogiri::XML::Builder.new do |xml|
+        builder = Nokogiri::XML::Builder.new do |xml|
           xml.foo do |foo|
             Nokogiri::XML::Builder.with(foo) do |xml|
               xml.bar
@@ -305,7 +305,7 @@ module Nokogiri
           end
         end
 
-        assert_equal("<?xml version=\"1.0\"?><foo><bar/></foo>",
+        assert_equal("<?xml version=\"1.0\"?><foo>  <bar/></foo>",
           builder.to_xml.gsub(/\n/, ''))
       end
 

--- a/test/xml/test_builder.rb
+++ b/test/xml/test_builder.rb
@@ -296,6 +296,19 @@ module Nokogiri
           builder.to_xml.gsub(/\n/, ''))
       end
 
+      def test_builder_inside_builder
+        Nokogiri::XML::Builder.new do |xml|
+          xml.foo do |foo|
+            Nokogiri::XML::Builder.with(foo) do |xml|
+              xml.bar
+            end
+          end
+        end
+
+        assert_equal("<?xml version=\"1.0\"?><foo><bar/></foo>",
+          builder.to_xml.gsub(/\n/, ''))
+      end
+
     private
 
       def namespaces_defined_on(node)


### PR DESCRIPTION
This kind of structure (though where each builder is in an `#export` method on a model of some sort, not quite this simple) is very useful for composing a document, but it currently fails like so:

```
  1) Error:
test_builder_inside_builder(Nokogiri::XML::TestBuilder):
NoMethodError: undefined method `parent=' for nil:NilClass
    /Users/ben/code/nokogiri/lib/nokogiri/xml/builder.rb:385:in `insert'
    /Users/ben/code/nokogiri/lib/nokogiri/xml/builder.rb:377:in `method_missing'
    /Users/ben/code/nokogiri/test/xml/test_builder.rb:303:in `block (3 levels) in test_builder_inside_builder'
    /Users/ben/code/nokogiri/lib/nokogiri/xml/builder.rb:293:in `initialize'
    /Users/ben/code/nokogiri/lib/nokogiri/xml/builder.rb:254:in `new'
    /Users/ben/code/nokogiri/lib/nokogiri/xml/builder.rb:254:in `with'
    /Users/ben/code/nokogiri/test/xml/test_builder.rb:302:in `block (2 levels) in test_builder_inside_builder'
    /Users/ben/code/nokogiri/lib/nokogiri/xml/builder.rb:393:in `call'
    /Users/ben/code/nokogiri/lib/nokogiri/xml/builder.rb:393:in `insert'
    /Users/ben/code/nokogiri/lib/nokogiri/xml/builder.rb:377:in `method_missing'
    /Users/ben/code/nokogiri/test/xml/test_builder.rb:301:in `block in test_builder_inside_builder'
    /Users/ben/code/nokogiri/lib/nokogiri/xml/builder.rb:293:in `initialize'
    /Users/ben/code/nokogiri/test/xml/test_builder.rb:300:in `new'
    /Users/ben/code/nokogiri/test/xml/test_builder.rb:300:in `test_builder_inside_builder'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:942:in `run'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:781:in `block in _run_suite'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:774:in `map'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:774:in `_run_suite'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:764:in `block in _run_suites'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:764:in `map'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:764:in `_run_suites'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:740:in `_run_anything'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:903:in `run_tests'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:890:in `block in _run'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:889:in `each'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:889:in `_run'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:878:in `run'
    /Users/ben/.rvm/gems/ruby-2.0.0-p195/gems/minitest-2.2.2/lib/minitest/unit.rb:658:in `block in autorun'
```

Any help in figuring out why this is would be appreciated.