### PR TITLE
Adds support for Solaris, OpenSolaris, or illumos.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -111,6 +111,13 @@ Binary packages are available for:
 * SuSE[http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/]
 * Fedora[http://s390.koji.fedoraproject.org/koji/packageinfo?packageID=6756]
 
+If you are installing on Solaris, OpenSolaris, or illumos will need to install
+libxslt[http://www.opencsw.org/package/libxslt/] and
+libxml[http://www.opencsw.org/package/libxml2_2/] from OpenCSW.  After these
+libraries have been installed, run:
+
+    NOKOGIRI_USE_SYSTEM_LIBRARIES=true sudo gem install nokogiri
+
 == DEVELOPMENT:
 
 === Developing on C Ruby (MRI)

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -74,6 +74,9 @@ else
     # First search /opt/local for macports
     '/opt/local/include',
 
+    # Then check for OpenCSW packages
+    '/opt/csw/include',
+
     # Then search /usr/local for people that installed from source
     '/usr/local/include',
 
@@ -91,6 +94,9 @@ else
     LIB_DIRS = [
       # First search /opt/local for macports
       '/opt/local/lib',
+
+      # Then check for OpenCSW packages
+      '/opt/csw/lib',
 
       # Then search /usr/local for people that installed from source
       '/usr/local/lib',


### PR DESCRIPTION
Nokogiri fails to install on Solaris boxes.  This PR fixes this issue.

The reason is that libxslt library will not compile from source without some [tweaks](https://mail.gnome.org/archives/xslt/2011-May/msg00032.html) to the configure script.  The workaround is to either edit the configure script or use an OpenCSW binary.

This PR adds some clarity for Solaris to the installation section of the README, and adds the OpenCSW default paths. 
