### PR TITLE
extconf.rb: Don't call pkg_config when using bundled libraries

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -119,6 +119,8 @@ else
       XML2_HEADER_DIRS.unshift File.join(brew_prefix, 'include/libxml2')
     end
 
+    pkg_config('libxslt')
+    pkg_config('libxml-2.0')
   else
     require 'mini_portile'
     require 'yaml'
@@ -219,9 +221,6 @@ end
 dir_config('zlib', HEADER_DIRS, LIB_DIRS)
 dir_config('xml2', XML2_HEADER_DIRS, LIB_DIRS)
 dir_config('xslt', HEADER_DIRS, LIB_DIRS)
-
-pkg_config('libxslt')
-pkg_config('libxml-2.0')
 
 asplode "libxml2"  unless find_header('libxml/parser.h')
 asplode "libxslt"  unless find_header('libxslt/xslt.h')


### PR DESCRIPTION
This patch changes to call `pkg_config` only when `NOKOGIRI_USE_SYSTEM_LIBRARIES` specified,
because `pkg_config` isn't required when using bundled libraries.

And this works as workaround for the bug in 2.0.0-p0, 195, 247: https://bugs.ruby-lang.org/issues/8595

2.0.0-p{0,195,247}'s mkmf modifies `$LDFLAGS` after calling `pkg_config`. (Already fixed in upstream.. waiting for next release)

`pkg_config('libxml-2.0')` removes `-rpath` that added by extconf.rb, so compiled binary will be linked with system's installation.
