### PR TITLE
nokogiri 1.6.0 fails to load embedded version of libxml2 if absolute path changes

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -1,5 +1,22 @@
 ENV['RC_ARCHS'] = '' if RUBY_PLATFORM =~ /darwin/
 
+# Available options:
+#
+# --enable-clean (default)
+# --disable-clean
+#
+# --enable-static (default)
+# --disable-static
+#
+# --with-iconv-dir=DIR
+#
+# --with-zlib-dir=DIR
+#
+# --use-system-libraries
+#   --with-xml2-dir=DIR / --with-xml2-config=CONFIG
+#   --with-xslt-dir=DIR / --with-xslt-config=CONFIG
+#   --with-exslt-dir=DIR / --with-exslt-config=CONFIG
+
 # :stopdoc:
 
 require 'mkmf'


### PR DESCRIPTION
Our build system does a `bundle install --path ./bundler` on one machine; then tars up the result and sends it to the rest of production.

Unfortunately the tar-ball gets extracted into a different directory on the production servers from the temporary build server directory, which means that the absolute path hard-coded into `nokogiri.so` at compile time is wrong. This means that nokogiri picks up the system version of libxml2 and not the embedded version and you get a warning on start-up.

I think this is fixable on Linux by using Dylib.dlopen to open the libxml2.so file eagerly; not certain the correct way to fix on a Mac.

To replicate see the instructions at https://github.com/ConradIrwin/nokogiri-test.
