### PR TITLE
Nokogiri doesn't recognize xml namespace

### DIFF
--- a/test/xml/test_namespace.rb
+++ b/test/xml/test_namespace.rb
@@ -92,7 +92,7 @@ module Nokogiri
       end
 
       def test_recognize_namespace_in_attribute
-        doc = Document.parse(%Q{<link xmlns:special="http://nowhere.com"></link>})
+        doc = Nokogiri::HTML::Document.parse(%Q{<link xmlns:special="http://nowhere.com"></link>})
         assert !doc.namespaces.empty?, 'namespace was not recognized'
       end
     end


### PR DESCRIPTION
Nokogiri should recognize the namespace on the root node.

// @rafaelfranca
