### PR TITLE
Added failing tests for '<<' and '<<<some html'.

### DIFF
--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -889,6 +889,17 @@ eoxml
         Nokogiri::XML f
         f.close
       end
+
+      def test_returns_same_string_from_safe_html
+        doc = Document.new('<<<some html')
+        assert_equal 1, doc.children.size, "Document should have an element."
+        assert_equal '<<<some html', doc.to_s
+      end
+
+      def test_create_element_from_unclosed_double_brackets
+        doc = Document.new('<<<some html>')
+        assert_equal '<<', doc.to_s
+      end
     end
   end
 end


### PR DESCRIPTION
I called:

``` ruby
doc = Nokogiri::XML::Document.parse('<<<some html')
doc.to_s
```

I expected getting the string back. However, Nokogiri returns an empty string.

In the case of '<<', this is what the test returns:
`+"<?xml version=\"<<<some html>\"?>
+"
`

// @rafaelfranca
