### PR TITLE
Ensure that '-llzma' linker option comes after '-lxml2'.

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -306,7 +306,7 @@ else
 
     # xslt-config --libs or pkg-config libxslt --libs does not include
     # -llzma, so we need to add it manually when linking statically.
-    have_library('lzma')
+    have_library('lzma') && $libs.concat(" -llzma")
   end
 end
 


### PR DESCRIPTION
On Ubuntu-13.10 64-bit this test fails (and some other) when using static build of packaged libraries:

```
$ ruby -Itest:lib:.  test/html/sax/test_parser.rb -v -n test_parse_empty_file
/home/lars/comcard/rake-compiler-dev-box/nokogiri/test/helper.rb:11: version info: {"warnings"=>[], "nokogiri"=>"1.6.0", "ruby"=>{"version"=>"2.0.0", "platform"=>"x86_64-linux", "description"=>"ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-linux]", "engine"=>"ruby"}, "libxml"=>{"binding"=>"extension", "source"=>"packaged", "libxml2_path"=>"/home/lars/comcard/rake-compiler-dev-box/nokogiri/ports/libxml2/2.8.0", "libxslt_path"=>"/home/lars/comcard/rake-compiler-dev-box/nokogiri/ports/libxslt/1.1.28", "compiled"=>"2.8.0", "loaded"=>"2.8.0"}}
Run options: -v -n test_parse_empty_file --seed 47805

# Running:

ruby: symbol lookup error: /home/lars/comcard/rake-compiler-dev-box/nokogiri/lib/nokogiri/nokogiri.so: undefined symbol: lzma_auto_decoder
```
