### PR TITLE
Work around broken vsnprintf implementation in mingw.

### DIFF
--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -14,7 +14,12 @@ VALUE mNokogiriHtmlSax ;
  */
 int vasprintf (char **strp, const char *fmt, va_list ap)
 {
-  int len = vsnprintf (NULL, 0, fmt, ap) + 1;
+  /* Mingw32/64 have a broken vsnprintf implementation that fails when
+   * using a zero-byte limit in order to retrieve the required size for malloc.
+   * So we use a one byte buffer instead.
+   */
+  char tmp[1];
+  int len = vsnprintf (tmp, 1, fmt, ap) + 1;
   char *res = (char *)malloc((unsigned int)len);
   if (res == NULL)
       return -1;


### PR DESCRIPTION
This fixes currently failing tests in XML::TestSaxEntityReference: https://gist.github.com/larskanis/7186885

It affects the currently released nokogiri-1.6.0-x86-mingw32.gem for both ruby-1.9 and ruby-2.0.

I found that the following build environments have this bug and verified that the attached patch works around it on all of them:
`gcc (tdm-1) 4.5.2` - used for native builds on ruby-1.9
`gcc (rubenvb-4.7.2-release) 4.7.2` - used for native build on ruby-2.0 (both x86 and x64)
`i586-mingw32msvc-gcc (GCC) 4.2.1-sjlj (mingw32-2)` - used to cross build for ruby-1.9
`x86_64-w64-mingw32-gcc (rubenvb-4.7.2-release) 4.7.2` - used to cross build for ruby-2.0-x64
`i686-w64-mingw32-gcc (rubenvb-4.7.2-release) 4.7.2` - used to cross build for ruby-2.0-x86

This issue is independent from #989, but also affects the x64-mingw32 version.

All nokogiri tests pass when the gem is built with any of the above environments and when using this PR together with #989. Verified with Ruby-x64 2.0.0-p0, Ruby-x86 2.0.0-p0 and Ruby-x86 1.9.3-p392 installed per RubyInstaller.

The buildin vasprintf() function is also used on Solaris, which I'm not able to test. But the given workaround should work on any platform that implements vsnprintf() according to C99.
