### PR TITLE
Fix segfault when doing marking and doc is not a document node

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -14,7 +14,14 @@ static void debug_node_dealloc(xmlNodePtr x)
 
 static void mark(xmlNodePtr node)
 {
-  rb_gc_mark(DOC_RUBY_OBJECT(node->doc));
+  xmlNodePtr doc = node->doc;
+  if(doc->type == XML_DOCUMENT_NODE || doc->type == XML_HTML_DOCUMENT_NODE) {
+    if(DOC_RUBY_OBJECT_TEST(doc)) {
+      rb_gc_mark(DOC_RUBY_OBJECT(doc));
+    }
+  } else if(node->doc->_private) {
+    rb_gc_mark((VALUE)doc->_private);
+  }
 }
 
 /* :nodoc: */


### PR DESCRIPTION
This fixes the problem where the doc node can actually also be a
XML_DOCUMENT_FRAG_NODE. In that case it's structured like a node which
means it stores a VALUE inside _private.

This checks the type of the code and uses the correct marking for the
specific cases.

Fixes #939
