### PR TITLE
pass env's CFLAGS through to sub-builds

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -262,7 +262,7 @@ else
           [
             "--disable-shared",
             "--enable-static",
-            "CFLAGS=-fPIC",
+            "CFLAGS='-fPIC #{ENV["CFLAGS"]}'",
           ]
         else
           [


### PR DESCRIPTION
This is needed in order for `CFLAGS="-g blahblah" to pass down to libxml and friends".
