### PR TITLE
fix customised save format options never override default option

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -899,7 +899,6 @@ module Nokogiri
         # FIXME: this is a hack around broken libxml versions
         return dump_html if Nokogiri.uses_libxml? && %w[2 6] === LIBXML_VERSION.split('.')[0..1]
 
-        options[:save_with] |= save_option if options[:save_with]
         options[:save_with] = save_option unless options[:save_with]
         serialize(options)
       end


### PR DESCRIPTION
The default option DEFAULT_HTML is always being used despite of :save_with=>0. 

doc.to_html(:save_with => 0)  doesn't work because 
options[:save_with] |= save_option  #=> DEFAULT_HTML, which is 71. 

options[:save_with] = save_option unless options[:save_with] # this line does the job, it means when :save_with is set with some customized saving options, such as NO_DECLARATION | AS_HTML, then the default one should not be used anymore.
