### PR TITLE
Remove excess + from CHANGELOG.rdoc

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -42,7 +42,7 @@
   * (JRuby) XML SAX push parser leaks memory on JRuby, but not on MRI. #998
 
 
-+=== 1.6.1 / 2013-12-14
+=== 1.6.1 / 2013-12-14
 
 * Bugfixes
 


### PR DESCRIPTION
The 1.6.1 title in the CHANGELOG was not displaying properly due to a `+` character on the beginning of that line.
