### PR TITLE
Fix 1.6.1 heading in changelog

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -42,7 +42,7 @@
   * (JRuby) XML SAX push parser leaks memory on JRuby, but not on MRI. #998
 
 
-+=== 1.6.1 / 2013-12-14
+=== 1.6.1 / 2013-12-14
 
 * Bugfixes
 


### PR DESCRIPTION
An extra `+` before the `===` caused the 1.6.1 heading to be rendered as not a heading.
