### PR TITLE
Fix to fail searching libxml2/libxslt on mswin.

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -376,7 +376,7 @@ end
   "xslt"  => ['xsltParseStylesheetDoc', 'libxslt/xslt.h'],
   "exslt" => ['exsltFuncRegister',      'libexslt/exslt.h'],
 }.each { |lib, (func, header)|
-  have_func(func, header) || have_library(lib, func, header) or asplode("lib#{lib}")
+  have_func(func, header) || have_library(lib, func, header) || have_library("lib#{lib}", func, header) or asplode("lib#{lib}")
 }
 
 unless have_func('xmlHasFeature')


### PR DESCRIPTION
ext/nokogiri/extconf.rb searches xml2.lib, xslt.lib and exslt.lib on mswin platform.
But it fails because libxml2 and libxslt installs libxml2.lib, libxslt.lib and libexslt.lib.

I tested with:
- Windows 7 SP1
- cl.exe for x64 (Visual Studio 2013 Express for Windows Desktop)
- Ruby 2.1.0 (ruby 2.1.0p0 (2013-12-25 revision 44422) [x64-mswin64_120])
- libxml2 2.8.0
- libxslt 1.1.28
