### PR TITLE
FIX: doc.root add omment or processinginstruction sibling

### DIFF
--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -233,7 +233,7 @@ module Nokogiri
       undef_method :namespace_definitions, :line, :add_namespace
 
       def add_child node_or_tags
-        raise "Document already has a root node" if root && root.name != 'nokogiri_text_wrapper'
+        raise "Document already has a root node" if root && root.name != 'nokogiri_text_wrapper' && !(node_or_tags.is_a?(XML::Comment) || node_or_tags.is_a?(XML::ProcessingInstruction))
         node_or_tags = coerce(node_or_tags)
         if node_or_tags.is_a?(XML::NodeSet)
           raise "Document cannot have multiple root nodes" if node_or_tags.size > 1

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -313,7 +313,7 @@ module Nokogiri
       #
       # Also see related method +before+.
       def add_previous_sibling node_or_tags
-        raise ArgumentError.new("A document may not have multiple root nodes.") if parent.is_a?(XML::Document) && !node_or_tags.is_a?(XML::ProcessingInstruction)
+        raise ArgumentError.new("A document may not have multiple root nodes.") if parent.is_a?(XML::Document) && !(node_or_tags.is_a?(XML::Comment) || node_or_tags.is_a?(XML::ProcessingInstruction))
 
         add_sibling :previous, node_or_tags
       end
@@ -326,7 +326,7 @@ module Nokogiri
       #
       # Also see related method +after+.
       def add_next_sibling node_or_tags
-        raise ArgumentError.new("A document may not have multiple root nodes.") if parent.is_a?(XML::Document)
+        raise ArgumentError.new("A document may not have multiple root nodes.") if parent.is_a?(XML::Document) && !(node_or_tags.is_a?(XML::Comment) || node_or_tags.is_a?(XML::ProcessingInstruction))
         
         add_sibling :next, node_or_tags
       end

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -1144,6 +1144,67 @@ eoxml
         root << "<a>hello:with_colon</a>"
         assert_match(/hello:with_colon/, document.to_xml)
       end
+
+      def test_document_add_morethanone_comment_or_processinginstruction
+        document = Nokogiri::XML::Document.new
+        root = Nokogiri::XML::Node.new 'foo', document
+        document.root = root
+
+        comment1 = Nokogiri::XML::Comment.new(document, 'comment message')
+        pi1 = Nokogiri::XML::ProcessingInstruction.new(document, 'xml-pi', 'key="value"')
+
+        assert_equal comment1, document.add_child(comment1)
+        assert_equal pi1, document.add_child(pi1)
+
+        assert_equal comment1, root.add_previous_sibling(comment1)
+        assert_equal pi1, root.add_previous_sibling(pi1)
+
+        assert_equal comment1, root.add_next_sibling(comment1)
+        assert_equal pi1, root.add_next_sibling(pi1)
+      end
+
+      def test_document_add_morethanone_other_node
+        document = Nokogiri::XML::Document.new
+        root = Nokogiri::XML::Node.new 'foo', document
+        document.root = root
+
+        node1 = Nokogiri::XML::Node.new('node1',  document)
+
+        assert_raises(RuntimeError, 'Document already has a root node') do
+          document.add_child(node1)
+        end
+
+        assert_raises(ArgumentError, 'A document may not have multiple root nodes') do
+          root.add_previous_sibling(node1)
+        end
+
+        assert_raises(ArgumentError, 'A document may not have multiple root nodes') do
+          root.add_next_sibling(node1)
+        end
+      end
+
+      def test_node_add_sibling
+        document = Nokogiri::XML::Document.new
+        root = Nokogiri::XML::Node.new 'foo', document
+        document.root = root
+
+        comment1 = Nokogiri::XML::Comment.new(document, 'comment message')
+        pi1 = Nokogiri::XML::ProcessingInstruction.new(document, 'xml-pi', 'key="value"')
+        node1 = Nokogiri::XML::Node.new('node1',  document)
+        node2 = Nokogiri::XML::Node.new('node2',  document)
+
+        assert_equal comment1, root.add_child(comment1)
+        assert_equal pi1, root.add_child(pi1)
+        assert_equal node1, root.add_child(node1)
+
+        assert_equal comment1, node1.add_previous_sibling(comment1)
+        assert_equal pi1, node1.add_previous_sibling(pi1)
+        assert_equal node2, node1.add_previous_sibling(node2)
+
+        assert_equal comment1, node1.add_next_sibling(comment1)
+        assert_equal pi1, node1.add_next_sibling(pi1)
+        assert_equal node2, node1.add_next_sibling(node2)
+      end
     end
   end
 end


### PR DESCRIPTION
FIX:    doc.root cann't add_next_sibling comment or processinginstruction

```
pi   = Nokogiri::XML::ProcessingInstruction.new(doc, 'xml-xxx', 'yy="zz"')
comm = Nokogiri::XML::Comment.new(doc, 'xxx')

doc.root.add_previous_sibling(pi)     # ok
doc.add_child(pi)                     # RuntimeError: Document already has a root node
doc.root.add_next_sibling(pi)         # ArgumentError: A document may not have multiple root nodes

doc.root.add_previous_sibling(comm)   # ArgumentError: A document may not have multiple root nodes
doc.root.add_next_sibling(comm)       # ArgumentError: A document may not have multiple root nodes
```
