### PR TITLE
Allow Nokogiri::XML::Node#parse from unparented non-element nodes.

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -25,6 +25,7 @@
   * Nokogiri::XML::Node#prepend_child is added. #664
   * Nokogiri::XML::SAX::ParserContext#recovery is added. #453
   * Fix documentation for XML::Node#namespace. #803 #802 (Thanks, Hoylen Sue)
+  * Allow Nokogiri::XML::Node#parse from unparented non-element nodes. #407
 
 * Bugfixes
 

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -508,6 +508,15 @@ module Nokogiri
       # *this* node.  Returns a XML::NodeSet containing the nodes parsed from
       # +string_or_io+.
       def parse string_or_io, options = nil
+        ##
+        # When the current node is unparented and not an element node, use the
+        # document as the parsing context instead. Otherwise, the in-context
+        # parser cannot find an element or a document node.
+        # Document Fragments are also not usable by the in-context parser.
+        if !element? && !xml? && (!parent || parent.fragment?)
+          return document.parse(string_or_io, options)
+        end
+
         options ||= (document.html? ? ParseOptions::DEFAULT_HTML : ParseOptions::DEFAULT_XML)
         if Fixnum === options
           options = Nokogiri::XML::ParseOptions.new(options)

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -76,6 +76,11 @@ module Nokogiri
         assert_instance_of klass, doc
       end
 
+      def test_unparented_text_node_parse
+        fragment = Nokogiri::XML::DocumentFragment.parse("foo")
+        fragment.children.after("<bar/>")
+      end
+
       def test_xml_fragment
         fragment = Nokogiri::XML.fragment("<div>a</div>")
         assert_equal "<div>a</div>", fragment.to_s

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -133,6 +133,12 @@ module Nokogiri
         node.parse('<baz><</baz>')
       end
 
+      def test_parse_with_unparented_text_context_node
+        doc = XML::Document.new
+        elem = XML::Text.new("foo", doc)
+        elem.parse("<bar/>")
+      end
+
       def test_subclass_dup
         subclass = Class.new(Nokogiri::XML::Node)
         node = subclass.new('foo', @xml).dup


### PR DESCRIPTION
Giving this changeset a chance to be reviewed before committing.

@flavorjones - You looked at this ticket at one point. Does this solution look reasonable?

To see what libxml2 is doing here, look at parser.c:xmlParseInNodeContext(). Note how it traverses up the tree in search of an XML_ELEMENT_NODE or an XML_DOCUMENT_NODE.

The solution here is to detect that scenario and to use the document node for parsing context instead.

The problem only occurs with libxml2, and not in jruby. I've applied the solution to both since it doesn't seem to hurt.

Fixes #407
