### PR TITLE
Use the :encoding arg on Document.parse even when contents are blank

### DIFF
--- a/lib/nokogiri/html/document.rb
+++ b/lib/nokogiri/html/document.rb
@@ -173,7 +173,7 @@ module Nokogiri
 
           if string_or_io.respond_to?(:read)
             url ||= string_or_io.respond_to?(:path) ? string_or_io.path : nil
-            if !encoding
+            unless encoding
               # Libxml2's parser has poor support for encoding
               # detection.  First, it does not recognize the HTML5
               # style meta charset declaration.  Secondly, even if it
@@ -196,7 +196,9 @@ module Nokogiri
           end
 
           # read_memory pukes on empty docs
-          return new if string_or_io.nil? or string_or_io.empty?
+          if string_or_io.nil? or string_or_io.empty?
+            return encoding ? new.tap { |i| i.encoding = encoding } : new
+          end
 
           encoding ||= EncodingReader.detect_encoding(string_or_io)
 

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -45,7 +45,9 @@ module Nokogiri
         # Give the options to the user
         yield options if block_given?
 
-        return new if !options.strict? && empty_doc?(string_or_io)
+        if !options.strict? && empty_doc?(string_or_io)
+          return encoding ? new.tap { |i| i.encoding = encoding } : new
+        end
 
         doc = if string_or_io.respond_to?(:read)
           url ||= string_or_io.respond_to?(:path) ? string_or_io.path : nil

--- a/test/html/test_document_encoding.rb
+++ b/test/html/test_document_encoding.rb
@@ -3,8 +3,8 @@ require "helper"
 
 module Nokogiri
   module HTML
-    if RUBY_VERSION =~ /^1\.9/
-      class TestDocumentEncoding < Nokogiri::TestCase
+    class TestDocumentEncoding < Nokogiri::TestCase
+      if RUBY_VERSION =~ /^1\.9/  
         def test_encoding
           doc = Nokogiri::HTML File.open(SHIFT_JIS_HTML, 'rb')
 
@@ -81,6 +81,11 @@ module Nokogiri
           assert_equal ['http://tenderlovemaking.com/'],
             doc.css('a').map { |a| a['href'] }
         end
+      end
+
+      def test_empty_doc_encoding
+        encoding = 'US-ASCII'
+        assert_equal encoding, Nokogiri::HTML.parse(nil, nil, encoding).encoding
       end
     end
 

--- a/test/xml/test_node_encoding.rb
+++ b/test/xml/test_node_encoding.rb
@@ -101,6 +101,11 @@ module Nokogiri
             assert_equal doc.encoding, v.encoding.name
           end
         end
+
+        def test_empty_doc_encoding
+          encoding = 'US-ASCII'
+          assert_equal encoding, Nokogiri::XML(nil, nil, encoding).encoding
+        end
       end
     end
   end


### PR DESCRIPTION
Currently, `Nokogiri::XML::Document.parse` and `Nokogiri::HTML::Document.parse` discards the `encoding` argument if it receives `nil` or `blank` contents for the `string_or_io` argument.  This pull tweaks the code to set the `encoding` value (if it is passed in) even when the `string_or_io` argument is blank.

```ruby
# before this pull request
doc = Nokogiri.HTML(nil, nil, 'UTF-8')
doc.encoding # => nil
# after this pull request
doc = Nokogiri.HTML(nil, nil, 'UTF-8')
doc.encoding # => 'UTF-8'
```

This is really just a convenience thing, so that if you want to compose a blank document with an particular encoding, you can do something like this:

```ruby
doc = Nokogiri.HTML(nil, nil, 'UTF-8')
Nokogiri::HTML::DocumentFragment.new(doc, string)
```

instead of having to do something like this:

```ruby
doc = Nokogiri::HTML::Document.new
doc.encoding = 'UTF-8'
Nokogiri::HTML::DocumentFragment.new(doc, string)
```

This is particularly helpful for Ruby18 users where the `String` class does not have the concept of encoding on it's own.  True, you can technically condense the above example down into this:

```ruby
doc = Nokogiri::HTML::Document.new.tap { |d| d.encoding = 'UTF-8' }
Nokogiri::HTML::DocumentFragment.new(doc, string)
```

But it's cleaner to just have the `parse` method enforce the encoding regardless of contents it receives.