### PR TITLE
Bang finder methods - raise if element is nil.

### DIFF
--- a/lib/nokogiri/xml/bang_finders.rb
+++ b/lib/nokogiri/xml/bang_finders.rb
@@ -1,20 +1,29 @@
 module Nokogiri
   module XML
     module BangFinders
-
       def at!(*args)
-        at(*args).tap       { |v| raise Nokogiri::XML::NotFound if v.nil? }
+        node = at(*args);       raise NotFound.new(args, self) if node.nil?; node
       end
 
       def at_xpath!(*args)
-        at_xpath(*args).tap { |v| raise Nokogiri::XML::NotFound if v.nil? }
+        node = at_xpath(*args); raise NotFound.new(args, self) if node.nil?; node
       end
 
       def at_css!(*args)
-        at_css(*args).tap   { |v| raise Nokogiri::XML::NotFound if v.nil? }
+        node = at_css(*args);   raise NotFound.new(args, self) if node.nil?; node
       end
+
     end
 
-    NotFound = Class.new(StandardError)
+    class NotFound < StandardError
+      attr_reader :message
+      def initialize(needle, haystack)
+        @message = "#{needle} in \n#{snippet(haystack)}"
+      end
+      def snippet(haystack)
+        snippet = haystack.to_s
+        snippet.length > 200 ? "#{snippet[0...200]}..." : snippet
+      end
+    end
   end
 end

--- a/lib/nokogiri/xml/bang_finders.rb
+++ b/lib/nokogiri/xml/bang_finders.rb
@@ -1,0 +1,20 @@
+module Nokogiri
+  module XML
+    module BangFinders
+
+      def at!(*args)
+        at(*args).tap       { |v| raise Nokogiri::XML::NotFound if v.nil? }
+      end
+
+      def at_xpath!(*args)
+        at_xpath(*args).tap { |v| raise Nokogiri::XML::NotFound if v.nil? }
+      end
+
+      def at_css!(*args)
+        at_css(*args).tap   { |v| raise Nokogiri::XML::NotFound if v.nil? }
+      end
+    end
+
+    NotFound = Class.new(StandardError)
+  end
+end

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -1,5 +1,6 @@
 require 'stringio'
 require 'nokogiri/xml/node/save_options'
+require 'nokogiri/xml/bang_finders'
 
 module Nokogiri
   module XML
@@ -35,6 +36,7 @@ module Nokogiri
     # You may search this node's subtree using Node#xpath and Node#css
     class Node
       include Nokogiri::XML::PP::Node
+      include Nokogiri::XML::BangFinders
       include Enumerable
 
       # Element node type, see Nokogiri::XML::Node#element?

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -1,3 +1,4 @@
+require 'nokogiri/xml/bang_finders'
 module Nokogiri
   module XML
     ####
@@ -5,6 +6,7 @@ module Nokogiri
     # a NodeSet is return as a result of searching a Document via
     # Nokogiri::XML::Node#css or Nokogiri::XML::Node#xpath
     class NodeSet
+      include Nokogiri::XML::BangFinders
       include Enumerable
 
       # The Document this NodeSet is associated with

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -462,9 +462,10 @@ module Nokogiri
 
       def test_at!
         assert_equal @xml.at!('address'), @xml.at('address')
-        assert_raises(Nokogiri::XML::NotFound) do
+        err = assert_raises(Nokogiri::XML::NotFound) do
           @xml.at!('helmetSize')
         end
+        err.message.must_match(/helmetSize/)
       end
 
       def test_at_self
@@ -481,9 +482,10 @@ module Nokogiri
 
       def test_at_xpath!
         assert_equal @xml.at_xpath!('//address'), @xml.at_xpath('//address')
-        assert_raises(Nokogiri::XML::NotFound) do
+        err = assert_raises(Nokogiri::XML::NotFound) do
           @xml.at_xpath!('//helmetSize')
         end
+        err.message.must_match(/\/\/helmetSize/)
       end
 
       def test_at_css
@@ -495,9 +497,10 @@ module Nokogiri
 
       def test_at_css!
         assert_equal @xml.at_css!('address'), @xml.at_css('address')
-        assert_raises(Nokogiri::XML::NotFound) do
+        err = assert_raises(Nokogiri::XML::NotFound) do
           @xml.at_css!('helmetSize')
         end
+        err.message.must_match(/helmetSize/)
       end
 
       def test_percent

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -460,6 +460,13 @@ module Nokogiri
         assert_equal node, @xml.xpath('//address').first
       end
 
+      def test_at!
+        assert_equal @xml.at!('address'), @xml.at('address')
+        assert_raises(Nokogiri::XML::NotFound) do
+          @xml.at!('helmetSize')
+        end
+      end
+
       def test_at_self
         node = @xml.at('address')
         assert_equal node, node.at('.')
@@ -472,11 +479,25 @@ module Nokogiri
         assert_equal node, nodes.first
       end
 
+      def test_at_xpath!
+        assert_equal @xml.at_xpath!('//address'), @xml.at_xpath('//address')
+        assert_raises(Nokogiri::XML::NotFound) do
+          @xml.at_xpath!('//helmetSize')
+        end
+      end
+
       def test_at_css
         node = @xml.at_css('address')
         nodes = @xml.css('address')
         assert_equal 5, nodes.size
         assert_equal node, nodes.first
+      end
+
+      def test_at_css!
+        assert_equal @xml.at_css!('address'), @xml.at_css('address')
+        assert_raises(Nokogiri::XML::NotFound) do
+          @xml.at_css!('helmetSize')
+        end
       end
 
       def test_percent

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -316,14 +316,38 @@ module Nokogiri
         assert_equal node_set.first, node_set.at(0)
       end
 
+      def test_at!
+        assert node_set = @xml.search('//employee')
+        assert_equal node_set.at!(0), node_set.at(0)
+        assert_raises(Nokogiri::XML::NotFound) do
+          node_set.at!(500)
+        end
+      end
+
       def test_at_xpath
         assert node_set = @xml.search('//employee')
         assert_equal node_set.first.first_element_child, node_set.at_xpath('./employeeId')
       end
 
+      def test_at_xpath!
+        assert node_set = @xml.search('//employee')
+        assert_equal node_set.at_xpath!('./employeeId'), node_set.at_xpath('./employeeId')
+        assert_raises(Nokogiri::XML::NotFound) do
+          node_set.at_xpath!('./helmetSize')
+        end
+      end
+
       def test_at_css
         assert node_set = @xml.search('//employee')
         assert_equal node_set.first.first_element_child, node_set.at_css('employeeId')
+      end
+
+      def test_at_css!
+        assert node_set = @xml.search('//employee')
+        assert_equal node_set.at_css!('employeeId'), node_set.at_css('employeeId')
+        assert_raises(Nokogiri::XML::NotFound) do
+          node_set.at_css!('helmetSize')
+        end
       end
 
       def test_percent

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -319,9 +319,10 @@ module Nokogiri
       def test_at!
         assert node_set = @xml.search('//employee')
         assert_equal node_set.at!(0), node_set.at(0)
-        assert_raises(Nokogiri::XML::NotFound) do
+        err = assert_raises(Nokogiri::XML::NotFound) do
           node_set.at!(500)
         end
+        err.message.must_match(/500/)
       end
 
       def test_at_xpath
@@ -332,9 +333,10 @@ module Nokogiri
       def test_at_xpath!
         assert node_set = @xml.search('//employee')
         assert_equal node_set.at_xpath!('./employeeId'), node_set.at_xpath('./employeeId')
-        assert_raises(Nokogiri::XML::NotFound) do
+        err = assert_raises(Nokogiri::XML::NotFound) do
           node_set.at_xpath!('./helmetSize')
         end
+        err.message.must_match(/\.\/helmetSize/)
       end
 
       def test_at_css
@@ -345,9 +347,10 @@ module Nokogiri
       def test_at_css!
         assert node_set = @xml.search('//employee')
         assert_equal node_set.at_css!('employeeId'), node_set.at_css('employeeId')
-        assert_raises(Nokogiri::XML::NotFound) do
+        err = assert_raises(Nokogiri::XML::NotFound) do
           node_set.at_css!('helmetSize')
         end
+        err.message.must_match(/helmetSize/)
       end
 
       def test_percent


### PR DESCRIPTION
Add 'at!', 'at_css!', and 'at_xpath!' to Node and NodeSet.
Each bang method simply calls its non-bang counterpart and
either returns its value or, if that value is nil, raises
Nokogiri::XML::NotFound.

Fixes https://github.com/sparklemotion/nokogiri/issues/1045