### PR TITLE
Fix attribute/namespace consistency between original and cloned documents in JRuby

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -34,6 +34,7 @@ package nokogiri;
 
 import static java.lang.Math.max;
 import static nokogiri.internals.NokogiriHelpers.getCachedNodeOrCreate;
+import static nokogiri.internals.NokogiriHelpers.clearCachedNode;
 import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
 import static nokogiri.internals.NokogiriHelpers.nodeArrayToRubyArray;
 import static nokogiri.internals.NokogiriHelpers.nonEmptyStringOrNil;
@@ -455,6 +456,7 @@ public class XmlNode extends RubyObject {
 
     public void relink_namespace(ThreadContext context) {
         if (node instanceof Element) {
+            clearCachedNode(node);
             Element e = (Element) node;
             String prefix = e.getPrefix();
             String currentNS = e.getNamespaceURI();
@@ -485,9 +487,13 @@ public class XmlNode extends RubyObject {
                     } else {
                         nsUri = attr.lookupNamespaceURI(attrPrefix);
                     }
+                    if (nsUri == e.getNamespaceURI()) {
+                        nsUri = null;
+                    }
                     if (!(nsUri == null || "".equals(nsUri))) {
                         XmlNamespace.createFromAttr(context.getRuntime(), attr);
                     }
+                    clearCachedNode(attr);
                     NokogiriHelpers.renameNode(attr, nsUri, nodeName);
                 }
             }

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -93,6 +93,10 @@ public class NokogiriHelpers {
         return (XmlNode) node.getUserData(CACHED_NODE);
     }
 
+    public static void clearCachedNode(Node node) {
+        node.setUserData(CACHED_NODE, null, null);
+    }
+
     /**
      * Get the XmlNode associated with the underlying
      * <code>node</code>. Creates a new XmlNode (or appropriate subclass)

--- a/test/namespaces/test_namespaces_in_cloned_doc.rb
+++ b/test/namespaces/test_namespaces_in_cloned_doc.rb
@@ -1,0 +1,31 @@
+require "helper"
+
+module Nokogiri
+  module XML
+    class TestNamespacesInClonedDoc < Nokogiri::TestCase
+      def setup
+        super
+        b = Nokogiri::XML::Builder.new do |xml|
+          xml.mods("xmlns"=>"http://www.loc.gov/mods/v3") {
+            xml.name(:type=>"personal") {
+              xml.namePart()
+            }
+          }
+        end
+
+        @doc = b.doc
+        @clone = Nokogiri::XML(@doc.to_s)
+      end
+
+      def check_namespace e
+        e.namespace.nil? ? nil : e.namespace.href
+      end
+
+      def test_namespace_ns
+        xpath = '//oxns:name[@type="personal"]'
+        namespaces = {'oxns' => "http://www.loc.gov/mods/v3"}
+        assert_equal @doc.xpath(xpath, namespaces).length, @clone.xpath(xpath, namespaces).length
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses #1034

Clear cached nodes when relinking namespaces
Remove attribute namespace when it matches the host element's namespace
