### PR TITLE
Fix NullPointerException resulting from incorrect namespace comparison

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -478,14 +478,14 @@ public class XmlNode extends RubyObject {
                         attrPrefix = NokogiriHelpers.getPrefix(attr.getNodeName());
                     }
                     String nodeName = attr.getNodeName();
-                    if ("xml".equals(prefix)) {
+                    if ("xml".equals(attrPrefix)) {
                         nsUri = "http://www.w3.org/XML/1998/namespace";
                     } else if ("xmlns".equals(attrPrefix) || nodeName.equals("xmlns")) {
                         nsUri = "http://www.w3.org/2000/xmlns/";
                     } else {
                         nsUri = attr.lookupNamespaceURI(attrPrefix);
                     }
-                    if (!(nsUri == null || "".equals(nsUri))) {
+                    if (!(nsUri == null || "".equals(nsUri) || "http://www.w3.org/XML/1998/namespace".equals(nsUri))) {
                         XmlNamespace.createFromAttr(context.getRuntime(), attr);
                     }
                     NokogiriHelpers.renameNode(attr, nsUri, nodeName);

--- a/test/xml/test_node_attributes.rb
+++ b/test/xml/test_node_attributes.rb
@@ -59,6 +59,23 @@ module Nokogiri
         assert_equal [], node.namespace_definitions.map(&:prefix)
       end
 
+      def test_append_child_element_with_prefixed_attributes
+        doc = Nokogiri::XML "<root/>"
+        node = doc.root
+
+        assert_equal [], node.namespace_definitions.map(&:prefix)
+
+
+        # assert_nothing_raised do
+          child_node = Nokogiri::XML::Node.new 'foo', doc
+          child_node['xml:lang'] = 'en-GB'
+
+          node << child_node
+        # end
+
+        assert_equal [], child_node.namespace_definitions.map(&:prefix)
+      end
+
       def test_namespace_key?
         doc = Nokogiri::XML <<-eoxml
           <root xmlns:tlm='http://tenderlovemaking.com/'>


### PR DESCRIPTION
This comparison should use the attribute prefix instead of the element prefix, and omit the default XML namespace from the generated namespace list. The current implementation throws a NullPointerException when a new element with an xml: prefixed attribute is inserted into the DOM.
