### PR TITLE
Fix for #843 - the xml reader bombs out when trying access attribute namespaces

### DIFF
--- a/ext/nokogiri/xml_namespace.c
+++ b/ext/nokogiri/xml_namespace.c
@@ -38,19 +38,19 @@ VALUE Nokogiri_wrap_xml_namespace(xmlDocPtr doc, xmlNsPtr node)
 {
   VALUE ns, document, node_cache;
 
-  assert(doc->_private);
-
   if(node->_private)
     return (VALUE)node->_private;
 
   ns = Data_Wrap_Struct(cNokogiriXmlNamespace, 0, 0, node);
 
-  document = DOC_RUBY_OBJECT(doc);
+  if (doc->_private) {
+    document = DOC_RUBY_OBJECT(doc);
 
-  node_cache = rb_iv_get(document, "@node_cache");
-  rb_ary_push(node_cache, ns);
+    node_cache = rb_iv_get(document, "@node_cache");
+    rb_ary_push(node_cache, ns);
 
-  rb_iv_set(ns, "@document", DOC_RUBY_OBJECT(doc));
+    rb_iv_set(ns, "@document", DOC_RUBY_OBJECT(doc));
+  }
 
   node->_private = (void *)ns;
 

--- a/ext/nokogiri/xml_namespace.c
+++ b/ext/nokogiri/xml_namespace.c
@@ -37,8 +37,12 @@ static VALUE href(VALUE self)
 VALUE Nokogiri_wrap_xml_namespace(xmlDocPtr doc, xmlNsPtr node)
 {
   VALUE ns, document, node_cache;
+  nokogiriTuplePtr node_has_a_document;
 
-  if(node->_private)
+  if (doc->type == XML_DOCUMENT_FRAG_NODE) doc = doc->doc;
+  node_has_a_document = DOC_RUBY_OBJECT_TEST(doc);
+
+  if(node->_private && node_has_a_document)
     return (VALUE)node->_private;
 
   ns = Data_Wrap_Struct(cNokogiriXmlNamespace, 0, 0, node);

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -386,6 +386,25 @@ class TestReader < Nokogiri::TestCase
                   reader.map { |n| n.namespace_uri })
   end
 
+  def test_namespaced_attributes
+    reader = Nokogiri::XML::Reader.from_memory(<<-eoxml)
+    <x xmlns:edi='http://ecommerce.example.org/schema' xmlns:commons="http://rets.org/xsd/RETSCommons">
+      <edi:foo commons:street-number="43">hello</edi:foo>
+      <y edi:name="francis" bacon="87"/>
+    </x>
+    eoxml
+    attr_ns = []
+    while reader.read
+      if reader.node_type == Nokogiri::XML::Node::ELEMENT_NODE
+        reader.attribute_nodes.each {|attr| attr_ns << (attr.namespace.nil? ? nil : attr.namespace.prefix) }
+      end
+    end
+    assert_equal(['commons',
+                  'edi',
+                  nil],
+                 attr_ns)
+  end
+
   def test_local_name
     reader = Nokogiri::XML::Reader.from_memory(<<-eoxml)
     <x xmlns:edi='http://ecommerce.example.org/schema'>


### PR DESCRIPTION
See #843 for an example of the issue.

Was hoping for some help with this if anyone can lend a hand. Have added a test case which is now passing under C ruby but failing under jruby.

These commits fix an issue in the nokogiri reader when trying to access namespace properties on attribute nodes. Currently when trying to access them via the attribute_nodes method it halts the ruby interpreter :(

If you copy and paste the test case into master, without applying the patch you should be able to see the test suite crash mid way through.




