### PR TITLE
Workaround the MSYS character escaping bug on native mingw builds only.

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -232,11 +232,13 @@ else
   $CFLAGS << " -g -DXP_UNIX"
 end
 
-if RbConfig::MAKEFILE_CONFIG['CC'] =~ /mingw/
+if RUBY_PLATFORM =~ /mingw/i
   # Work around a character escaping bug in MSYS by passing an arbitrary
   # double quoted parameter to gcc. See https://sourceforge.net/p/mingw/bugs/2142
   $CPPFLAGS << ' "-Idummypath"'
+end
 
+if RbConfig::MAKEFILE_CONFIG['CC'] =~ /mingw/
   $CFLAGS << " -DIN_LIBXML"
   # Mingw32 package is static linked
   $LIBS << " -lz -liconv"


### PR DESCRIPTION
It was triggered on cross builds only before, so that native builds with the DevKit didn't work. Sorry, I didn't test the last commit in #989 fully...
