### PR TITLE
Fix JRuby memory exhaustion vulnerability

### DIFF
--- a/ext/java/nokogiri/internals/NokogiriNonStrictErrorHandler.java
+++ b/ext/java/nokogiri/internals/NokogiriNonStrictErrorHandler.java
@@ -90,9 +90,11 @@ public class NokogiriNonStrictErrorHandler extends NokogiriErrorHandler{
      * the parsing to stop, or an error that can be ignored.
      */
     private static boolean isFatal(String msg) {
+        String msgLowerCase = msg.toLowerCase();
         return
-          msg.toLowerCase().contains("in prolog") ||
-          msg.toLowerCase().contains("limit") ||
-          msg.toLowerCase().contains("preceding the root element must be well-formed");
+          msgLowerCase.contains("in prolog") ||
+          msgLowerCase.contains("limit") ||
+          msgLowerCase.contains("preceding the root element must be well-formed") ||
+          msgLowerCase.contains("following the root element must be well-formed");
     }
 }

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -625,6 +625,12 @@ module Nokogiri
         refute_empty doc.errors
       end
 
+      def test_memory_explosion_on_wrong_formatted_element_following_the_root_element
+        doc = Nokogiri::XML("<a/><\n")
+        refute_nil doc
+        refute_empty doc.errors
+      end
+
       def test_document_has_errors
         doc = Nokogiri::XML(<<-eoxml)
           <foo><bar></foo>


### PR DESCRIPTION
This pull request fixes JRuby memory exhaustion vulnerability which may lead to DoS attack. 

It is very similar to the one described here:
https://groups.google.com/forum/#!msg/ruby-security-ann/DeJpjTAg1FA/CADdUQ6N_qMJ
