### PR TITLE
Add Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.2
   - ruby-head
   - jruby-19mode
   - jruby-20mode
@@ -20,6 +21,8 @@ matrix:
     - rvm: 1.9.3
       jdk: openjdk7
     - rvm: 2.0.0
+      jdk: openjdk7
+    - rvm: 2.1.2
       jdk: openjdk7
     - rvm: ruby-head
       jdk: openjdk7


### PR DESCRIPTION
Would be great to know Ruby 2.1.2 is supported.
