### PR TITLE
Update README examples with to match new Google HTML.

### DIFF
--- a/README.ja.rdoc
+++ b/README.ja.rdoc
@@ -39,26 +39,29 @@ IRCのチャンネルはfreenodeの #nokogiri です。
   require 'nokogiri'
   require 'open-uri'
   
-  doc = Nokogiri::HTML(open('http://www.google.com/search?q=tenderlove'))
+  # Get a Nokogiri::HTML::Document for the page we’re interested in...
+
+  doc = Nokogiri::HTML(open('http://www.google.com/search?q=sparklemotion'))
+
+  # Do funky things with it using Nokogiri::XML::Node methods...
   
   ####
   # Search for nodes by css
-  doc.css('h3.r a.l').each do |link|
+  doc.css('h3.r a').each do |link|
     puts link.content
   end
   
   ####
   # Search for nodes by xpath
-  doc.xpath('//h3/a[@class="l"]').each do |link|
+  doc.xpath('//h3[@class="r"]/a').each do |link|
     puts link.content
   end
   
   ####
   # Or mix and match.
-  doc.search('h3.r a.l', '//h3/a[@class="l"]').each do |link|
+  doc.search('h3.r a', '//h3[@class="r"]/a').each do |link|
     puts link.content
   end
-
 
 == REQUIREMENTS:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -59,16 +59,15 @@ The IRC channel is #nokogiri on freenode.
 
   ####
   # Search for nodes by xpath
-  doc.xpath('//h3/a').each do |link|
+  doc.xpath('//h3[@class="r"]/a').each do |link|
     puts link.content
   end
 
   ####
   # Or mix and match.
-  doc.search('h3.r a.l', '//h3/a').each do |link|
+  doc.search('h3.r a', '//h3[@class="r"]/a').each do |link|
     puts link.content
   end
-
 
 == REQUIREMENTS:
 


### PR DESCRIPTION
The perils of HTML scraping...

I wasn't sure what the combined example was supposed to be because the CSS selector and the XPATH selectors are equivalent.  Is that how it's supposed to be?

@flavorjones