### PR TITLE
link libxml2 with liblzma if it is found

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -505,6 +505,7 @@ else
   end
 end
 
+find_library("lzma", 'lzma_end') # for systems with liblzma
 {
   "xml2"  => ['xmlParseDoc',            'libxml/parser.h'],
   "xslt"  => ['xsltParseStylesheetDoc', 'libxslt/xslt.h'],


### PR DESCRIPTION
If the system have liblzma (and lzma.h), libxml2 enables xz/lzma helper.
It compiles xzlib.c which depends liblzma.
Therefore extconf.rb must run find_library("lzma") and link libxml2
with liblzma.