### PR TITLE
Fix segfault on parsing invalid html

### DIFF
--- a/ext/nokogiri/html_sax_push_parser.c
+++ b/ext/nokogiri/html_sax_push_parser.c
@@ -11,6 +11,7 @@ static VALUE native_write(VALUE self, VALUE _chunk, VALUE _last_chunk)
   xmlParserCtxtPtr ctx;
   const char * chunk  = NULL;
   int size            = 0;
+  int rc = 0;
 
 
   Data_Get_Struct(self, xmlParserCtxt, ctx);
@@ -20,10 +21,15 @@ static VALUE native_write(VALUE self, VALUE _chunk, VALUE _last_chunk)
     size = (int)RSTRING_LEN(_chunk);
   }
 
-  if(htmlParseChunk(ctx, chunk, size, Qtrue == _last_chunk ? 1 : 0)) {
+  rc = htmlParseChunk(ctx, chunk, size, Qtrue == _last_chunk ? 1 : 0);
+  if(rc != 0) {
     if (!(ctx->options & XML_PARSE_RECOVER)) {
       xmlErrorPtr e = xmlCtxtGetLastError(ctx);
-      Nokogiri_error_raise(NULL, e);
+      if (e != NULL) {
+        Nokogiri_error_raise(NULL, e);
+      } else {
+        rb_raise(rb_eArgError, "XML error: %d", rc);
+      }
     }
   }
 

--- a/test/html/test_document_encoding.rb
+++ b/test/html/test_document_encoding.rb
@@ -143,6 +143,11 @@ module Nokogiri
           assert_equal(evil, ary_from_file)
         }
       end
+
+      def test_does_not_fail_with_illformatted_html
+        doc = Nokogiri::HTML('"</html>";'.force_encoding(Encoding::BINARY))
+        assert doc
+      end
     end
   end
 end


### PR DESCRIPTION
htmlParseChunk does not guarantee to return any error, it can just
return XML_ERR_DOCUMENT_END or XML_PARSER_EOF without setting the last
error.

In that case just raise ArgumentError.

Fixes #1126