### PR TITLE
Fix #1109. Clear the XPath cache when an attribute is removed

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1315,6 +1315,7 @@ public class XmlNode extends RubyObject {
             String key = name.convertToString().asJavaString();
             Element element = (Element) node;
             element.removeAttribute(key);
+            clearXpathContext(getNode());
         }
         return this;
     }

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -486,7 +486,7 @@ module Nokogiri
       # Remove the attribute named +name+
       def remove_attribute name
         attributes[name].remove if key? name
-      end
+      end unless Nokogiri.jruby?
       alias :delete :remove_attribute
 
       ###

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -177,6 +177,14 @@ module Nokogiri
         assert_send [elapsed_time, :<, time_limit], "XPath is taking too long"
       end
 
+      # issue #1109 (jruby impl's xpath() cache not being cleared )
+      def test_xpath_results_cache_should_get_cleared
+        doc = Nokogiri::HTML("<html><div selected></div></html>")
+        element = doc.at_xpath('//div[@selected]')
+        element.remove_attribute('selected')
+        assert_nil doc.at_xpath('//div[@selected]')
+      end
+
       def test_custom_xpath_function_returns_string
         if Nokogiri.uses_libxml?
           result = @xml.xpath('thing("asdf")', @handler)
@@ -330,7 +338,7 @@ END
             <RecordReference>a</RecordReference>
           </Product>
         </ONIXMessage>}
-        
+
         xml_doc = Nokogiri::XML(xml_string)
         onix = xml_doc.children.first
         assert_equal 'a', onix.at_xpath('xmlns:Product').at_xpath('xmlns:RecordReference').text
@@ -348,7 +356,7 @@ END
               <title>Artikkelin otsikko Hydrangea artiklan 1</title>
           </titleInfo>
         </mods>}
-        
+
         xml_doc = Nokogiri::XML(xml_string)
         ns_hash = {'mods'=>'http://www.loc.gov/mods/v3'}
         node = xml_doc.at_xpath('//mods:titleInfo[1]',ns_hash)
@@ -369,7 +377,7 @@ END
               <title>Artikkelin otsikko Hydrangea artiklan 1</title>
           </titleInfo>
         </mods>}
-        
+
         xml_doc = Nokogiri::XML(xml_string)
         ns_hash = {'mods'=>'http://www.loc.gov/mods/v3'}
         node = xml_doc.at_xpath('//mods:titleInfo[1]',ns_hash)


### PR DESCRIPTION
This is a fix for #1109. I'd like someone to eyeball since it introduces some changes to the ruby side of nokogiri to conditionally define `remove_attribute` in MRI only. Under JRuby `remove_attribute` is defined in the Java code and the code was being replaced with the ruby version. 