### PR TITLE
add /usr/local/include to search path

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -129,6 +129,9 @@ def each_iconv_idir
     }.first and yield idir
   }
 
+  # Try /usr/local
+  yield "/usr/local/include"
+
   # Try the system default
   yield "/usr/include"
 


### PR DESCRIPTION
If iconv is installed in /usr/local/include but there is no pkg-config
information for the package, then extconf will fail to find a path to
the header files and will not be able to provide it to the libxml2
build.

I don't know a better way of solving this problem, since otherwise the
idea is that you want to use the default mkmf CFLAGS and be able to
tell which include directory the default compile is finding the header
files in.  We'd need to do something like expand the $CFLAGS (hard enough
with mkmf) and then pop off the -I's and add them back one at a time
until you found where iconv.h was actually hiding.
