### PR TITLE
Fix warnings in test suite.

### DIFF
--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -221,7 +221,7 @@ eohtml
         title = doc.at('/html/head/title')
         assert_not_nil title
         assert_equal 'new', title.text
-        assert_equal -1, doc.at('meta[@http-equiv]') <=> title
+        assert_equal(-1, doc.at('meta[@http-equiv]') <=> title)
 
         doc = Nokogiri::HTML(<<eohtml)
 <html>
@@ -236,7 +236,7 @@ eohtml
         title = doc.at('/html//title')
         assert_not_nil title
         assert_equal 'new', title.text
-        assert_equal -1, title <=> doc.at('body')
+        assert_equal(-1, title <=> doc.at('body'))
 
         doc = Nokogiri::HTML(<<eohtml)
 <html>
@@ -248,14 +248,14 @@ eohtml
 eohtml
         doc.title = 'new'
         assert_equal 'new', doc.title
-        assert_equal -1, doc.at('meta[@charset]') <=> doc.at('title')
-        assert_equal -1, doc.at('title') <=> doc.at('body')
+        assert_equal(-1, doc.at('meta[@charset]') <=> doc.at('title'))
+        assert_equal(-1, doc.at('title') <=> doc.at('body'))
 
         doc = Nokogiri::HTML('<!DOCTYPE html><p>hello')
         doc.title = 'new'
         assert_equal 'new', doc.title
         assert_instance_of Nokogiri::XML::DTD, doc.children.first
-        assert_equal -1, doc.at('title') <=> doc.at('p')
+        assert_equal(-1, doc.at('title') <=> doc.at('p'))
 
         doc = Nokogiri::HTML('')
         doc.title = 'new'

--- a/test/xml/test_builder.rb
+++ b/test/xml/test_builder.rb
@@ -14,7 +14,7 @@ module Nokogiri
       end
 
       def test_builder_multiple_nodes
-        builder = Nokogiri::XML::Builder.new do |xml|
+        Nokogiri::XML::Builder.new do |xml|
           0.upto(10) do
             xml.text "test"
           end

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -54,7 +54,7 @@ module Nokogiri
         root << txt
         root << ent
         d << root
-        assert_match /&#8217;/, d.to_html
+        assert_match(/&#8217;/, d.to_html)
       end
 
       def test_document_with_initial_space

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -376,14 +376,6 @@ module Nokogiri
         end
       end
 
-      def test_prepend_child_fragment_with_multiple_nodes
-        doc = Nokogiri::XML::Document.new
-        fragment = doc.fragment('<hello /><goodbye />')
-        assert_raises(RuntimeError) do
-          doc.prepend_child fragment
-        end
-      end
-
       def test_prepend_child_with_multiple_roots
         assert_raises(RuntimeError) do
           @xml.prepend_child Node.new('foo', @xml)

--- a/test/xml/test_entity_reference.rb
+++ b/test/xml/test_entity_reference.rb
@@ -26,7 +26,7 @@ EOF
         doc = Nokogiri::XML xml
         lf_node = Nokogiri::XML::EntityReference.new(doc, "#xa")
         doc.xpath('/item').first.add_child(lf_node)
-        assert_match /&#xa;/, doc.to_xml
+        assert_match(/&#xa;/, doc.to_xml)
       end
     end
 

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -858,7 +858,7 @@ b"></div>
         ne = d1.root.xpath('//a').first.dup(1)
         ne.content += "& < & > \" &"
         d2.root << ne
-        assert_match /<a>&amp;&amp; &lt; &amp; &gt; \" &amp;<\/a>/, d2.to_s
+        assert_match(/<a>&amp;&amp; &lt; &amp; &gt; \" &amp;<\/a>/, d2.to_s)
       end
 
       def test_content_after_appending_text


### PR DESCRIPTION
This resolves all the ruby errors that spit out when running the test suite. Minor, but annoying.

```
/Users/kylev/Work/nokogiri/test/html/test_document.rb:224: warning: ambiguous first argument; put parentheses or even spaces
/Users/kylev/Work/nokogiri/test/html/test_document.rb:239: warning: ambiguous first argument; put parentheses or even spaces
/Users/kylev/Work/nokogiri/test/html/test_document.rb:251: warning: ambiguous first argument; put parentheses or even spaces
/Users/kylev/Work/nokogiri/test/html/test_document.rb:252: warning: ambiguous first argument; put parentheses or even spaces
/Users/kylev/Work/nokogiri/test/html/test_document.rb:258: warning: ambiguous first argument; put parentheses or even spaces
/Users/kylev/Work/nokogiri/test/xml/test_builder.rb:17: warning: assigned but unused variable - builder
/Users/kylev/Work/nokogiri/test/xml/test_document.rb:57: warning: ambiguous first argument; put parentheses or even spaces
/Users/kylev/Work/nokogiri/test/xml/test_document.rb:379: warning: method redefined; discarding old test_prepend_child_fragment_with_multiple_nodes
/Users/kylev/Work/nokogiri/test/xml/test_document.rb:371: warning: previous definition of test_prepend_child_fragment_with_multiple_nodes was here
/Users/kylev/Work/nokogiri/test/xml/test_entity_reference.rb:29: warning: ambiguous first argument; put parentheses or even spaces
/Users/kylev/Work/nokogiri/test/xml/test_node.rb:861: warning: ambiguous first argument; put parentheses or even spaces
```

This feeble penance is offered in hope for assistance on #1138, which I haven't yet managed to debug and fix. :smiling_imp: 