### PR TITLE
Fix support for element_children in document fragments.

### DIFF
--- a/ports/patches/libxml2/0012-Frag-element-children.patch
+++ b/ports/patches/libxml2/0012-Frag-element-children.patch
@@ -1,0 +1,26 @@
+--- a/tree.c.orig	2012-05-14 19:39:20.000000000 -0700
++++ b/tree.c	2014-07-29 13:01:58.000000000 -0700
+@@ -3438,6 +3438,7 @@
+         case XML_ELEMENT_NODE:
+         case XML_ENTITY_NODE:
+         case XML_DOCUMENT_NODE:
++        case XML_DOCUMENT_FRAG_NODE:
+         case XML_HTML_DOCUMENT_NODE:
+             cur = parent->children;
+             break;
+@@ -3473,6 +3474,7 @@
+         case XML_ELEMENT_NODE:
+         case XML_ENTITY_NODE:
+         case XML_DOCUMENT_NODE:
++        case XML_DOCUMENT_FRAG_NODE:
+         case XML_HTML_DOCUMENT_NODE:
+             cur = parent->children;
+             break;
+@@ -3508,6 +3510,7 @@
+         case XML_ELEMENT_NODE:
+         case XML_ENTITY_NODE:
+         case XML_DOCUMENT_NODE:
++        case XML_DOCUMENT_FRAG_NODE:
+         case XML_HTML_DOCUMENT_NODE:
+             cur = parent->last;
+             break;

--- a/test/html/test_document_fragment.rb
+++ b/test/html/test_document_fragment.rb
@@ -230,6 +230,11 @@ module Nokogiri
           fragment.to_s)
       end
 
+      def test_element_children_counts
+        doc = Nokogiri::HTML::DocumentFragment.parse("   <div>  </div>\n   ")
+        assert doc.element_children.count == 1
+      end
+
       def test_malformed_fragment_is_corrected
         fragment = HTML::DocumentFragment.parse("<div </div>")
         assert_equal "<div></div>", fragment.to_s


### PR DESCRIPTION
libxml2 doesn't support finding children in document fragments, but I don't think there's a good reason for this. Bug and proposed patch for libxml2 here:

https://bugzilla.gnome.org/show_bug.cgi?id=733900

This addresses Nokogiri #1138.

Unfortunately, I haven't been able to get comment on the patch from upstream libxml2 on either the bug or [a message](https://mail.gnome.org/archives/xml/2014-July/msg00003.html) about it.
