### PR TITLE
if node doesnt have parent unlink in jruby should return self.

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1354,7 +1354,10 @@ public class XmlNode extends RubyObject {
     @JRubyMethod(name = {"unlink", "remove"})
     public IRubyObject unlink(ThreadContext context) {
         if(node.getParentNode() == null) {
-            throw context.getRuntime().newRuntimeError("TYPE: " + node.getNodeType()+ " PARENT NULL");
+            //throw context.getRuntime().newRuntimeError("TYPE: " + node.getNodeType()+ " PARENT NULL");
+            return this;
+            // if node doesn't have parent node - simply return self, as would Nokogiri for C would do
+            // because that means that node is already detached
         } else {
             clearXpathContext(node.getParentNode());
             node.getParentNode().removeChild(node);

--- a/test/html/test_document_fragment.rb
+++ b/test/html/test_document_fragment.rb
@@ -23,6 +23,10 @@ module Nokogiri
           assert_equal "こんにちは！", f.content
         end
       end
+      
+      def test_unlink_empty_document
+        Nokogiri::HTML::DocumentFragment.parse('').unlink
+      end
 
       def test_colons_are_not_removed
         doc = Nokogiri::HTML::DocumentFragment.parse("<span>3:30pm</span>")


### PR DESCRIPTION
If node doesn't have parent node - simply return self, as would Nokogiri for C would do, because that means that node is already detached (test case included).

This commit fixes issue #1112.