### PR TITLE
Disable unknown warning option

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -74,7 +74,7 @@ end
 def add_cflags(flags)
   print "checking if the C compiler accepts #{flags}... "
   with_cflags("#{$CFLAGS} #{flags}") do
-    if try_compile("int main() {return 0;}")
+    if try_compile("int main() {return 0;}", werror: true)
       puts 'yes'
       true
     else


### PR DESCRIPTION
`-Wno-error=unused-command-line-argument-hard-error-in-future` is not supported by old clang.
