### PR TITLE
Escape full path when patching

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -294,7 +294,7 @@ def monkey_patch_mini_portile
       @patch_files.each do |full_path|
         next unless File.exists?(full_path)
         output "Running patch with #{full_path}..."
-        execute('patch', %Q(patch -p1 < #{full_path}))
+        execute('patch', %Q(patch -p1 < "#{full_path}"))
       end
     end
   end


### PR DESCRIPTION
This ensures that patching is successful even if the ROOT path contains spaces.
This is the same approach that mini_portile takes. https://github.com/luislavena/mini_portile/blob/v0.6.1/lib/mini_portile.rb#L256