### PR TITLE
CLI mode: use Pry rather than IRB if it's available

### DIFF
--- a/bin/nokogiri
+++ b/bin/nokogiri
@@ -2,6 +2,7 @@
 require 'optparse'
 require 'open-uri'
 require 'irb'
+require 'pry' rescue LoadError
 require 'uri'
 require 'rubygems'
 require 'nokogiri'
@@ -72,7 +73,11 @@ else
     eval @script, binding, '<main>'
   else
     puts "Your document is stored in @doc..."
-    IRB.start
+    if defined? Pry
+      Pry.start
+    else
+      IRB.start
+    end
   end
 end
 


### PR DESCRIPTION
Pry offers a couple of features, namely the pretty-printing of collections and syntax highlighting of returned values, that make working with Nokogiri documents in the REPL more user-friendly.

This pull request doesn't add Pry as a dependency of Nokogiri or change the default behaviour (I figured that was too far), but instead simply uses Pry over IRB if Pry is available and otherwise falls back to the previous IRB behaviour.

I use the CLI interface to Nokogiri quite a lot, so this improves things for me considerably; I assume there are others in the same boat.