### PR TITLE
Use have_header() to check for the existence of iconv.h

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -436,10 +436,10 @@ else
       ]
     end
   else
-    if darwin_p && !File.exist?('/usr/include/iconv.h')
+    if darwin_p && !have_header('iconv.h')
       abort <<'EOM'.chomp
 -----
-The file "/usr/include/iconv.h" is missing in your build environment,
+The file "iconv.h" is missing in your build environment,
 which means you haven't installed Xcode Command Line Tools properly.
 
 To install Command Line Tools, try running `xcode-select --install` on


### PR DESCRIPTION
Simply checking */usr/include* is no longer working on the latest versions of Xcode and OS X, because there is no */usr/include* anymore. On OS X 10.10 with Xcode 6, the header resides in */Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/include/iconv.h*

In addition to that, the simple check also ignores things like `--with-iconv-dir`, of course.