### PR TITLE
Do not use strdup() in Node::get() anymore.

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -826,7 +826,11 @@ static VALUE get(VALUE self, VALUE rattribute)
   if (NIL_P(rattribute)) return Qnil;
 
   Data_Get_Struct(self, xmlNode, node);
-  attribute = strdup(StringValuePtr(rattribute));
+
+  rattribute = StringValue(rattribute);
+  attribute = malloc(RSTRING_LEN(rattribute) + 1);
+  strncpy(attribute, RSTRING_PTR(rattribute), RSTRING_LEN(rattribute));
+  attribute[RSTRING_LEN(rattribute)] = '\0';
 
   colon = strchr(attribute, ':');
   if (colon) {


### PR DESCRIPTION
Hi,

this replaces `strdup()` in `xml_node.c::get()` as it was causing a segmentation fault for certain input for us on a rather ancient CentOS 6 system.

Unfortunately can't provide a test case for it, as it does not crash with a more recent GCC/glibc. However, MWE can be found [here](https://github.com/FlavourSys/nokogiri-strdup-segfault-mwe).

Malte