### PR TITLE
overwrite dup() method to fill clone with content

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -904,6 +904,10 @@ public class XmlNode extends RubyObject {
         return doc;
     }
 
+    public IRubyObject dup() {
+        return this.dup_implementation(getMetaClass().getClassRuntime(), true);
+    }
+
     @JRubyMethod
     public IRubyObject dup(ThreadContext context) {
         return this.dup_implementation(context, true);
@@ -917,13 +921,17 @@ public class XmlNode extends RubyObject {
     }
 
     protected IRubyObject dup_implementation(ThreadContext context, boolean deep) {
+       return dup_implementation(context.getRuntime(), deep);
+    }
+
+    protected IRubyObject dup_implementation(Ruby runtime, boolean deep) {
         XmlNode clone;
         try {
             clone = (XmlNode) clone();
         } catch (CloneNotSupportedException e) {
-            throw context.getRuntime().newRuntimeError(e.toString());
+            throw runtime.newRuntimeError(e.toString());
         }
-        if (node == null) throw context.getRuntime().newRuntimeError("FFFFFFFFFUUUUUUU");
+        if (node == null) throw runtime.newRuntimeError("FFFFFFFFFUUUUUUU");
         Node newNode = node.cloneNode(deep);
         clone.node = newNode;
         return clone;

--- a/test/files/GH_1042.html
+++ b/test/files/GH_1042.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head></head>
+<body>
+  <table align="center" border>
+    <tr><th>foo1.0</th><th>bar</th><th>bazz</th></tr>
+    <tr><td>foo1.1</td><td>bar</td><td>bazz</td></tr>
+  </table>
+  <table align="center" border>
+    <tr><th>foo2.0</th><th>bar</th><th>bazz</th></tr>
+    <tr><td>foo2.1</td><td>bar</td><td>bazz</td></tr>
+  </table>
+  <table align="center" border>
+    <tr><th>foo3.0</th><th>bar</th><th>bazz</th></tr>
+    <tr><td>foo3.1</td><td>bar</td><td>bazz</td></tr>
+  </table>
+</body>
+</html>

--- a/test/html/test_node.rb
+++ b/test/html/test_node.rb
@@ -192,5 +192,21 @@ module Nokogiri
         end
       end
     end
+
+    def test_GH_1042
+      file = File.join(ASSETS_DIR, 'GH_1042.html');
+      html = Nokogiri::HTML(File.read(file))
+      table = html.xpath("//table")[1]
+      trs = table.xpath("tr").drop(1)
+
+      # the jruby inplementation of drop uses dup() on the IRubyObject (which
+      # is NOT the same dup() method on the ruby Object) which produces a
+      # shallow clone. a shallow of valid XMLNode triggers several
+      # NullPointerException on inspect() since loads of invariants
+      # are not set. the fix for GH1042 ensures a proper working clone.
+      assert_nothing_raised do
+        trs.inspect
+      end
+    end
   end
 end


### PR DESCRIPTION
fixes #1042 the drop failed because the clone XmlElement was shallow
and calling certain methods resulted in NPE

Sponsored by Lookout Inc.