### PR TITLE
fix XML::Reader working with non-existent attributes

### DIFF
--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -219,19 +219,6 @@ static VALUE reader_attribute(VALUE self, VALUE name)
   name = StringValue(name) ;
 
   value = xmlTextReaderGetAttribute(reader, (xmlChar*)StringValuePtr(name));
-  if(value == NULL) {
-    /* this section is an attempt to workaround older versions of libxml that
-       don't handle namespaces properly in all attribute-and-friends functions */
-    xmlChar *prefix = NULL ;
-    xmlChar *localname = xmlSplitQName2((xmlChar*)StringValuePtr(name), &prefix);
-    if (localname != NULL) {
-      value = xmlTextReaderLookupNamespace(reader, localname);
-      xmlFree(localname) ;
-    } else {
-      value = xmlTextReaderLookupNamespace(reader, prefix);
-    }
-    xmlFree(prefix);
-  }
   if(value == NULL) return Qnil;
 
   rb_value = NOKOGIRI_STR_NEW2(value);

--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -1,0 +1,15 @@
+require "helper"
+
+module Nokogiri
+  module XML
+    class TestReader < Nokogiri::TestCase
+      def test_nonexistent_attribute
+        require 'nokogiri'
+        reader = Nokogiri::XML::Reader("<root xmlns='bob'><el attr='fred' /></root>")
+        reader.read
+        reader.read
+        assert_equal reader.attribute('other'), nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
nokogiri now bundles a newer libxml, so doesn't have to
worry about old bad behavior, and the workaround was broken

without this fix, the test case would return 
`reader.attribute('other') # => bob`
apparently picking up the default namespace for any missing attributes