### PR TITLE
reset the namespace cache when replacing the document's innerHtml

### DIFF
--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -639,4 +639,9 @@ public class XmlDocument extends XmlNode {
         }
         return this;
     }
+
+    public void resetNamespaceCache(ThreadContext context) {
+        nsCache = new NokogiriNamespaceCache();
+        createAndCacheNamespaces(context.getRuntime(), node);
+    }
 }

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1540,6 +1540,10 @@ public class XmlNode extends RubyObject {
             coalesceTextNodes(context, other, scheme);
         }
 
+        if (this instanceof XmlDocument) {
+            ((XmlDocument) this).resetNamespaceCache(context);
+        }
+
         relink_namespace(context);
         // post_add_child(context, this, other);
 

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -425,6 +425,21 @@ END
         assert_equal 1, xml_doc.xpath('//mods:titleInfo',ns_hash).length
         assert_equal 'finnish', xml_doc.xpath('//mods:titleInfo[1]/@lang',ns_hash).first.value
       end
+
+      def test_xpath_after_reset_doc_via_innerhtml
+        xml = <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">
+  <text:section name="Section1">[TEXT_INSIDE_SECTION]</text:section>
+</document>
+XML
+
+        doc = Nokogiri::XML(xml)
+        doc.inner_html = doc.inner_html
+        sections = doc.xpath(".//text:section[@name='Section1']")
+        assert_equal 1, sections.size
+        assert_equal "[TEXT_INSIDE_SECTION]", sections.first.text
+      end
     end
   end
 end


### PR DESCRIPTION
the reset is needed to associated the namespace info with the nodes

fixes #1180

Sponsored by Lookout Inc.