### PR TITLE
Change to make sure that Nokogiri works with gem-compiler to generate binary gem

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -60,12 +60,6 @@ def do_clean
       FileUtils.rmdir(dir.parent, parents: true, verbose: true)
     }
 
-    if enable_config('static')
-      # ports installation can be safely removed if statically linked.
-      FileUtils.rm_rf(root + 'ports', verbose: true)
-    else
-      FileUtils.rm_rf(root + 'ports' + 'archives', verbose: true)
-    end
   end
 
   exit! 0


### PR DESCRIPTION
This change might require more review..

Basically we need to create binary gems. We use gem-compiler for that. In order to make gem-compiler work with nokogiri,  we need to make sure all original files exists out there so that it can be repackaged without any errors.



