### PR TITLE
Add iframe attritube 'autoplay'

### DIFF
--- a/lib/nokogiri/html/element_description_defaults.rb
+++ b/lib/nokogiri/html/element_description_defaults.rb
@@ -216,9 +216,9 @@ module Nokogiri
       HR_DEPR = ['align', 'noshade', 'size', 'width']
       VERSION_ATTR = ['version']
       HTML_CONTENT = ['head', 'body', 'frameset']
-      IFRAME_ATTRS = [COREATTRS, 'longdesc', 'name', 'src', 'frameborder',
-                      'marginwidth', 'marginheight', 'scrolling', 'align',
-                      'height', 'width']
+      IFRAME_ATTRS = [COREATTRS, 'autoplay', 'longdesc', 'name', 'src',
+                      'frameborder', 'marginwidth', 'marginheight', 
+                      'scrolling', 'align', 'height', 'width']
       IMG_ATTRS = [ATTRS, 'longdesc', 'name', 'height', 'width', 'usemap',
                    'ismap']
       EMBED_ATTRS = [COREATTRS, 'align', 'alt', 'border', 'code', 'codebase',


### PR DESCRIPTION
Add iframe attritube 'autoplay'. (Also reindent the successive lines).

The goal is to have Nokogiri HTML output for an iframe use a binary attribute for autoplay, such as:

    <iframe src="..." autoplay>

