### PR TITLE
Fix cli tool example links

### DIFF
--- a/bin/nokogiri
+++ b/bin/nokogiri
@@ -41,9 +41,9 @@ opts = OptionParser.new do |opts|
   opts.define_head "Usage: nokogiri <uri|path> [options]"
   opts.separator ""
   opts.separator "Examples:"
-  opts.separator "  nokogiri http://www.ruby-lang.org/"
+  opts.separator "  nokogiri https://www.ruby-lang.org/"
   opts.separator "  nokogiri ./public/index.html"
-  opts.separator "  curl -s http://nokogiri.org | nokogiri -e'p $_.css(\"h1\").length'"
+  opts.separator "  curl -s http://www.nokogiri.org | nokogiri -e'p $_.css(\"h1\").length'"
   opts.separator ""
   opts.separator "Options:"
 


### PR DESCRIPTION
Running an example command `nokogiri http://www.ruby-lang.org/` results with the following error

    'open_loop': redirection forbidden: http://www.ruby-lang.org/ -> https://www.ruby-lang.org/ (RuntimeError)

As for the other example `curl -s http://nokogiri.org` returns

    <html>
    <head><title>301 Moved Permanently</title></head>
    <body bgcolor="white">
    <center><h1>301 Moved Permanently</h1></center>
    <hr><center>nginx</center>
    </body>
    </html>

which (I think) has `h1` tag only by accident.