### PR TITLE
unescape css identifiers to allow use in css queries

### DIFF
--- a/lib/nokogiri/css/parser.rb
+++ b/lib/nokogiri/css/parser.rb
@@ -8,9 +8,15 @@ require 'racc/parser.rb'
 
 
 require 'nokogiri/css/parser_extras'
+
 module Nokogiri
   module CSS
     class Parser < Racc::Parser
+
+
+def unescape_css_identifier(identifier)
+  identifier.gsub(/\\(?:([^0-9a-fA-F])|([0-9a-fA-F]{1,6})\s?)/){ |m| $1 || [$2.hex].pack('U') }
+end
 ##### State transition tables begin ###
 
 racc_action_table = [
@@ -406,7 +412,7 @@ end
 # reduce 17 omitted
 
 def _reduce_18(val, _values, result)
- result = Node.new(:CLASS_CONDITION, [val[1]]) 
+ result = Node.new(:CLASS_CONDITION, [unescape_css_identifier(val[1])]) 
     result
 end
 
@@ -650,7 +656,7 @@ end
 # reduce 57 omitted
 
 def _reduce_58(val, _values, result)
- result = Node.new(:ID, val) 
+ result = Node.new(:ID, [unescape_css_identifier(val.first)]) 
     result
 end
 

--- a/lib/nokogiri/css/parser.y
+++ b/lib/nokogiri/css/parser.y
@@ -55,7 +55,7 @@ rule
     | simple_selector
     ;
   class
-    : '.' IDENT { result = Node.new(:CLASS_CONDITION, [val[1]]) }
+    : '.' IDENT { result = Node.new(:CLASS_CONDITION, [unescape_css_identifier(val[1])]) }
     ;
   element_name
     : namespaced_ident
@@ -218,7 +218,7 @@ rule
     | negation
     ;
   attribute_id
-    : HASH { result = Node.new(:ID, val) }
+    : HASH { result = Node.new(:ID, [unescape_css_identifier(val.first)]) }
     ;
   attrib_val_0or1
     : eql_incl_dash IDENT { result = [val.first, val[1]] }
@@ -254,3 +254,8 @@ end
 
 require 'nokogiri/css/parser_extras'
 
+---- inner
+
+def unescape_css_identifier(identifier)
+  identifier.gsub(/\\(?:([^0-9a-fA-F])|([0-9a-fA-F]{1,6})\s?)/){ |m| $1 || [$2.hex].pack('U') }
+end

--- a/test/css/test_parser.rb
+++ b/test/css/test_parser.rb
@@ -160,7 +160,7 @@ module Nokogiri
         assert_xpath '//a[position() = 1]',             @parser.parse('a:first-of-type') # no parens
         assert_xpath "//a[contains(concat(' ', normalize-space(@class), ' '), ' b ')][position() = 1]",
                      @parser.parse('a.b:first-of-type') # no parens
-        assert_xpath '//a[position() = 99]',            @parser.parse('a:nth-of-type(99)') 
+        assert_xpath '//a[position() = 99]',            @parser.parse('a:nth-of-type(99)')
         assert_xpath "//a[contains(concat(' ', normalize-space(@class), ' '), ' b ')][position() = 99]",
                      @parser.parse('a.b:nth-of-type(99)')
         assert_xpath '//a[position() = last()]',        @parser.parse('a:last-of-type()')
@@ -259,6 +259,10 @@ module Nokogiri
 
       def test_id
         assert_xpath "//*[@id = 'foo']", @parser.parse('#foo')
+        assert_xpath "//*[@id = 'escape:needed,']", @parser.parse('#escape\:needed\,')
+        assert_xpath "//*[@id = 'escape:needed,']", @parser.parse('#escape\3Aneeded\,')
+        assert_xpath "//*[@id = 'escape:needed,']", @parser.parse('#escape\3A needed\2C')
+        assert_xpath "//*[@id = 'escape:needed']", @parser.parse('#escape\00003Aneeded')
       end
 
       def test_pseudo_class_no_ident
@@ -294,6 +298,8 @@ module Nokogiri
                       @parser.parse('foo.awesome')
         assert_xpath  "//foo//*[contains(concat(' ', normalize-space(@class), ' '), ' awesome ')]",
                       @parser.parse('foo .awesome')
+        assert_xpath  "//foo//*[contains(concat(' ', normalize-space(@class), ' '), ' awe.some ')]",
+                      @parser.parse('foo .awe\.some')
       end
 
       def test_bare_not

--- a/test/files/tlm.html
+++ b/test/files/tlm.html
@@ -46,7 +46,7 @@
 .codesnip-container  {border:1px solid #ccc; background:#eee; padding: 5px;margin:10px;}
 </style>
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://tenderlovemaking.com/xmlrpc.php?rsd" />
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://tenderlovemaking.com/wp-includes/wlwmanifest.xml" /> 
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://tenderlovemaking.com/wp-includes/wlwmanifest.xml" />
 <meta name="generator" content="WordPress 2.6" />
 
 	<link rel="stylesheet" type="text/css" href="http://tenderlovemaking.com/wp-content/plugins/spell_checker/spell_checker.css" />
@@ -826,6 +826,7 @@ page.<span class="me1">body</span> =~ /&lt;textarea<span class="br0">&#91;</span
 </ul>
 </div>
 
+<div id="abc.123" class='special.character'>Special character div</div>
 <div id="footer">
 A design by <a href="http://blog.geminigeek.com/wordpress-theme">GeminiGeek</a> &bull; Powered by <a href="http://wordpress.org">Wordpress</a><!--&bull; <a href="#">CSS</a> &bull; <a href="#">xHTML 1.0</a>-->
 </div>

--- a/test/html/sax/test_parser.rb
+++ b/test/html/sax/test_parser.rb
@@ -29,9 +29,9 @@ module Nokogiri
           # Take a look at the comment in test_parse_document to know
           # a possible reason to this difference.
           if Nokogiri.uses_libxml?
-            assert_equal 1110, @parser.document.end_elements.length
+            assert_equal 1111, @parser.document.end_elements.length
           else
-            assert_equal 1119, @parser.document.end_elements.length
+            assert_equal 1120, @parser.document.end_elements.length
           end
         end
 

--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -474,6 +474,15 @@ eohtml
         assert_equal 1, found.length
       end
 
+      def test_find_by_css_with_escaped_characters
+        found_without_escape = @html.css("div[@id='abc.123']")
+        found_by_id = @html.css('#abc\.123')
+        found_by_class = @html.css('.special\.character')
+        assert_equal 1, found_without_escape.length
+        assert_equal found_by_id, found_without_escape
+        assert_equal found_by_class, found_without_escape
+      end
+
       def test_find_with_function
         assert @html.css("div:awesome() h1", Class.new {
           def awesome divs


### PR DESCRIPTION
Allow for querying css that uses "special" characters in id and class names such as
<div id="a.b"></div>
querying with 
document.css('#a\\.b')
will work correctly with this PR - failed previously