### PR TITLE
Fix windows native build with RubyInstaller and DevKit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 
 source "https://rubygems.org/"
 
-gem "mini_portile", "~>0.6.0"
+gem "mini_portile", "~>0.7.0", git: 'https://github.com/larskanis/mini_portile.git', branch: 'literally-configure-options'
 
 gem "rdoc", "~>4.0", :group => [:development, :test]
 gem "hoe-bundler", ">=1.1", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -132,7 +132,7 @@ HOE = Hoe.spec 'nokogiri' do
       # for more details, see:
       # - https://github.com/sparklemotion/nokogiri/issues/1102
       # - https://github.com/luislavena/mini_portile/issues/32
-      ["mini_portile",    "~> 0.6.0"],
+      ["mini_portile",    "~> 0.7.0"],
     ]
   end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - SET PATH=C:\MinGW\bin;%PATH%
+  - SET RAKEOPT=-rdevkit
   - ruby --version
   - gem --version
   - bundle install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+install:
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - SET PATH=C:\MinGW\bin;%PATH%
+  - ruby --version
+  - gem --version
+  - bundle install
+
+build: off
+
+test_script:
+  - bundle exec rake
+
+environment:
+  matrix:
+    - ruby_version: "193"
+    - ruby_version: "200"
+    - ruby_version: "200-x64"
+    - ruby_version: "21"
+    - ruby_version: "21-x64"
+    - ruby_version: "22"
+    - ruby_version: "22-x64"


### PR DESCRIPTION
This depends on https://github.com/flavorjones/mini_portile/pull/51 in regards to the handling of configure_options. I therefore assigned a git link in the Gemfile, temporary.

Rubys stdlib shellwords is generelly an issue on Windows. It's sadly, but Windows uses several different ways to escape command line options. While shellwords mostly works in Msys bash (and therefore in a Makefile), it is completely wrong in cmd.exe or msvcrt based programs. It's annoying, but escape rules in mkmf.rb functions (like try_compile etc) are different to that of $CPPFLAGS etc. which run in a Makefile. I made an attempt to codify the different escape rules in, but don't think this is necessary for nokogiri:
   https://github.com/larskanis/shellwords/tree/master/lib/shellwords

As a compromise I used String#inspect for the lists of patches. This works well enough on all platforms.

This fixes https://github.com/sparklemotion/nokogiri/issues/1190 and already includes  https://github.com/sparklemotion/nokogiri/pull/1308 , to make sure, that the native build is actively checked.
