### PR TITLE
Style tag should not html encode entities in JRuby

### DIFF
--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -741,6 +741,10 @@ public class SaveContextVisitor {
       return htmlDoc && text.getParentNode().getNodeName().equals("script");
     }
 
+    private boolean isHtmlStyle(Text text) {
+      return htmlDoc && text.getParentNode().getNodeName().equals("style");
+    }
+
     private static char lineSeparator = '\n'; // System.getProperty("line.separator"); ?
     public boolean enter(Text text) {
         String textContent = text.getNodeValue();
@@ -752,7 +756,7 @@ public class SaveContextVisitor {
             }
         }
 
-        if (NokogiriHelpers.shouldEncode(text) && !isHtmlScript(text)) {
+        if (NokogiriHelpers.shouldEncode(text) && !isHtmlScript(text) && !isHtmlStyle(text)) {
             textContent = encodeJavaString(textContent);
         }
 

--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -655,6 +655,32 @@ eohtml
         Nokogiri::XML::Element.new("div", doc).set_attribute('id', 'unique-issue-1262')
         assert_equal 0, doc.errors.length
       end
+
+      def test_script_html_encoding
+        html = Nokogiri::HTML <<-EOHTML
+        <html>
+          <head>
+            <script>var isGreater = 4 > 5;</script>
+          </head>
+          <body></body>
+        </html>
+        EOHTML
+        node = html.xpath("//script").first
+        assert_equal("var isGreater = 4 > 5;", node.inner_html)
+      end
+
+      def test_style_html_encoding
+        html = Nokogiri::HTML <<-EOHTML
+        <html>
+          <head>
+            <style>tr > div { display:block; }</style>
+          </head>
+          <body></body>
+        </html>
+        EOHTML
+        node = html.xpath("//style").first
+        assert_equal("tr > div { display:block; }", node.inner_html)
+      end
     end
   end
 end


### PR DESCRIPTION
This is a fix for: https://github.com/sparklemotion/nokogiri/issues/1315

If you run the following code in JRuby it will result in the > in the style element being HTML entity encoded &gt;, this does not occur with MRI.

```
html = '<!DOCTYPE html><html><head><style>tr > div { display:block; }</style></head><body><h1>Mr. Belvedere Fan > Club</h1></body></html>'
html_doc = Nokogiri::HTML(html)
puts html_doc.to_html
```

```
<!DOCTYPE html >
<html><head><style>tr &gt; div { display:block; }</style></head><body><h1>Mr. Belvedere Fan &gt; Club</h1></body></html>
```

With this fix the style matches MRI
```
<!DOCTYPE html >
<html><head><style>tr > div { display:block; }</style></head><body><h1>Mr. Belvedere Fan &gt; Club</h1></body></html>
```