### PR TITLE
fix appending text nodes before existing text nodes (jruby)

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1635,10 +1635,6 @@ public class XmlNode extends RubyObject {
 
         Node nextSib = thisNode.getNextSibling();
 
-        if (nextSib != null &&
-            nextSib.getNodeType() == Node.TEXT_NODE &&
-            otherNode.getNodeType() == Node.TEXT_NODE) return;
-
         if (nextSib != null) {
             parent.insertBefore(otherNode, nextSib);
         } else {

--- a/test/xml/test_node_reparenting.rb
+++ b/test/xml/test_node_reparenting.rb
@@ -280,6 +280,20 @@ module Nokogiri
             assert_equal "text nodefoo <p></p> bar", xml.root.children.to_html
           end
 
+          it 'should append a text node before an existing non text node' do
+            xml = Nokogiri::XML %Q(<root><p>foo</p><p>bar</p></root>)
+            p = xml.at_css 'p'
+            p.add_next_sibling 'a'
+            assert_equal '<root><p>foo</p>a<p>bar</p></root>', xml.root.to_s
+          end
+
+          it 'should append a text node before an existing text node' do
+            xml = Nokogiri::XML %Q(<root><p>foo</p>after</root>)
+            p = xml.at_css 'p'
+            p.add_next_sibling 'x'
+            assert_equal '<root><p>foo</p>xafter</root>', xml.root.to_s
+          end
+
           describe "with a text node after" do
             it "should not defensively dup the 'after' text node" do
               xml = Nokogiri::XML %Q(<root>before<p></p>after</root>)


### PR DESCRIPTION
While trying to fix at least some of Loofah's current test failures with JRuby I stumbled upon this.

I honestly do not understand what those 4 lines I removed from XmlNode are supposed to do - to me they look quite wrong since as a result the node to be inserted is simply discarded. Removing them fixed my test and caused no others to fail.

jruby 1.7.21 (1.9.3p551) 2015-07-07 a741a82 on OpenJDK 64-Bit Server VM 1.7.0_79-b14
