### PR TITLE
add test case checking decoration of empty NodeSet, which fails on JRuby

### DIFF
--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -219,6 +219,16 @@ module Nokogiri
         assert fragment.children.respond_to?(:awesome!), fragment.children.class
       end
 
+      def test_decorator_is_applied_to_empty_set
+        x = Module.new do
+          def awesome!
+          end
+        end
+        util_decorate(@xml, x)
+        fragment = Nokogiri::XML::DocumentFragment.new(@xml, "")
+        assert fragment.children.respond_to?(:awesome!), fragment.children.class
+      end
+
       def test_add_node_to_doc_fragment_segfault
         frag = Nokogiri::XML::DocumentFragment.new(@xml, '<p>hello world</p>')
         Nokogiri::XML::Comment.new(frag,'moo')


### PR DESCRIPTION
It seems that empty NodeSets do not have any decorators applied to them on JRuby, while they indeed get decorated on Ruby. The problem seems to be that `initialize` in XmlNodeSet.java expects the first element of the node set as an argument, where it retrieves the document from which is then used for decoration. empty set -> no first element -> no decoration takes place. I have a test case illustrating the problem, but unfortunately no idea for a solution.

Loofah (and therefore also rails-html-sanitizer) has several test cases failing on JRuby because of this.
