### PR TITLE
failing test (on jruby): css search problem involving whitespace and …

### DIFF
--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -136,6 +136,24 @@ module Nokogiri
         assert_equal expected, search_xpath
       end
 
+      def test_fragment_css_search_with_whitespace_and_node_removal
+        # The same xml without leading whitespace in front of the first line
+        # does not expose the error. Putting both nodes on the same line
+        # instead also fixes the crash.
+        fragment = Nokogiri::XML::DocumentFragment.parse <<-EOXML
+          <p id="content">hi</p>
+<p>another paragraph</p>
+        EOXML
+        children = fragment.css('p')
+        assert_equal 2, children.length
+        # removing the last node instead does not yield the error. Probably the
+        # node removal leaves around two consecutive text nodes which make the
+        # css search crash?
+        children.first.remove
+        # using xpath('/p') instead works as expected
+        assert_equal 1, fragment.css('p').length
+      end
+
       def test_fragment_search_three_ways
         frag = Nokogiri::XML::Document.new.fragment '<p id="content">foo</p><p id="content">bar</p>'
         expected = frag.xpath('./*[@id = "content"]')


### PR DESCRIPTION
…node removal

The problem seems to occur only when due to removal of a node surrounded by whitespace two consecutive text nodes are left behind. In that case a css search for the remaining element ends up in a DTM exception:

```
Java::JavaLang::RuntimeException: Could not resolve the node to a handle
   org.apache.xml.dtm.ref.DTMManagerDefault.getDTMHandleFromNode(DTMManagerDefault.java:576)
    org.apache.xpath.XPathContext.getDTMHandleFromNode(XPathContext.java:184)       
    org.apache.xpath.XPath.execute(XPath.java:303) 
    nokogiri.XmlXpathContext.tryGetNodeSet(XmlXpathContext.java:198)
...
```

Since it might have been related I already tried replacing all uses of internal com.sun API with the official Xalan API, adding the 2.7.2 Xalan jars as per #1212, but it didn't help with this problem (and still caused the same errors mentioned there).
