### PR TITLE
listen to --with-iconv-dir=<path> on OS X

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -144,6 +144,8 @@ def iconv_libs
       if (config = preserving_globals{ dir_config(name) }).any?
         idirs, ldirs = config
         return ["-L#{ldirs}"]
+      else
+        return nil
       end
     }
   end

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -590,8 +590,13 @@ end
   'xmlRelaxNGSetValidStructuredErrors', 'xmlSchemaSetValidStructuredErrors',
   'xmlSchemaSetParserStructuredErrors'
 ].each { |func|
-  have_func(func, nil, iconv_libs) or
-    abort("#{func}() is missing")
+  if RUBY_VERSION <= '1.9.3'
+    have_func(func, nil) or
+      abort("#{func}() is missing")
+  else
+    have_func(func, nil, iconv_libs) or
+      abort("#{func}() is missing")
+  end
 }
 
 if ENV['CPUPROFILE']


### PR DESCRIPTION
## About

Among the issues touched by this are #972, #1119, #1231 and #1345 - not claiming they are fixed...

## Environment
Here's where I started debugging/installing and prepared this contribution from.

OS X:
```
% sw_vers
ProductName:       Mac OS X
ProductVersion: 10.10.5
BuildVersion:   14F27
```

Xcode:
```
% xcodebuild -version
Xcode 7.1
Build version 7B91b
% xcode-select -v
xcode-select version 2339.
```

Macports:
Spot that I started on the non-universal variants.
```
% port version
Version: 2.3.4
% port installed zlib lzma libiconv
The following ports are currently installed:
  libiconv @1.14_0
  libiconv @1.14_0+universal (active)
  lzma @4.65_0+universal (active)
  zlib @1.2.8_0
  zlib @1.2.8_0+universal (active)
```

## Install guide
@flavorjones you [asked](https://github.com/sparklemotion/nokogiri/issues/1119#issuecomment-68426814) for additions to OS X install guide.

`export ARCHFLAGS="-arch x86_64"` as diagnosed by @oliver-whiteman can help with:

```
Undefined symbols for architecture i386:
  "_crc32", referenced from:
      _xmlCreateZMemBuff in libxml2.a(xmlIO.o)
      _xmlZMemBuffAppend in libxml2.a(xmlIO.o)
<snip>
```
A better solution is to install the `universal` variants
```bash
sudo port install zlib +universal
sudo port install libiconv +universal
sudo port install lzma +universal
```
Sadly, this isn't the whole story as @oliver-whiteman found.
```
checking for main() in -llzma... yes
checking for xmlParseDoc() in libxml/parser.h... no
checking for xmlParseDoc() in -lxml2... no
checking for xmlParseDoc() in -llibxml2... no
-----
libxml2 is missing.  Please locate mkmf.log to investigate how it is failing.
```
As @rsanchezsaez mentioned this will affect **all** users of Macports with `zlib` and `libiconv` ports installed, where they are not the **universal** variants. The option of moving `/opt/local` sideways did not fill me with joy and `mkmf.log` shows this inability to find `iconv_open` and hence this PR.

### merge
So if this is merged the guide should reflect the requirement of:

```bash
sudo port install zlib +universal
sudo port install libiconv +universal
sudo port install lzma +universal
bundle config build.nokogiri --with-xml2-include=/opt/local/include/libxml2 --with-xml2-lib=/opt/local/lib --with-xslt-dir=/opt/local --with-iconv-dir=/opt/local
```

**or**

As has been pointed out, installation of `libxml2` and `libxslt` macports/brew and the use the `--use-system-libraries` or `NOKOGIRI_USE_SYSTEM_LIBRARIES=1`

Making note that the **universal** variants are installed.
```bash
sudo port install libxml2 +universal
sudo port install libxslt +universal
bundle config build.nokogiri --use-system-libraries --with-xml2-config=/opt/local/bin/xml2-config --with-xslt-config=/opt/local/bin/xslt-config
## <edit> as noted by @knu this is probably enough
bundle config build.nokogiri --use-system-libraries --with-opt-dir=/opt/local
## <edit> or even (given pkg-config installed and will find libxml-2.0.pc and libxslt.pc)
bundle config build.nokogiri --use-system-libraries
```