### PR TITLE
Switch to mini_portile2 for building dependent libraries.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 
 source "https://rubygems.org/"
 
-gem "mini_portile", "~>0.7.0.rc4"
+gem "mini_portile2", "~>2.0.0.rc1"
 
 gem "rdoc", "~>4.0", :group => [:development, :test]
 gem "hoe-bundler", ">=1.1", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -128,7 +128,8 @@ HOE = Hoe.spec 'nokogiri' do
 
   unless java?
     self.extra_deps += [
-      ["mini_portile",    "~> 0.7.0.rc4"],
+      # Keep this version in sync with the one in extconf.rb !
+      ["mini_portile2",    "~> 2.0.0.rc1"],
     ]
   end
 

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -391,7 +391,10 @@ when using_system_libraries?
 else
   message "Building nokogiri using packaged libraries.\n"
 
-  require 'mini_portile'
+  # The gem version constraint in the Rakefile is not respected at install time.
+  # Keep this version in sync with the one in the Rakefile !
+  gem "mini_portile2", "~> 2.0.0.rc1"
+  require 'mini_portile2'
   require 'yaml'
 
   static_p = enable_config('static', true) or


### PR DESCRIPTION
Gem `mini_portile` will be renamed to `mini_portile2` for the next release.
Among other changes, `mini_portile2` takes `configure_options` literally.
That was already addressed in commit 6195f2bde4 .