### PR TITLE
Ensure strings are zero terminated, where C-str pointers are expected.

### DIFF
--- a/ext/nokogiri/html_document.c
+++ b/ext/nokogiri/html_document.c
@@ -18,8 +18,8 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
   external_id = rb_ary_entry(rest, (long)1);
 
   doc = htmlNewDoc(
-      RTEST(uri) ? (const xmlChar *)StringValuePtr(uri) : NULL,
-      RTEST(external_id) ? (const xmlChar *)StringValuePtr(external_id) : NULL
+      RTEST(uri) ? (const xmlChar *)StringValueCStr(uri) : NULL,
+      RTEST(external_id) ? (const xmlChar *)StringValueCStr(external_id) : NULL
   );
   rb_doc = Nokogiri_wrap_xml_document(klass, doc);
   rb_obj_call_init(rb_doc, argc, argv);
@@ -39,8 +39,8 @@ static VALUE read_io( VALUE klass,
                       VALUE encoding,
                       VALUE options )
 {
-  const char * c_url    = NIL_P(url)      ? NULL : StringValuePtr(url);
-  const char * c_enc    = NIL_P(encoding) ? NULL : StringValuePtr(encoding);
+  const char * c_url    = NIL_P(url)      ? NULL : StringValueCStr(url);
+  const char * c_enc    = NIL_P(encoding) ? NULL : StringValueCStr(encoding);
   VALUE error_list      = rb_ary_new();
   VALUE document;
   htmlDocPtr doc;
@@ -103,8 +103,8 @@ static VALUE read_memory( VALUE klass,
                           VALUE options )
 {
   const char * c_buffer = StringValuePtr(string);
-  const char * c_url    = NIL_P(url)      ? NULL : StringValuePtr(url);
-  const char * c_enc    = NIL_P(encoding) ? NULL : StringValuePtr(encoding);
+  const char * c_url    = NIL_P(url)      ? NULL : StringValueCStr(url);
+  const char * c_enc    = NIL_P(encoding) ? NULL : StringValueCStr(encoding);
   int len               = (int)RSTRING_LEN(string);
   VALUE error_list      = rb_ary_new();
   VALUE document;

--- a/ext/nokogiri/html_element_description.c
+++ b/ext/nokogiri/html_element_description.c
@@ -245,7 +245,7 @@ static VALUE name(VALUE self)
 static VALUE get_description(VALUE klass, VALUE tag_name)
 {
   const htmlElemDesc * description = htmlTagLookup(
-      (const xmlChar *)StringValuePtr(tag_name)
+      (const xmlChar *)StringValueCStr(tag_name)
   );
 
   if(NULL == description) return Qnil;

--- a/ext/nokogiri/html_entity_lookup.c
+++ b/ext/nokogiri/html_entity_lookup.c
@@ -9,7 +9,7 @@
 static VALUE get(VALUE self, VALUE key)
 {
   const htmlEntityDesc * desc =
-    htmlEntityLookup((const xmlChar *)StringValuePtr(key));
+    htmlEntityLookup((const xmlChar *)StringValueCStr(key));
   VALUE klass, args[3];
 
   if(NULL == desc) return Qnil;

--- a/ext/nokogiri/html_sax_parser_context.c
+++ b/ext/nokogiri/html_sax_parser_context.c
@@ -31,12 +31,12 @@ parse_memory(VALUE klass, VALUE data, VALUE encoding)
     }
 
     if (RTEST(encoding)) {
-	xmlCharEncodingHandlerPtr enc = xmlFindCharEncodingHandler(StringValuePtr(encoding));
+	xmlCharEncodingHandlerPtr enc = xmlFindCharEncodingHandler(StringValueCStr(encoding));
 	if (enc != NULL) {
 	    xmlSwitchToEncoding(ctxt, enc);
 	    if (ctxt->errNo == XML_ERR_UNSUPPORTED_ENCODING) {
 		rb_raise(rb_eRuntimeError, "Unsupported encoding %s",
-			 StringValuePtr(encoding));
+			 StringValueCStr(encoding));
 	    }
 	}
     }
@@ -47,8 +47,8 @@ parse_memory(VALUE klass, VALUE data, VALUE encoding)
 static VALUE parse_file(VALUE klass, VALUE filename, VALUE encoding)
 {
   htmlParserCtxtPtr ctxt = htmlCreateFileParserCtxt(
-      StringValuePtr(filename),
-      StringValuePtr(encoding)
+      StringValueCStr(filename),
+      StringValueCStr(encoding)
   );
   return Data_Wrap_Struct(klass, NULL, deallocate, ctxt);
 }

--- a/ext/nokogiri/html_sax_push_parser.c
+++ b/ext/nokogiri/html_sax_push_parser.c
@@ -46,10 +46,10 @@ static VALUE initialize_native(VALUE self, VALUE _xml_sax, VALUE _filename,
 
   Data_Get_Struct(_xml_sax, xmlSAXHandler, sax);
 
-  if(_filename != Qnil) filename = StringValuePtr(_filename);
+  if(_filename != Qnil) filename = StringValueCStr(_filename);
 
   if (!NIL_P(encoding)) {
-    enc = xmlParseCharEncoding(StringValuePtr(encoding));
+    enc = xmlParseCharEncoding(StringValueCStr(encoding));
     if (enc == XML_CHAR_ENCODING_ERROR)
       rb_raise(rb_eArgError, "Unsupported Encoding");
   }

--- a/ext/nokogiri/xml_attr.c
+++ b/ext/nokogiri/xml_attr.c
@@ -20,7 +20,7 @@ static VALUE set_value(VALUE self, VALUE content)
     xmlNode *tmp;
 
     /* Encode our content */
-    buffer = xmlEncodeEntitiesReentrant(attr->doc, (unsigned char *)StringValuePtr(content));
+    buffer = xmlEncodeEntitiesReentrant(attr->doc, (unsigned char *)StringValueCStr(content));
 
     attr->children = xmlStringGetNodeList(attr->doc, buffer);
     attr->last = NULL;
@@ -61,7 +61,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
 
   node = xmlNewDocProp(
       xml_doc,
-      (const xmlChar *)StringValuePtr(name),
+      (const xmlChar *)StringValueCStr(name),
       NULL
   );
 

--- a/ext/nokogiri/xml_comment.c
+++ b/ext/nokogiri/xml_comment.c
@@ -34,7 +34,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
 
   node = xmlNewDocComment(
       xml_doc,
-      (const xmlChar *)StringValuePtr(content)
+      (const xmlChar *)StringValueCStr(content)
   );
 
   rb_node = Nokogiri_wrap_xml_node(klass, node);

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -181,7 +181,7 @@ static VALUE set_encoding(VALUE self, VALUE encoding)
   if (doc->encoding)
       free((char *) doc->encoding); /* this may produce a gcc cast warning */
 
-  doc->encoding = xmlStrdup((xmlChar *)StringValuePtr(encoding));
+  doc->encoding = xmlStrdup((xmlChar *)StringValueCStr(encoding));
 
   return encoding;
 }
@@ -228,8 +228,8 @@ static VALUE read_io( VALUE klass,
                       VALUE encoding,
                       VALUE options )
 {
-  const char * c_url    = NIL_P(url)      ? NULL : StringValuePtr(url);
-  const char * c_enc    = NIL_P(encoding) ? NULL : StringValuePtr(encoding);
+  const char * c_url    = NIL_P(url)      ? NULL : StringValueCStr(url);
+  const char * c_enc    = NIL_P(encoding) ? NULL : StringValueCStr(encoding);
   VALUE error_list      = rb_ary_new();
   VALUE document;
   xmlDocPtr doc;
@@ -279,8 +279,8 @@ static VALUE read_memory( VALUE klass,
                           VALUE options )
 {
   const char * c_buffer = StringValuePtr(string);
-  const char * c_url    = NIL_P(url)      ? NULL : StringValuePtr(url);
-  const char * c_enc    = NIL_P(encoding) ? NULL : StringValuePtr(encoding);
+  const char * c_url    = NIL_P(url)      ? NULL : StringValueCStr(url);
+  const char * c_enc    = NIL_P(encoding) ? NULL : StringValueCStr(encoding);
   int len               = (int)RSTRING_LEN(string);
   VALUE error_list      = rb_ary_new();
   VALUE document;
@@ -355,7 +355,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
   version = rb_ary_entry(rest, (long)0);
   if (NIL_P(version)) version = rb_str_new2("1.0");
 
-  doc = xmlNewDoc((xmlChar *)StringValuePtr(version));
+  doc = xmlNewDoc((xmlChar *)StringValueCStr(version));
   rb_doc = Nokogiri_wrap_xml_document(klass, doc);
   rb_obj_call_init(rb_doc, argc, argv);
   return rb_doc ;
@@ -383,13 +383,13 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
  *         </bicycle>
  *       </root>
  *       EOXML
- *    
+ *
  *    doc.xpath("//tire").to_s # => ""
  *    doc.xpath("//part:tire", "part" => "http://general-motors.com/").to_s # => "<part:tire>Michelin Model XGV</part:tire>"
  *    doc.xpath("//part:tire", "part" => "http://schwinn.com/").to_s # => "<part:tire>I'm a bicycle tire!</part:tire>"
- *    
+ *
  *    doc.remove_namespaces!
- *    
+ *
  *    doc.xpath("//tire").to_s # => "<tire>Michelin Model XGV</tire><tire>I'm a bicycle tire!</tire>"
  *    doc.xpath("//part:tire", "part" => "http://general-motors.com/").to_s # => ""
  *    doc.xpath("//part:tire", "part" => "http://schwinn.com/").to_s # => ""
@@ -436,11 +436,11 @@ static VALUE create_entity(int argc, VALUE *argv, VALUE self)
   xmlResetLastError();
   ptr = xmlAddDocEntity(
       doc,
-      (xmlChar *)(NIL_P(name)        ? NULL                        : StringValuePtr(name)),
+      (xmlChar *)(NIL_P(name)        ? NULL                        : StringValueCStr(name)),
       (int)      (NIL_P(type)        ? XML_INTERNAL_GENERAL_ENTITY : NUM2INT(type)),
-      (xmlChar *)(NIL_P(external_id) ? NULL                        : StringValuePtr(external_id)),
-      (xmlChar *)(NIL_P(system_id)   ? NULL                        : StringValuePtr(system_id)),
-      (xmlChar *)(NIL_P(content)     ? NULL                        : StringValuePtr(content))
+      (xmlChar *)(NIL_P(external_id) ? NULL                        : StringValueCStr(external_id)),
+      (xmlChar *)(NIL_P(system_id)   ? NULL                        : StringValueCStr(system_id)),
+      (xmlChar *)(NIL_P(content)     ? NULL                        : StringValueCStr(content))
     );
 
   if(NULL == ptr) {
@@ -484,9 +484,9 @@ static int block_caller(void * ctx, xmlNodePtr _node, xmlNodePtr _parent)
  *  doc.canonicalize { |obj, parent| ... }
  *
  * Canonicalize a document and return the results.  Takes an optional block
- * that takes two parameters: the +obj+ and that node's +parent+.  
+ * that takes two parameters: the +obj+ and that node's +parent+.
  * The  +obj+ will be either a Nokogiri::XML::Node, or a Nokogiri::XML::Namespace
- * The block must return a non-nil, non-false value if the +obj+ passed in 
+ * The block must return a non-nil, non-false value if the +obj+ passed in
  * should be included in the canonicalized document.
  */
 static VALUE canonicalize(int argc, VALUE* argv, VALUE self)
@@ -531,14 +531,14 @@ static VALUE canonicalize(int argc, VALUE* argv, VALUE self)
     ns = calloc((size_t)ns_len+1, sizeof(xmlChar *));
     for (i = 0 ; i < ns_len ; i++) {
       VALUE entry = rb_ary_entry(incl_ns, i);
-      const char * ptr = StringValuePtr(entry);
+      const char * ptr = StringValueCStr(entry);
       ns[i] = (xmlChar*) ptr;
     }
   }
 
 
-  xmlC14NExecute(doc, cb, ctx, 
-    (int)      (NIL_P(mode)        ? 0 : NUM2INT(mode)), 
+  xmlC14NExecute(doc, cb, ctx,
+    (int)      (NIL_P(mode)        ? 0 : NUM2INT(mode)),
     ns,
     (int)      RTEST(with_comments),
     buf);

--- a/ext/nokogiri/xml_encoding_handler.c
+++ b/ext/nokogiri/xml_encoding_handler.c
@@ -9,7 +9,7 @@ static VALUE get(VALUE klass, VALUE key)
 {
   xmlCharEncodingHandlerPtr handler;
 
-  handler = xmlFindCharEncodingHandler(StringValuePtr(key));
+  handler = xmlFindCharEncodingHandler(StringValueCStr(key));
   if(handler)
     return Data_Wrap_Struct(klass, NULL, NULL, handler);
 
@@ -23,7 +23,7 @@ static VALUE get(VALUE klass, VALUE key)
  */
 static VALUE delete(VALUE klass, VALUE name)
 {
-  if(xmlDelEncodingAlias(StringValuePtr(name))) return Qnil;
+  if(xmlDelEncodingAlias(StringValueCStr(name))) return Qnil;
 
   return Qtrue;
 }
@@ -35,7 +35,7 @@ static VALUE delete(VALUE klass, VALUE name)
  */
 static VALUE alias(VALUE klass, VALUE from, VALUE to)
 {
-  xmlAddEncodingAlias(StringValuePtr(from), StringValuePtr(to));
+  xmlAddEncodingAlias(StringValueCStr(from), StringValueCStr(to));
 
   return to;
 }

--- a/ext/nokogiri/xml_entity_reference.c
+++ b/ext/nokogiri/xml_entity_reference.c
@@ -21,7 +21,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
 
   node = xmlNewReference(
       xml_doc,
-      (const xmlChar *)StringValuePtr(name)
+      (const xmlChar *)StringValueCStr(name)
   );
 
   nokogiri_root_node(node);

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -331,7 +331,7 @@ static VALUE encode_special_chars(VALUE self, VALUE string)
   Data_Get_Struct(self, xmlNode, node);
   encoded = xmlEncodeSpecialChars(
       node->doc,
-      (const xmlChar *)StringValuePtr(string)
+      (const xmlChar *)StringValueCStr(string)
   );
 
   encoded_str = NOKOGIRI_STR_NEW2(encoded);
@@ -367,9 +367,9 @@ static VALUE create_internal_subset(VALUE self, VALUE name, VALUE external_id, V
 
   dtd = xmlCreateIntSubset(
       doc,
-      NIL_P(name)        ? NULL : (const xmlChar *)StringValuePtr(name),
-      NIL_P(external_id) ? NULL : (const xmlChar *)StringValuePtr(external_id),
-      NIL_P(system_id)   ? NULL : (const xmlChar *)StringValuePtr(system_id)
+      NIL_P(name)        ? NULL : (const xmlChar *)StringValueCStr(name),
+      NIL_P(external_id) ? NULL : (const xmlChar *)StringValueCStr(external_id),
+      NIL_P(system_id)   ? NULL : (const xmlChar *)StringValueCStr(system_id)
   );
 
   if(!dtd) return Qnil;
@@ -398,9 +398,9 @@ static VALUE create_external_subset(VALUE self, VALUE name, VALUE external_id, V
 
   dtd = xmlNewDtd(
       doc,
-      NIL_P(name)        ? NULL : (const xmlChar *)StringValuePtr(name),
-      NIL_P(external_id) ? NULL : (const xmlChar *)StringValuePtr(external_id),
-      NIL_P(system_id)   ? NULL : (const xmlChar *)StringValuePtr(system_id)
+      NIL_P(name)        ? NULL : (const xmlChar *)StringValueCStr(name),
+      NIL_P(external_id) ? NULL : (const xmlChar *)StringValueCStr(external_id),
+      NIL_P(system_id)   ? NULL : (const xmlChar *)StringValueCStr(system_id)
   );
 
   if(!dtd) return Qnil;
@@ -737,7 +737,7 @@ static VALUE key_eh(VALUE self, VALUE attribute)
 {
   xmlNodePtr node;
   Data_Get_Struct(self, xmlNode, node);
-  if(xmlHasProp(node, (xmlChar *)StringValuePtr(attribute)))
+  if(xmlHasProp(node, (xmlChar *)StringValueCStr(attribute)))
     return Qtrue;
   return Qfalse;
 }
@@ -752,8 +752,8 @@ static VALUE namespaced_key_eh(VALUE self, VALUE attribute, VALUE namespace)
 {
   xmlNodePtr node;
   Data_Get_Struct(self, xmlNode, node);
-  if(xmlHasNsProp(node, (xmlChar *)StringValuePtr(attribute),
-        NIL_P(namespace) ? NULL : (xmlChar *)StringValuePtr(namespace)))
+  if(xmlHasNsProp(node, (xmlChar *)StringValueCStr(attribute),
+        NIL_P(namespace) ? NULL : (xmlChar *)StringValueCStr(namespace)))
     return Qtrue;
   return Qfalse;
 }
@@ -778,7 +778,7 @@ static VALUE set(VALUE self, VALUE property, VALUE value)
    */
   if (node->type != XML_ELEMENT_NODE)
     return(Qnil);
-  prop = xmlHasProp(node, (xmlChar *)StringValuePtr(property));
+  prop = xmlHasProp(node, (xmlChar *)StringValueCStr(property));
   if (prop && prop->children) {
     for (cur = prop->children; cur; cur = cur->next) {
       if (cur->_private) {
@@ -788,8 +788,8 @@ static VALUE set(VALUE self, VALUE property, VALUE value)
     }
   }
 
-  xmlSetProp(node, (xmlChar *)StringValuePtr(property),
-      (xmlChar *)StringValuePtr(value));
+  xmlSetProp(node, (xmlChar *)StringValueCStr(property),
+      (xmlChar *)StringValueCStr(value));
 
   return value;
 }
@@ -812,7 +812,7 @@ static VALUE get(VALUE self, VALUE rattribute)
   if (NIL_P(rattribute)) return Qnil;
 
   Data_Get_Struct(self, xmlNode, node);
-  attribute = strdup(StringValuePtr(rattribute));
+  attribute = strdup(StringValueCStr(rattribute));
 
   colon = strchr(attribute, ':');
   if (colon) {
@@ -823,7 +823,7 @@ static VALUE get(VALUE self, VALUE rattribute)
     if (ns) {
       value = xmlGetNsProp(node, (xmlChar*)(attr_name), ns->href);
     } else {
-      value = xmlGetProp(node, (xmlChar*)StringValuePtr(rattribute));
+      value = xmlGetProp(node, (xmlChar*)StringValueCStr(rattribute));
     }
   } else {
     value = xmlGetNoNsProp(node, (xmlChar*)attribute);
@@ -870,7 +870,7 @@ static VALUE attr(VALUE self, VALUE name)
   xmlNodePtr node;
   xmlAttrPtr prop;
   Data_Get_Struct(self, xmlNode, node);
-  prop = xmlHasProp(node, (xmlChar *)StringValuePtr(name));
+  prop = xmlHasProp(node, (xmlChar *)StringValueCStr(name));
 
   if(! prop) return Qnil;
   return Nokogiri_wrap_xml_node(Qnil, (xmlNodePtr)prop);
@@ -887,8 +887,8 @@ static VALUE attribute_with_ns(VALUE self, VALUE name, VALUE namespace)
   xmlNodePtr node;
   xmlAttrPtr prop;
   Data_Get_Struct(self, xmlNode, node);
-  prop = xmlHasNsProp(node, (xmlChar *)StringValuePtr(name),
-      NIL_P(namespace) ? NULL : (xmlChar *)StringValuePtr(namespace));
+  prop = xmlHasNsProp(node, (xmlChar *)StringValueCStr(name),
+      NIL_P(namespace) ? NULL : (xmlChar *)StringValueCStr(namespace));
 
   if(! prop) return Qnil;
   return Nokogiri_wrap_xml_node(Qnil, (xmlNodePtr)prop);
@@ -1025,7 +1025,7 @@ static VALUE set_native_content(VALUE self, VALUE content)
     child = next ;
   }
 
-  xmlNodeSetContent(node, (xmlChar *)StringValuePtr(content));
+  xmlNodeSetContent(node, (xmlChar *)StringValueCStr(content));
   return content;
 }
 
@@ -1063,7 +1063,7 @@ static VALUE set_lang(VALUE self_rb, VALUE lang_rb)
   xmlChar* lang ;
 
   Data_Get_Struct(self_rb, xmlNode, self);
-  lang = (xmlChar*)StringValuePtr(lang_rb);
+  lang = (xmlChar*)StringValueCStr(lang_rb);
 
   xmlNodeSetLang(self, lang);
 
@@ -1128,7 +1128,7 @@ static VALUE set_name(VALUE self, VALUE new_name)
 {
   xmlNodePtr node;
   Data_Get_Struct(self, xmlNode, node);
-  xmlNodeSetName(node, (xmlChar*)StringValuePtr(new_name));
+  xmlNodeSetName(node, (xmlChar*)StringValueCStr(new_name));
   return new_name;
 }
 
@@ -1202,13 +1202,13 @@ static VALUE native_write_to(
 
   before_indent = xmlTreeIndentString;
 
-  xmlTreeIndentString = StringValuePtr(indent_string);
+  xmlTreeIndentString = StringValueCStr(indent_string);
 
   savectx = xmlSaveToIO(
       (xmlOutputWriteCallback)io_write_callback,
       (xmlOutputCloseCallback)io_close_callback,
       (void *)io,
-      RTEST(encoding) ? StringValuePtr(encoding) : NULL,
+      RTEST(encoding) ? StringValueCStr(encoding) : NULL,
       (int)NUM2INT(options)
   );
 
@@ -1255,7 +1255,7 @@ static VALUE add_namespace_definition(VALUE self, VALUE prefix, VALUE href)
   ns = xmlSearchNs(
       node->doc,
       node,
-      (const xmlChar *)(NIL_P(prefix) ? NULL : StringValuePtr(prefix))
+      (const xmlChar *)(NIL_P(prefix) ? NULL : StringValueCStr(prefix))
   );
 
   if(!ns) {
@@ -1264,8 +1264,8 @@ static VALUE add_namespace_definition(VALUE self, VALUE prefix, VALUE href)
     }
     ns = xmlNewNs(
         namespacee,
-        (const xmlChar *)StringValuePtr(href),
-        (const xmlChar *)(NIL_P(prefix) ? NULL : StringValuePtr(prefix))
+        (const xmlChar *)StringValueCStr(href),
+        (const xmlChar *)(NIL_P(prefix) ? NULL : StringValueCStr(prefix))
     );
   }
 
@@ -1295,7 +1295,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
 
   Data_Get_Struct(document, xmlDoc, doc);
 
-  node = xmlNewNode(NULL, (xmlChar *)StringValuePtr(name));
+  node = xmlNewNode(NULL, (xmlChar *)StringValueCStr(name));
   node->doc = doc->doc;
   nokogiri_root_node(node);
 

--- a/ext/nokogiri/xml_processing_instruction.c
+++ b/ext/nokogiri/xml_processing_instruction.c
@@ -23,8 +23,8 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
 
   node = xmlNewDocPI(
       xml_doc,
-      (const xmlChar *)StringValuePtr(name),
-      (const xmlChar *)StringValuePtr(content)
+      (const xmlChar *)StringValueCStr(name),
+      (const xmlChar *)StringValueCStr(content)
   );
 
   nokogiri_root_node(node);

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -218,12 +218,12 @@ static VALUE reader_attribute(VALUE self, VALUE name)
   if(NIL_P(name)) return Qnil;
   name = StringValue(name) ;
 
-  value = xmlTextReaderGetAttribute(reader, (xmlChar*)StringValuePtr(name));
+  value = xmlTextReaderGetAttribute(reader, (xmlChar*)StringValueCStr(name));
   if(value == NULL) {
     /* this section is an attempt to workaround older versions of libxml that
        don't handle namespaces properly in all attribute-and-friends functions */
     xmlChar *prefix = NULL ;
-    xmlChar *localname = xmlSplitQName2((xmlChar*)StringValuePtr(name), &prefix);
+    xmlChar *localname = xmlSplitQName2((xmlChar*)StringValueCStr(name), &prefix);
     if (localname != NULL) {
       value = xmlTextReaderLookupNamespace(reader, localname);
       xmlFree(localname) ;
@@ -546,8 +546,8 @@ static VALUE from_memory(int argc, VALUE *argv, VALUE klass)
   rb_scan_args(argc, argv, "13", &rb_buffer, &rb_url, &encoding, &rb_options);
 
   if (!RTEST(rb_buffer)) rb_raise(rb_eArgError, "string cannot be nil");
-  if (RTEST(rb_url)) c_url = StringValuePtr(rb_url);
-  if (RTEST(encoding)) c_encoding = StringValuePtr(encoding);
+  if (RTEST(rb_url)) c_url = StringValueCStr(rb_url);
+  if (RTEST(encoding)) c_encoding = StringValueCStr(encoding);
   if (RTEST(rb_options)) c_options = (int)NUM2INT(rb_options);
 
   reader = xmlReaderForMemory(
@@ -590,8 +590,8 @@ static VALUE from_io(int argc, VALUE *argv, VALUE klass)
   rb_scan_args(argc, argv, "13", &rb_io, &rb_url, &encoding, &rb_options);
 
   if (!RTEST(rb_io)) rb_raise(rb_eArgError, "io cannot be nil");
-  if (RTEST(rb_url)) c_url = StringValuePtr(rb_url);
-  if (RTEST(encoding)) c_encoding = StringValuePtr(encoding);
+  if (RTEST(rb_url)) c_url = StringValueCStr(rb_url);
+  if (RTEST(encoding)) c_encoding = StringValueCStr(encoding);
   if (RTEST(rb_options)) c_options = (int)NUM2INT(rb_options);
 
   reader = xmlReaderForIO(

--- a/ext/nokogiri/xml_sax_parser_context.c
+++ b/ext/nokogiri/xml_sax_parser_context.c
@@ -45,7 +45,7 @@ parse_io(VALUE klass, VALUE io, VALUE encoding)
  */
 static VALUE parse_file(VALUE klass, VALUE filename)
 {
-  xmlParserCtxtPtr ctxt = xmlCreateFileParserCtxt(StringValuePtr(filename));
+  xmlParserCtxtPtr ctxt = xmlCreateFileParserCtxt(StringValueCStr(filename));
   return Data_Wrap_Struct(klass, NULL, deallocate, ctxt);
 }
 

--- a/ext/nokogiri/xml_sax_push_parser.c
+++ b/ext/nokogiri/xml_sax_push_parser.c
@@ -59,7 +59,7 @@ static VALUE initialize_native(VALUE self, VALUE _xml_sax, VALUE _filename)
 
   Data_Get_Struct(_xml_sax, xmlSAXHandler, sax);
 
-  if(_filename != Qnil) filename = StringValuePtr(_filename);
+  if(_filename != Qnil) filename = StringValueCStr(_filename);
 
   ctx = xmlCreatePushParserCtxt(
       sax,

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -61,7 +61,7 @@ static VALUE validate_file(VALUE self, VALUE rb_filename)
   VALUE errors;
 
   Data_Get_Struct(self, xmlSchema, schema);
-  filename = (const char*)StringValuePtr(rb_filename) ;
+  filename = (const char*)StringValueCStr(rb_filename) ;
 
   errors = rb_ary_new();
 

--- a/ext/nokogiri/xml_text.c
+++ b/ext/nokogiri/xml_text.c
@@ -19,7 +19,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
 
   Data_Get_Struct(document, xmlDoc, doc);
 
-  node = xmlNewText((xmlChar *)StringValuePtr(string));
+  node = xmlNewText((xmlChar *)StringValueCStr(string));
   node->doc = doc->doc;
 
   nokogiri_root_node(node);

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -21,8 +21,8 @@ static VALUE register_ns(VALUE self, VALUE prefix, VALUE uri)
   Data_Get_Struct(self, xmlXPathContext, ctx);
 
   xmlXPathRegisterNs( ctx,
-                      (const xmlChar *)StringValuePtr(prefix),
-                      (const xmlChar *)StringValuePtr(uri)
+                      (const xmlChar *)StringValueCStr(prefix),
+                      (const xmlChar *)StringValueCStr(uri)
   );
   return self;
 }
@@ -39,10 +39,10 @@ static VALUE register_variable(VALUE self, VALUE name, VALUE value)
    xmlXPathObjectPtr xmlValue;
    Data_Get_Struct(self, xmlXPathContext, ctx);
 
-   xmlValue = xmlXPathNewCString(StringValuePtr(value));
+   xmlValue = xmlXPathNewCString(StringValueCStr(value));
 
    xmlXPathRegisterVariable( ctx,
-      (const xmlChar *)StringValuePtr(name),
+      (const xmlChar *)StringValueCStr(name),
       xmlValue
    );
 
@@ -108,7 +108,7 @@ void Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr c
     case T_STRING:
       xmlXPathReturnString(
           ctx,
-          xmlCharStrdup(StringValuePtr(result))
+          xmlCharStrdup(StringValueCStr(result))
       );
       break;
     case T_TRUE:
@@ -200,7 +200,7 @@ static VALUE evaluate(int argc, VALUE *argv, VALUE self)
   if(rb_scan_args(argc, argv, "11", &search_path, &xpath_handler) == 1)
     xpath_handler = Qnil;
 
-  query = (xmlChar *)StringValuePtr(search_path);
+  query = (xmlChar *)StringValueCStr(search_path);
 
   if(Qnil != xpath_handler) {
     /* FIXME: not sure if this is the correct place to shove private data. */

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -22,7 +22,7 @@ static void dealloc(nokogiriXsltStylesheetTuple *wrapper)
     NOKOGIRI_DEBUG_START(doc);
     xsltFreeStylesheet(doc); /* commented out for now. */
     NOKOGIRI_DEBUG_END(doc);
-    
+
     free(wrapper);
 }
 
@@ -47,7 +47,7 @@ VALUE Nokogiri_wrap_xslt_stylesheet(xsltStylesheetPtr ss)
 
   self = Data_Make_Struct(cNokogiriXsltStylesheet, nokogiriXsltStylesheetTuple,
                           mark, dealloc, wrapper);
-  
+
   ss->_private = (void *)self;
   wrapper->ss = ss;
   wrapper->func_instances = rb_ary_new();
@@ -122,7 +122,7 @@ static void swallow_superfluous_xml_errors(void * userdata, xmlErrorPtr error, .
  *  returns Nokogiri::XML::Document
  *
  *  Example:
- * 
+ *
  *    doc   = Nokogiri::XML(File.read(ARGV[0]))
  *    xslt  = Nokogiri::XSLT(File.read(ARGV[1]))
  *    puts xslt.transform(doc, ['key', 'value'])
@@ -158,7 +158,7 @@ static VALUE transform(int argc, VALUE* argv, VALUE self)
     params = calloc((size_t)param_len+1, sizeof(char*));
     for (j = 0 ; j < param_len ; j++) {
       VALUE entry = rb_ary_entry(paramobj, j);
-      const char * ptr = StringValuePtr(entry);
+      const char * ptr = StringValueCStr(entry);
       params[j] = ptr;
     }
     params[param_len] = 0 ;
@@ -211,7 +211,7 @@ static void * initFunc(xsltTransformContextPtr ctxt, const xmlChar *uri)
     for(i = 0; i < RARRAY_LEN(methods); i++) {
 	VALUE method_name = rb_obj_as_string(rb_ary_entry(methods, i));
 	xsltRegisterExtFunction(ctxt,
-          (unsigned char *)StringValuePtr(method_name), uri, method_caller);
+          (unsigned char *)StringValueCStr(method_name), uri, method_caller);
     }
 
     Data_Get_Struct(ctxt->style->_private, nokogiriXsltStylesheetTuple,
@@ -245,7 +245,7 @@ static VALUE registr(VALUE self, VALUE uri, VALUE obj)
     if(NIL_P(modules)) rb_raise(rb_eRuntimeError, "wtf! @modules isn't set");
 
     rb_hash_aset(modules, uri, obj);
-    xsltRegisterExtModule((unsigned char *)StringValuePtr(uri), initFunc, shutdownFunc);
+    xsltRegisterExtModule((unsigned char *)StringValueCStr(uri), initFunc, shutdownFunc);
     return self;
 }
 


### PR DESCRIPTION
Ruby-2.2 changes the String handling in such a way, that strings can
no longer be expected to be zero terminated. When zero terminated
strings are expected in the C code, StringValueCStr() must be used.
See: https://github.com/ruby/ruby/blob/v2_2_0/NEWS#L319

Using StringValuePtr() without a length check, can also become a
security issue, because it can leak the memory after the string.

This was already an issue in the pg.gem: https://github.com/ged/ruby-pg/pull/5