### PR TITLE
Fix error when running rspec-rails tests

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -393,6 +393,7 @@ else
 
   # The gem version constraint in the Rakefile is not respected at install time.
   # Keep this version in sync with the one in the Rakefile !
+  require 'rubygems'
   gem "mini_portile2", "~> 2.0.0"
   require 'mini_portile2'
   message "Using mini_portile version #{MiniPortile::VERSION}\n"


### PR DESCRIPTION
I was getting the following error during `nokogiri` installation when running `rspec-rails` tests

```
extconf.rb:396:in `<main>': undefined method `gem' for main:Object
```

I think this should fix it.