### PR TITLE
Simplify NodeSet#to_a with a minor speed-up.

### DIFF
--- a/ext/nokogiri/xml_node_set.c
+++ b/ext/nokogiri/xml_node_set.c
@@ -321,24 +321,16 @@ static VALUE slice(int argc, VALUE *argv, VALUE self)
 static VALUE to_array(VALUE self, VALUE rb_node)
 {
   xmlNodeSetPtr node_set ;
-  VALUE *elts;
   VALUE list;
   int i;
 
   Data_Get_Struct(self, xmlNodeSet, node_set);
 
-  elts = (VALUE *)calloc((size_t)(node_set->nodeNr), sizeof(VALUE));
+  list = rb_ary_new2(node_set->nodeNr);
   for(i = 0; i < node_set->nodeNr; i++) {
-    elts[i] = Nokogiri_wrap_xml_node_set_node(node_set->nodeTab[i], self);
-    rb_gc_register_address(&elts[i]);
+    VALUE elt = Nokogiri_wrap_xml_node_set_node(node_set->nodeTab[i], self);
+    rb_ary_push( list, elt );
   }
-
-  list = rb_ary_new4((long)node_set->nodeNr, elts);
-
-  for(i = 0; i < node_set->nodeNr; i++) {
-    rb_gc_unregister_address(&elts[i]);
-  }
-  free(elts);
 
   return list;
 }


### PR DESCRIPTION
This stood up while reviewing https://github.com/sparklemotion/nokogiri/pull/1362#discussion_r47873435 . The speed-up is around 10%:

```ruby
xml = Nokogiri::XML.parse("<r>#{"<a/>"*100}</r>")
set = xml.xpath('//a')
st = Time.now; 1000000.times{ set.to_a }; Time.now - st
```

... changed from 8.2 to 7.3 seconds on my (slow) netbook.
