### PR TITLE
Fix test failure when Encoding.default_external is not UTF-8.

### DIFF
--- a/test/xml/test_node_encoding.rb
+++ b/test/xml/test_node_encoding.rb
@@ -5,7 +5,7 @@ module Nokogiri
     class TestNodeEncoding < Nokogiri::TestCase
       def setup
         super
-        @html = Nokogiri::HTML(File.read(HTML_FILE), HTML_FILE)
+        @html = Nokogiri::HTML(File.open(HTML_FILE, "rb"))
       end
 
       def test_get_attribute


### PR DESCRIPTION
This fixes a test failure on Windows, that was caused
by loading a HTML document per File.read(). This function
returns a string in some cpXXX encoding on Windows, which
was used as the document encoding later on, so that the test
failed.

This fixes #1387 and obsoletes #1385 .