### PR TITLE
Fix encoding of xml node namespaces and improve encoding tests.

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'stringio'
 require 'nokogiri/xml/node/save_options'
 
@@ -439,12 +440,6 @@ module Nokogiri
       def namespaces
         Hash[namespace_scopes.map { |nd|
           key = ['xmlns', nd.prefix].compact.join(':')
-          if document.encoding
-            begin
-              key.force_encoding document.encoding
-            rescue ArgumentError
-            end
-          end
           [key, nd.href]
         }]
       end

--- a/test/html/test_node_encoding.rb
+++ b/test/html/test_node_encoding.rb
@@ -4,6 +4,48 @@ require "helper"
 module Nokogiri
   module HTML
     class TestNodeEncoding < Nokogiri::TestCase
+      def setup
+        super
+        @html = Nokogiri::HTML(File.open(NICH_FILE, "rb"))
+      end
+
+      def test_get_attribute
+        node = @html.css('a').first
+        assert_equal 'UTF-8', node['href'].encoding.name
+      end
+
+      def test_text_encoding_is_utf_8
+        assert_equal 'UTF-8', @html.text.encoding.name
+      end
+
+      def test_serialize_encoding_html
+        assert_equal @html.encoding.downcase,
+          @html.serialize.encoding.name.downcase
+
+        @doc = Nokogiri::HTML(@html.serialize)
+        assert_equal @html.serialize, @doc.serialize
+      end
+
+      def test_encode_special_chars
+        foo = @html.css('a').first.encode_special_chars('foo')
+        assert_equal 'UTF-8', foo.encoding.name
+      end
+
+      def test_content
+        node = @html.css('a').first
+        assert_equal 'UTF-8', node.content.encoding.name
+      end
+
+      def test_name
+        node = @html.css('a').first
+        assert_equal 'UTF-8', node.name.encoding.name
+      end
+
+      def test_path
+        node = @html.css('a').first
+        assert_equal 'UTF-8', node.path.encoding.name
+      end
+
       def test_inner_html
         doc = Nokogiri::HTML File.open(SHIFT_JIS_HTML, 'rb')
 

--- a/test/xml/test_document_encoding.rb
+++ b/test/xml/test_document_encoding.rb
@@ -5,15 +5,15 @@ module Nokogiri
     class TestDocumentEncoding < Nokogiri::TestCase
       def setup
         super
-        @xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE, 'UTF-8')
+        @xml = Nokogiri::XML(File.read(SHIFT_JIS_XML), SHIFT_JIS_XML)
       end
 
       def test_url
-        assert_equal @xml.encoding, @xml.url.encoding.name
+        assert_equal 'UTF-8', @xml.url.encoding.name
       end
 
       def test_encoding
-        assert_equal @xml.encoding, @xml.encoding.encoding.name
+        assert_equal 'UTF-8', @xml.encoding.encoding.name
       end
 
       def test_dotted_version

--- a/test/xml/test_node_encoding.rb
+++ b/test/xml/test_node_encoding.rb
@@ -4,30 +4,6 @@ require "helper"
 module Nokogiri
   module XML
     class TestNodeEncoding < Nokogiri::TestCase
-      def setup
-        super
-        @html = Nokogiri::HTML(File.open(HTML_FILE, "rb"))
-      end
-
-      def test_get_attribute
-        node = @html.css('a').first
-        assert_equal @html.encoding, node['href'].encoding.name
-      end
-
-      def test_text_encoding_is_utf_8
-        @html = Nokogiri::HTML(File.open(NICH_FILE))
-        assert_equal 'UTF-8', @html.text.encoding.name
-      end
-
-      def test_serialize_encoding_html
-        @html = Nokogiri::HTML(File.open(NICH_FILE))
-        assert_equal @html.encoding.downcase,
-          @html.serialize.encoding.name.downcase
-
-        @doc = Nokogiri::HTML(@html.serialize)
-        assert_equal @html.serialize, @doc.serialize
-      end
-
       def test_serialize_encoding_xml
         @xml = Nokogiri::XML(File.open(SHIFT_JIS_XML))
         assert_equal @xml.encoding.downcase,
@@ -35,11 +11,6 @@ module Nokogiri
 
         @doc = Nokogiri::XML(@xml.serialize)
         assert_equal @xml.serialize, @doc.serialize
-      end
-
-      def test_encode_special_chars
-        foo = @html.css('a').first.encode_special_chars('foo')
-        assert_equal @html.encoding, foo.encoding.name
       end
 
       def test_encoding_GH_1113
@@ -58,34 +29,20 @@ module Nokogiri
         assert_equal expected, frag.to_xml.sub(/^<.xml[^>]*>\n/m, '').strip
       end
 
-      def test_content
-        node = @html.css('a').first
-        assert_equal @html.encoding, node.content.encoding.name
-      end
-
-      def test_name
-        node = @html.css('a').first
-        assert_equal @html.encoding, node.name.encoding.name
-      end
-
-      def test_path
-        node = @html.css('a').first
-        assert_equal @html.encoding, node.path.encoding.name
-      end
+      VEHICLE_XML = <<-eoxml
+        <root>
+          <car xmlns:part="http://general-motors.com/">
+            <part:tire>Michelin Model XGV</part:tire>
+          </car>
+          <bicycle xmlns:part="http://schwinn.com/">
+            <part:tire>I'm a bicycle tire!</part:tire>
+          </bicycle>
+        </root>
+      eoxml
 
       def test_namespace
-        xml = <<-eoxml
-<root>
-  <car xmlns:part="http://general-motors.com/">
-    <part:tire>Michelin Model XGV</part:tire>
-  </car>
-  <bicycle xmlns:part="http://schwinn.com/">
-    <part:tire>I'm a bicycle tire!</part:tire>
-  </bicycle>
-</root>
-        eoxml
-        doc = Nokogiri::XML(xml, nil, 'UTF-8')
-        assert_equal 'UTF-8', doc.encoding
+        doc = Nokogiri::XML(VEHICLE_XML.encode('Shift_JIS'), nil, 'Shift_JIS')
+        assert_equal 'Shift_JIS', doc.encoding
         n = doc.xpath('//part:tire', { 'part' => 'http://schwinn.com/' }).first
         assert n
         assert_equal 'UTF-8', n.namespace.href.encoding.name
@@ -93,18 +50,8 @@ module Nokogiri
       end
 
       def test_namespace_as_hash
-        xml = <<-eoxml
-<root>
-  <car xmlns:part="http://general-motors.com/">
-    <part:tire>Michelin Model XGV</part:tire>
-  </car>
-  <bicycle xmlns:part="http://schwinn.com/">
-    <part:tire>I'm a bicycle tire!</part:tire>
-  </bicycle>
-</root>
-        eoxml
-        doc = Nokogiri::XML(xml, nil, 'UTF-8')
-        assert_equal 'UTF-8', doc.encoding
+        doc = Nokogiri::XML(VEHICLE_XML.encode('Shift_JIS'), nil, 'Shift_JIS')
+        assert_equal 'Shift_JIS', doc.encoding
         assert n = doc.xpath('//car').first
 
         n.namespace_definitions.each do |nd|

--- a/test/xml/test_node_encoding.rb
+++ b/test/xml/test_node_encoding.rb
@@ -88,8 +88,8 @@ module Nokogiri
         assert_equal 'UTF-8', doc.encoding
         n = doc.xpath('//part:tire', { 'part' => 'http://schwinn.com/' }).first
         assert n
-        assert_equal doc.encoding, n.namespace.href.encoding.name
-        assert_equal doc.encoding, n.namespace.prefix.encoding.name
+        assert_equal 'UTF-8', n.namespace.href.encoding.name
+        assert_equal 'UTF-8', n.namespace.prefix.encoding.name
       end
 
       def test_namespace_as_hash
@@ -108,13 +108,13 @@ module Nokogiri
         assert n = doc.xpath('//car').first
 
         n.namespace_definitions.each do |nd|
-          assert_equal doc.encoding, nd.href.encoding.name
-          assert_equal doc.encoding, nd.prefix.encoding.name
+          assert_equal 'UTF-8', nd.href.encoding.name
+          assert_equal 'UTF-8', nd.prefix.encoding.name
         end
 
         n.namespaces.each do |k,v|
-          assert_equal doc.encoding, k.encoding.name
-          assert_equal doc.encoding, v.encoding.name
+          assert_equal 'UTF-8', k.encoding.name
+          assert_equal 'UTF-8', v.encoding.name
         end
       end
     end


### PR DESCRIPTION
Fix encoding of keys returned by XML::Node#namespaces. The key parts were encoded like the document, but should be UTF-8 per definition. The value parts were already encoded as UTF-8.
    
Encoding of the various text returning functions was tested against the document encoding, but it should be UTF-8 per definition. The XML/HTML documents are now changed to a non-UTF-8 versions, to make the tests more meaningful.

This obsoletes #1385  - although the same content, the attached patches are better separated and so should be better to review, now.
