### PR TITLE
Don't remove empty directories after build.

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -57,7 +57,6 @@ def do_clean
     # clean the ports build directory
     Pathname.glob(pwd.join('tmp', '*', 'ports')) { |dir|
       FileUtils.rm_rf(dir, verbose: true)
-      FileUtils.rmdir(dir.parent, parents: true, verbose: true)
     }
 
     if enable_config('static')


### PR DESCRIPTION
Deletion of these empty directories is flawed on docker with overlayfs, so we better avoid it. The build artifacts are still removed after gem install.

This fixes nokogiri issue #1370 . For further details to the root issue see: https://github.com/docker/docker/issues/19082