### PR TITLE
Add Ruby 2.3.0 to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 - 2.0
 - 2.1
 - 2.2.3
+- 2.3.0
 - jruby-19mode
 - jruby-1.7.23
 - jruby-9.0.4.0
@@ -19,6 +20,10 @@ os:
 - osx
 
 matrix:
+  allow_failures:
+  # https://github.com/travis-ci/travis-ci/issues/5361
+  - os: osx
+    rvm: 2.3.0
   exclude:
   - os: osx
     rvm: ruby-1.9.2


### PR DESCRIPTION
Rails added.
https://github.com/rails/rails/pull/22792

Travis has the issue on MacOSX.
https://github.com/travis-ci/travis-ci/issues/5361