### PR TITLE
Dont assume rubygems is loaded before using gem command

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -392,6 +392,7 @@ else
 
   # The gem version constraint in the Rakefile is not respected at install time.
   # Keep this version in sync with the one in the Rakefile !
+  require 'rubygems'
   gem "mini_portile2", "~> 2.1.0"
   require 'mini_portile2'
   message "Using mini_portile version #{MiniPortile::VERSION}\n"


### PR DESCRIPTION
This is a clarification of why #1393 was needed. It's not that `rspec-rails` fails without this, but any installation where rubygems is not available (we deliberately do this on rspec's suites for speed reasons).  It would be better to ensure rubygems is available before using it's components.