### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -622,7 +622,7 @@ module Nokogiri
         encoding = options[:encoding] || document.encoding
         options[:encoding] = encoding
 
-        outstring = ""
+        outstring = String.new
         if encoding && outstring.respond_to?(:force_encoding)
           outstring.force_encoding(Encoding.find(encoding))
         end


### PR DESCRIPTION
These changes are the minimal ones necessary to allow Sequel's specs
to pass. There may well be other changes that are required.