### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal - version 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,37 @@ dist: trusty
 group: beta
 sudo: required
 
-rvm:
-- 2.0
-- 2.1
-- 2.2.5
-- 2.3.1
-- 2.4.0
-- jruby-1.7
-- jruby-9.1.5.0
-- rbx-3
-
-os:
-- linux
-- osx
-
 matrix:
-  allow_failures:
-  # https://github.com/travis-ci/travis-ci/issues/5361
+  include:
+  - os: linux
+    rvm: 2.0
+  - os: osx
+    rvm: 2.0
+  - os: linux
+    rvm: 2.1
+  - os: osx
+    rvm: 2.1
+  - os: linux
+    rvm: 2.2.5
   - os: osx
     rvm: 2.2.5
+  - os: linux
+    rvm: 2.3.1
   - os: osx
     rvm: 2.3.1
   - os: linux
-    rvm: rbx-3
-  exclude:
+    rvm: 2.4.0
+    env:
+      - RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
   - os: osx
+    rvm: 2.4.0
+    env:
+      - RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
+  - os: linux
     rvm: jruby-1.7
-  - os: osx
+  - os: linux
     rvm: jruby-9.1.5.0
-  - os: osx
+  - os: linux
     rvm: rbx-3
 
 notifications:

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -223,8 +223,8 @@ def iconv_configure_flags
 
       return [
         '--with-iconv=yes',
-        *("CPPFLAGS=#{idirs.map { |dir| '-I' << dir }.join(' ')}" if idirs),
-        *("LDFLAGS=#{ldirs.map { |dir| '-L' << dir }.join(' ')}" if ldirs),
+        *("CPPFLAGS=#{idirs.map { |dir| '-I' + dir }.join(' ')}" if idirs),
+        *("LDFLAGS=#{ldirs.map { |dir| '-L' + dir }.join(' ')}" if ldirs),
       ]
     end
   end
@@ -307,7 +307,7 @@ def process_recipe(name, version, static_p, cross_p)
     if RbConfig::CONFIG['target_cpu'] == 'universal'
       %w[CFLAGS LDFLAGS].each do |key|
         unless env[key].include?('-arch')
-          env[key] << ' ' << RbConfig::CONFIG['ARCH_FLAG']
+          env[key] += ' ' + RbConfig::CONFIG['ARCH_FLAG']
         end
       end
     end

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -623,7 +623,7 @@ module Nokogiri
         encoding = options[:encoding] || document.encoding
         options[:encoding] = encoding
 
-        outstring = ""
+        outstring = String.new
         if encoding && outstring.respond_to?(:force_encoding)
           outstring.force_encoding(Encoding.find(encoding))
         end

--- a/lib/nokogiri/xml/sax/parser.rb
+++ b/lib/nokogiri/xml/sax/parser.rb
@@ -68,8 +68,7 @@ module Nokogiri
 
         # Create a new Parser with +doc+ and +encoding+
         def initialize doc = Nokogiri::XML::SAX::Document.new, encoding = 'UTF-8'
-          check_encoding(encoding)
-          @encoding = encoding
+          @encoding = check_encoding(encoding)
           @document = doc
           @warned   = false
         end
@@ -88,9 +87,8 @@ module Nokogiri
         ###
         # Parse given +io+
         def parse_io io, encoding = 'ASCII'
-          check_encoding(encoding)
-          @encoding = encoding
-          ctx = ParserContext.io(io, ENCODINGS[encoding])
+          @encoding = check_encoding(encoding)
+          ctx = ParserContext.io(io, ENCODINGS[@encoding])
           yield ctx if block_given?
           ctx.parse_with self
         end
@@ -114,8 +112,9 @@ module Nokogiri
 
         private
         def check_encoding(encoding)
-          encoding.upcase!
-          raise ArgumentError.new("'#{encoding}' is not a valid encoding") unless ENCODINGS[encoding]
+          encoding.upcase.tap do |enc|
+            raise ArgumentError.new("'#{enc}' is not a valid encoding") unless ENCODINGS[enc]
+          end
         end
       end
     end

--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -15,7 +15,7 @@ module Nokogiri
       end
 
       def test_does_not_fail_with_illformatted_html
-        doc = Nokogiri::HTML('"</html>";'.force_encoding(Encoding::BINARY))
+        doc = Nokogiri::HTML('"</html>";'.dup.force_encoding(Encoding::BINARY))
         assert_not_nil doc
       end
 

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -221,7 +221,7 @@ module Nokogiri
       end
 
       def test_pp
-        out = StringIO.new('')
+        out = StringIO.new(String.new)
         ::PP.pp @xml, out
         assert_operator out.string.length, :>, 0
       end


### PR DESCRIPTION
Although bundler is fixed on master in respect to the frozen string literal, no version was released with this fixes, so far. So the travis-ci tests fail before the tests can run, currently.

However when `rake test` is started without bundler, all tests pass.
