### PR TITLE
more robust 'pkg-config' in extconf.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@
 source "https://rubygems.org/"
 
 gem "mini_portile2", "~>2.1.0"
+gem "pkg-config", "~>1.1.7"
 
 gem "rdoc", "~>4.0", :group => [:development, :test]
 gem "hoe-bundler", ">=1.1", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -128,8 +128,8 @@ HOE = Hoe.spec 'nokogiri' do
 
   unless java?
     self.extra_deps += [
-      # Keep this version in sync with the one in extconf.rb !
-      ["mini_portile2",    "~> 2.1.0"],
+      ["mini_portile2",    "~> 2.1.0"], # keep version in sync with extconf.rb
+      ["pkg-config",       "~> 1.1.7"], # keep version in sync with extconf.rb
     ]
   end
 


### PR DESCRIPTION
in the case where `pkg-config` isn't installed, which appears to be the
case for lots of freebsd people, let's fall back to the pkg-config gem,
which knows how to parse .pc files.