### PR TITLE
Fix #1436 - compatibity with gem-compiler.

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -61,9 +61,10 @@ def do_clean
 
     if enable_config('static')
       # ports installation can be safely removed if statically linked.
-      FileUtils.rm_rf(root + 'ports', verbose: true)
-    else
-      FileUtils.rm_rf(root + 'ports' + 'archives', verbose: true)
+      Pathname.glob(root.join('ports', '*')) do |dir|
+        next if dir.fnmatch?('*/archives')
+        FileUtils.rm_rf(dir, verbose: true)
+      end
     end
   end
 


### PR DESCRIPTION
The extconf.rb clean task removes most of the files, that are used only while build. However this broke gem-compiler, because it removed the archives as well, although they are part of the gemspec.

With this patch the archives are kept on disk. The downside is, that it increases the disk space used by nokogiri from 21MB to 30MB after install.

An alternative is gem-compiler's option `--prune`, as described here: https://github.com/luislavena/gem-compiler/issues/12
