### PR TITLE
Frozen String Literal Compatibility

### DIFF
--- a/lib/nokogiri.rb
+++ b/lib/nokogiri.rb
@@ -115,15 +115,19 @@ module Nokogiri
     def Slop(*args, &block)
       Nokogiri(*args, &block).slop!
     end
+
+    def install_default_aliases
+      # Make sure to support some popular encoding aliases not known by
+      # all iconv implementations.
+      {
+        'Windows-31J' => 'CP932',	# Windows-31J is the IANA registered name of CP932.
+      }.each { |alias_name, name|
+        EncodingHandler.alias(name, alias_name) if EncodingHandler[alias_name].nil?
+      }
+    end
   end
 
-  # Make sure to support some popular encoding aliases not known by
-  # all iconv implementations.
-  {
-    'Windows-31J' => 'CP932',	# Windows-31J is the IANA registered name of CP932.
-  }.each { |alias_name, name|
-    EncodingHandler.alias(name, alias_name) if EncodingHandler[alias_name].nil?
-  }
+  Nokogiri.install_default_aliases
 end
 
 ###

--- a/lib/nokogiri.rb
+++ b/lib/nokogiri.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 # Modify the PATH on windows so that the external DLLs will get loaded.
 
 require 'rbconfig'

--- a/lib/nokogiri/css.rb
+++ b/lib/nokogiri/css.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'nokogiri/css/node'
 require 'nokogiri/css/xpath_visitor'
 x = $-w

--- a/lib/nokogiri/css/node.rb
+++ b/lib/nokogiri/css/node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module CSS
     class Node

--- a/lib/nokogiri/css/parser.rb
+++ b/lib/nokogiri/css/parser.rb
@@ -320,42 +320,42 @@ Racc_debug_parser = false
 
 def _reduce_1(val, _values, result)
         result = [val.first, val.last].flatten
-      
+
     result
 end
 
 def _reduce_2(val, _values, result)
- result = val.flatten 
+ result = val.flatten
     result
 end
 
 def _reduce_3(val, _values, result)
- result = [val.last].flatten 
+ result = [val.last].flatten
     result
 end
 
 def _reduce_4(val, _values, result)
- result = :DIRECT_ADJACENT_SELECTOR 
+ result = :DIRECT_ADJACENT_SELECTOR
     result
 end
 
 def _reduce_5(val, _values, result)
- result = :CHILD_SELECTOR 
+ result = :CHILD_SELECTOR
     result
 end
 
 def _reduce_6(val, _values, result)
- result = :FOLLOWING_SELECTOR 
+ result = :FOLLOWING_SELECTOR
     result
 end
 
 def _reduce_7(val, _values, result)
- result = :DESCENDANT_SELECTOR 
+ result = :DESCENDANT_SELECTOR
     result
 end
 
 def _reduce_8(val, _values, result)
- result = :CHILD_SELECTOR 
+ result = :CHILD_SELECTOR
     result
 end
 
@@ -365,7 +365,7 @@ def _reduce_9(val, _values, result)
                   else
                     Node.new(:CONDITIONAL_SELECTOR, [val.first, val[1]])
                   end
-      
+
     result
 end
 
@@ -373,13 +373,13 @@ end
 
 def _reduce_11(val, _values, result)
         result = Node.new(:CONDITIONAL_SELECTOR, val)
-      
+
     result
 end
 
 def _reduce_12(val, _values, result)
         result = Node.new(:CONDITIONAL_SELECTOR, val)
-      
+
     result
 end
 
@@ -387,39 +387,39 @@ def _reduce_13(val, _values, result)
         result = Node.new(:CONDITIONAL_SELECTOR,
           [Node.new(:ELEMENT_NAME, ['*']), val.first]
         )
-      
+
     result
 end
 
 def _reduce_14(val, _values, result)
         result = Node.new(val.first, [nil, val.last])
-      
+
     result
 end
 
 def _reduce_15(val, _values, result)
         result = Node.new(val[1], [val.first, val.last])
-      
+
     result
 end
 
 def _reduce_16(val, _values, result)
         result = Node.new(:DESCENDANT_SELECTOR, [val.first, val.last])
-      
+
     result
 end
 
 # reduce 17 omitted
 
 def _reduce_18(val, _values, result)
- result = Node.new(:CLASS_CONDITION, [unescape_css_identifier(val[1])]) 
+ result = Node.new(:CLASS_CONDITION, [unescape_css_identifier(val[1])])
     result
 end
 
 # reduce 19 omitted
 
 def _reduce_20(val, _values, result)
- result = Node.new(:ELEMENT_NAME, val) 
+ result = Node.new(:ELEMENT_NAME, val)
     result
 end
 
@@ -427,19 +427,19 @@ def _reduce_21(val, _values, result)
         result = Node.new(:ELEMENT_NAME,
           [[val.first, val.last].compact.join(':')]
         )
-      
+
     result
 end
 
 def _reduce_22(val, _values, result)
         name = @namespaces.key?('xmlns') ? "xmlns:#{val.first}" : val.first
         result = Node.new(:ELEMENT_NAME, [name])
-      
+
     result
 end
 
 def _reduce_23(val, _values, result)
- result = val[0] 
+ result = val[0]
     result
 end
 
@@ -449,7 +449,7 @@ def _reduce_25(val, _values, result)
         result = Node.new(:ATTRIBUTE_CONDITION,
           [val[1]] + (val[2] || [])
         )
-      
+
     result
 end
 
@@ -457,7 +457,7 @@ def _reduce_26(val, _values, result)
         result = Node.new(:ATTRIBUTE_CONDITION,
           [val[1]] + (val[2] || [])
         )
-      
+
     result
 end
 
@@ -466,7 +466,7 @@ def _reduce_27(val, _values, result)
         result = Node.new(:PSEUDO_CLASS,
           [Node.new(:FUNCTION, ['nth-child(', val[1]])]
         )
-      
+
     result
 end
 
@@ -474,7 +474,7 @@ def _reduce_28(val, _values, result)
         result = Node.new(:ELEMENT_NAME,
           [[val.first, val.last].compact.join(':')]
         )
-      
+
     result
 end
 
@@ -482,52 +482,52 @@ def _reduce_29(val, _values, result)
         # Default namespace is not applied to attributes.
         # So we don't add prefix "xmlns:" as in namespaced_ident.
         result = Node.new(:ELEMENT_NAME, [val.first])
-      
+
     result
 end
 
 def _reduce_30(val, _values, result)
         result = Node.new(:FUNCTION, [val.first.strip])
-      
+
     result
 end
 
 def _reduce_31(val, _values, result)
         result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
-      
+
     result
 end
 
 def _reduce_32(val, _values, result)
         result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
-      
+
     result
 end
 
 def _reduce_33(val, _values, result)
         result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
-      
+
     result
 end
 
 def _reduce_34(val, _values, result)
         result = Node.new(:FUNCTION, [val.first.strip, val[1]].flatten)
-      
+
     result
 end
 
 def _reduce_35(val, _values, result)
- result = [val.first, val.last] 
+ result = [val.first, val.last]
     result
 end
 
 def _reduce_36(val, _values, result)
- result = [val.first, val.last] 
+ result = [val.first, val.last]
     result
 end
 
 def _reduce_37(val, _values, result)
- result = [val.first, val.last] 
+ result = [val.first, val.last]
     result
 end
 
@@ -550,7 +550,7 @@ def _reduce_40(val, _values, result)
           # assert_xpath("//a[foo(., a, 10)]", @parser.parse('a:foo(a, 10)'))
           result = val
         end
-      
+
     result
 end
 
@@ -560,7 +560,7 @@ def _reduce_41(val, _values, result)
         else
           raise Racc::ParseError, "parse error on IDENT '#{val[1]}'"
         end
-      
+
     result
 end
 
@@ -576,7 +576,7 @@ def _reduce_42(val, _values, result)
         else
           raise Racc::ParseError, "parse error on IDENT '#{val[1]}'"
         end
-      
+
     result
 end
 
@@ -596,18 +596,18 @@ def _reduce_43(val, _values, result)
         else
           raise Racc::ParseError, "parse error on IDENT '#{val[1]}'"
         end
-      
+
     result
 end
 
 def _reduce_44(val, _values, result)
         result = Node.new(:PSEUDO_CLASS, [val[1]])
-      
+
     result
 end
 
 def _reduce_45(val, _values, result)
- result = Node.new(:PSEUDO_CLASS, [val[1]]) 
+ result = Node.new(:PSEUDO_CLASS, [val[1]])
     result
 end
 
@@ -617,31 +617,31 @@ end
 
 def _reduce_48(val, _values, result)
         result = Node.new(:COMBINATOR, val)
-      
+
     result
 end
 
 def _reduce_49(val, _values, result)
         result = Node.new(:COMBINATOR, val)
-      
+
     result
 end
 
 def _reduce_50(val, _values, result)
         result = Node.new(:COMBINATOR, val)
-      
+
     result
 end
 
 def _reduce_51(val, _values, result)
         result = Node.new(:COMBINATOR, val)
-      
+
     result
 end
 
 def _reduce_52(val, _values, result)
         result = Node.new(:COMBINATOR, val)
-      
+
     result
 end
 
@@ -656,60 +656,60 @@ end
 # reduce 57 omitted
 
 def _reduce_58(val, _values, result)
- result = Node.new(:ID, [unescape_css_identifier(val.first)]) 
+ result = Node.new(:ID, [unescape_css_identifier(val.first)])
     result
 end
 
 def _reduce_59(val, _values, result)
- result = [val.first, val[1]] 
+ result = [val.first, val[1]]
     result
 end
 
 def _reduce_60(val, _values, result)
- result = [val.first, val[1]] 
+ result = [val.first, val[1]]
     result
 end
 
 # reduce 61 omitted
 
 def _reduce_62(val, _values, result)
- result = :equal 
+ result = :equal
     result
 end
 
 def _reduce_63(val, _values, result)
- result = :prefix_match 
+ result = :prefix_match
     result
 end
 
 def _reduce_64(val, _values, result)
- result = :suffix_match 
+ result = :suffix_match
     result
 end
 
 def _reduce_65(val, _values, result)
- result = :substring_match 
+ result = :substring_match
     result
 end
 
 def _reduce_66(val, _values, result)
- result = :not_equal 
+ result = :not_equal
     result
 end
 
 def _reduce_67(val, _values, result)
- result = :includes 
+ result = :includes
     result
 end
 
 def _reduce_68(val, _values, result)
- result = :dash_match 
+ result = :dash_match
     result
 end
 
 def _reduce_69(val, _values, result)
         result = Node.new(:NOT, [val[1]])
-      
+
     result
 end
 

--- a/lib/nokogiri/css/parser_extras.rb
+++ b/lib/nokogiri/css/parser_extras.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'thread'
 
 module Nokogiri

--- a/lib/nokogiri/css/syntax_error.rb
+++ b/lib/nokogiri/css/syntax_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'nokogiri/syntax_error'
 module Nokogiri
   module CSS

--- a/lib/nokogiri/css/xpath_visitor.rb
+++ b/lib/nokogiri/css/xpath_visitor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module CSS
     class XPathVisitor # :nodoc:

--- a/lib/nokogiri/decorators/slop.rb
+++ b/lib/nokogiri/decorators/slop.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module Decorators
     ###

--- a/lib/nokogiri/html.rb
+++ b/lib/nokogiri/html.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'nokogiri/html/entity_lookup'
 require 'nokogiri/html/document'
 require 'nokogiri/html/document_fragment'

--- a/lib/nokogiri/html/builder.rb
+++ b/lib/nokogiri/html/builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module HTML
     ###

--- a/lib/nokogiri/html/document.rb
+++ b/lib/nokogiri/html/document.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module HTML
     class Document < Nokogiri::XML::Document

--- a/lib/nokogiri/html/document_fragment.rb
+++ b/lib/nokogiri/html/document_fragment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module HTML
     class DocumentFragment < Nokogiri::XML::DocumentFragment

--- a/lib/nokogiri/html/element_description.rb
+++ b/lib/nokogiri/html/element_description.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module HTML
     class ElementDescription

--- a/lib/nokogiri/html/element_description_defaults.rb
+++ b/lib/nokogiri/html/element_description_defaults.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module HTML
     class ElementDescription

--- a/lib/nokogiri/html/entity_lookup.rb
+++ b/lib/nokogiri/html/entity_lookup.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module HTML
     class EntityDescription < Struct.new(:value, :name, :description); end

--- a/lib/nokogiri/html/sax/parser.rb
+++ b/lib/nokogiri/html/sax/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module HTML
     ###

--- a/lib/nokogiri/html/sax/parser_context.rb
+++ b/lib/nokogiri/html/sax/parser_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module HTML
     module SAX

--- a/lib/nokogiri/html/sax/push_parser.rb
+++ b/lib/nokogiri/html/sax/push_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module HTML
     module SAX

--- a/lib/nokogiri/syntax_error.rb
+++ b/lib/nokogiri/syntax_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   class SyntaxError < ::StandardError
   end

--- a/lib/nokogiri/version.rb
+++ b/lib/nokogiri/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   # The version of Nokogiri you are using
   VERSION = '1.6.8.rc3'

--- a/lib/nokogiri/xml.rb
+++ b/lib/nokogiri/xml.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'nokogiri/xml/pp'
 require 'nokogiri/xml/parse_options'
 require 'nokogiri/xml/sax'

--- a/lib/nokogiri/xml/attr.rb
+++ b/lib/nokogiri/xml/attr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class Attr < Node

--- a/lib/nokogiri/xml/attribute_decl.rb
+++ b/lib/nokogiri/xml/attribute_decl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     ###

--- a/lib/nokogiri/xml/builder.rb
+++ b/lib/nokogiri/xml/builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     ###

--- a/lib/nokogiri/xml/cdata.rb
+++ b/lib/nokogiri/xml/cdata.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class CDATA < Nokogiri::XML::Text

--- a/lib/nokogiri/xml/character_data.rb
+++ b/lib/nokogiri/xml/character_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class CharacterData < Nokogiri::XML::Node

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     ##

--- a/lib/nokogiri/xml/document_fragment.rb
+++ b/lib/nokogiri/xml/document_fragment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class DocumentFragment < Nokogiri::XML::Node

--- a/lib/nokogiri/xml/dtd.rb
+++ b/lib/nokogiri/xml/dtd.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class DTD < Nokogiri::XML::Node

--- a/lib/nokogiri/xml/element_content.rb
+++ b/lib/nokogiri/xml/element_content.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     ###

--- a/lib/nokogiri/xml/element_decl.rb
+++ b/lib/nokogiri/xml/element_decl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class ElementDecl < Nokogiri::XML::Node

--- a/lib/nokogiri/xml/entity_decl.rb
+++ b/lib/nokogiri/xml/entity_decl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class EntityDecl < Nokogiri::XML::Node

--- a/lib/nokogiri/xml/namespace.rb
+++ b/lib/nokogiri/xml/namespace.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class Namespace

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 require 'stringio'
 require 'nokogiri/xml/node/save_options'
 
@@ -622,7 +623,7 @@ module Nokogiri
         encoding = options[:encoding] || document.encoding
         options[:encoding] = encoding
 
-        outstring = ""
+        outstring = String.new("")
         if encoding && outstring.respond_to?(:force_encoding)
           outstring.force_encoding(Encoding.find(encoding))
         end

--- a/lib/nokogiri/xml/node/save_options.rb
+++ b/lib/nokogiri/xml/node/save_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class Node

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     ####

--- a/lib/nokogiri/xml/notation.rb
+++ b/lib/nokogiri/xml/notation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class Notation < Struct.new(:name, :public_id, :system_id)

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     ###

--- a/lib/nokogiri/xml/pp.rb
+++ b/lib/nokogiri/xml/pp.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require 'nokogiri/xml/pp/node'
 require 'nokogiri/xml/pp/character_data'

--- a/lib/nokogiri/xml/pp/character_data.rb
+++ b/lib/nokogiri/xml/pp/character_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     module PP

--- a/lib/nokogiri/xml/pp/node.rb
+++ b/lib/nokogiri/xml/pp/node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     module PP

--- a/lib/nokogiri/xml/processing_instruction.rb
+++ b/lib/nokogiri/xml/processing_instruction.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class ProcessingInstruction < Node

--- a/lib/nokogiri/xml/reader.rb
+++ b/lib/nokogiri/xml/reader.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     ###

--- a/lib/nokogiri/xml/relax_ng.rb
+++ b/lib/nokogiri/xml/relax_ng.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class << self

--- a/lib/nokogiri/xml/sax.rb
+++ b/lib/nokogiri/xml/sax.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'nokogiri/xml/sax/document'
 require 'nokogiri/xml/sax/parser_context'
 require 'nokogiri/xml/sax/parser'

--- a/lib/nokogiri/xml/sax/document.rb
+++ b/lib/nokogiri/xml/sax/document.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     ###

--- a/lib/nokogiri/xml/sax/parser.rb
+++ b/lib/nokogiri/xml/sax/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     module SAX
@@ -68,8 +69,7 @@ module Nokogiri
 
         # Create a new Parser with +doc+ and +encoding+
         def initialize doc = Nokogiri::XML::SAX::Document.new, encoding = 'UTF-8'
-          check_encoding(encoding)
-          @encoding = encoding
+          @encoding = check_encoding(encoding)
           @document = doc
           @warned   = false
         end
@@ -88,9 +88,8 @@ module Nokogiri
         ###
         # Parse given +io+
         def parse_io io, encoding = 'ASCII'
-          check_encoding(encoding)
-          @encoding = encoding
-          ctx = ParserContext.io(io, ENCODINGS[encoding])
+          @encoding = check_encoding(encoding)
+          ctx = ParserContext.io(io, ENCODINGS[@encoding])
           yield ctx if block_given?
           ctx.parse_with self
         end
@@ -114,8 +113,11 @@ module Nokogiri
 
         private
         def check_encoding(encoding)
+          #encoding may be frozen
+          encoding = encoding.dup if encoding.frozen?
           encoding.upcase!
           raise ArgumentError.new("'#{encoding}' is not a valid encoding") unless ENCODINGS[encoding]
+          encoding
         end
       end
     end

--- a/lib/nokogiri/xml/sax/parser_context.rb
+++ b/lib/nokogiri/xml/sax/parser_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     module SAX

--- a/lib/nokogiri/xml/sax/push_parser.rb
+++ b/lib/nokogiri/xml/sax/push_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     module SAX

--- a/lib/nokogiri/xml/schema.rb
+++ b/lib/nokogiri/xml/schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class << self

--- a/lib/nokogiri/xml/searchable.rb
+++ b/lib/nokogiri/xml/searchable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     #

--- a/lib/nokogiri/xml/syntax_error.rb
+++ b/lib/nokogiri/xml/syntax_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     ###

--- a/lib/nokogiri/xml/text.rb
+++ b/lib/nokogiri/xml/text.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class Text < Nokogiri::XML::CharacterData

--- a/lib/nokogiri/xml/xpath.rb
+++ b/lib/nokogiri/xml/xpath.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'nokogiri/xml/xpath/syntax_error'
 
 module Nokogiri

--- a/lib/nokogiri/xml/xpath/syntax_error.rb
+++ b/lib/nokogiri/xml/xpath/syntax_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class XPath

--- a/lib/nokogiri/xml/xpath_context.rb
+++ b/lib/nokogiri/xml/xpath_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XML
     class XPathContext

--- a/lib/nokogiri/xslt.rb
+++ b/lib/nokogiri/xslt.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'nokogiri/xslt/stylesheet'
 
 module Nokogiri

--- a/lib/nokogiri/xslt/stylesheet.rb
+++ b/lib/nokogiri/xslt/stylesheet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nokogiri
   module XSLT
     ###

--- a/lib/xsd/xmlparser/nokogiri.rb
+++ b/lib/xsd/xmlparser/nokogiri.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'nokogiri'
 
 module XSD # :nodoc:

--- a/tasks/test.rb
+++ b/tasks/test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :test do
   desc "run test suite with aggressive GC"
   task :gc => :build do

--- a/test/css/test_nthiness.rb
+++ b/test/css/test_nthiness.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/css/test_parser.rb
+++ b/test/css/test_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/css/test_tokenizer.rb
+++ b/test/css/test_tokenizer.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/css/test_xpath_visitor.rb
+++ b/test/css/test_xpath_visitor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/decorators/test_slop.rb
+++ b/test/decorators/test_slop.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #Process.setrlimit(Process::RLIMIT_CORE, Process::RLIM_INFINITY) unless RUBY_PLATFORM =~ /(java|mswin|mingw)/i
 $VERBOSE = true
 require 'minitest/autorun'

--- a/test/html/sax/test_parser.rb
+++ b/test/html/sax/test_parser.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/html/sax/test_parser_context.rb
+++ b/test/html/sax/test_parser_context.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/html/sax/test_push_parser.rb
+++ b/test/html/sax/test_push_parser.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/html/test_builder.rb
+++ b/test/html/test_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri
@@ -15,7 +16,7 @@ module Nokogiri
       end
 
       def test_does_not_fail_with_illformatted_html
-        doc = Nokogiri::HTML('"</html>";'.force_encoding(Encoding::BINARY))
+        doc = Nokogiri::HTML(String.new('"</html>";').force_encoding(Encoding::BINARY))
         assert_not_nil doc
       end
 

--- a/test/html/test_document_encoding.rb
+++ b/test/html/test_document_encoding.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/html/test_document_fragment.rb
+++ b/test/html/test_document_fragment.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/html/test_element_description.rb
+++ b/test/html/test_element_description.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/html/test_named_characters.rb
+++ b/test/html/test_named_characters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/html/test_node.rb
+++ b/test/html/test_node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 require 'nkf'

--- a/test/html/test_node_encoding.rb
+++ b/test/html/test_node_encoding.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/namespaces/test_additional_namespaces_in_builder_doc.rb
+++ b/test/namespaces/test_additional_namespaces_in_builder_doc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/namespaces/test_namespaces_aliased_default.rb
+++ b/test/namespaces/test_namespaces_aliased_default.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/namespaces/test_namespaces_in_builder_doc.rb
+++ b/test/namespaces/test_namespaces_in_builder_doc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/namespaces/test_namespaces_in_cloned_doc.rb
+++ b/test/namespaces/test_namespaces_in_cloned_doc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/namespaces/test_namespaces_in_created_doc.rb
+++ b/test/namespaces/test_namespaces_in_created_doc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/namespaces/test_namespaces_in_parsed_doc.rb
+++ b/test/namespaces/test_namespaces_in_parsed_doc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/namespaces/test_namespaces_preservation.rb
+++ b/test/namespaces/test_namespaces_preservation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri
@@ -13,14 +14,14 @@ module Nokogiri
             eoxml
       end
 
-      def test_xpath   
+      def test_xpath
         first = @xml.at_xpath('//xs:element', 'xs' => 'http://www.w3.org/2001/XMLSchema')
         last = @xml.at_xpath('//xs:element[last()]', 'xs' => 'http://www.w3.org/2001/XMLSchema')
         assert_equal 'http://api.geotrust.com/webtrust/query' , first.namespaces['xmlns:quer'], "Should contain quer namespace"
         assert_equal 'http://api.geotrust.com/webtrust/query' , last.namespaces['xmlns:quer'], "Should contain quer namespace"
       end
 
-      def test_traversing   
+      def test_traversing
         first = @xml.root.element_children.first
         last = @xml.root.element_children.last
         assert_equal 'http://api.geotrust.com/webtrust/query' , first.namespaces['xmlns:quer'], "Should contain quer namespace"

--- a/test/test_convert_xpath.rb
+++ b/test/test_convert_xpath.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 class TestConvertXPath < Nokogiri::TestCase

--- a/test/test_css_cache.rb
+++ b/test/test_css_cache.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 class TestCssCache < Nokogiri::TestCase

--- a/test/test_encoding_handler.rb
+++ b/test/test_encoding_handler.rb
@@ -6,6 +6,8 @@ require "helper"
 class TestEncodingHandler < Nokogiri::TestCase
   def teardown
     Nokogiri::EncodingHandler.clear_aliases!
+    #Replace default aliases removed by clear_aliases!
+    Nokogiri.install_default_aliases
   end
 
   def test_get

--- a/test/test_encoding_handler.rb
+++ b/test/test_encoding_handler.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/test_memory_leak.rb
+++ b/test/test_memory_leak.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 class TestMemoryLeak < Nokogiri::TestCase

--- a/test/test_nokogiri.rb
+++ b/test/test_nokogiri.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 class TestNokogiri < Nokogiri::TestCase

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 require "helper"
 
 class TestReader < Nokogiri::TestCase

--- a/test/test_soap4r_sax.rb
+++ b/test/test_soap4r_sax.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module XSD

--- a/test/test_xslt_transforms.rb
+++ b/test/test_xslt_transforms.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 class TestXsltTransforms < Nokogiri::TestCase

--- a/test/xml/node/test_save_options.rb
+++ b/test/xml/node/test_save_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/node/test_subclass.rb
+++ b/test/xml/node/test_subclass.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/sax/test_parser.rb
+++ b/test/xml/sax/test_parser.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/xml/sax/test_parser_context.rb
+++ b/test/xml/sax/test_parser_context.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/xml/sax/test_push_parser.rb
+++ b/test/xml/sax/test_push_parser.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/xml/test_attr.rb
+++ b/test/xml/test_attr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_attribute_decl.rb
+++ b/test/xml/test_attribute_decl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_builder.rb
+++ b/test/xml/test_builder.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/xml/test_c14n.rb
+++ b/test/xml/test_c14n.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_cdata.rb
+++ b/test/xml/test_cdata.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_comment.rb
+++ b/test/xml/test_comment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 require 'uri'
@@ -221,7 +222,7 @@ module Nokogiri
       end
 
       def test_pp
-        out = StringIO.new('')
+        out = StringIO.new(String.new(''))
         ::PP.pp @xml, out
         assert_operator out.string.length, :>, 0
       end

--- a/test/xml/test_document_encoding.rb
+++ b/test/xml/test_document_encoding.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_dtd.rb
+++ b/test/xml/test_dtd.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_dtd_encoding.rb
+++ b/test/xml/test_dtd_encoding.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/xml/test_element_content.rb
+++ b/test/xml/test_element_content.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_element_decl.rb
+++ b/test/xml/test_element_decl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_entity_decl.rb
+++ b/test/xml/test_entity_decl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_entity_reference.rb
+++ b/test/xml/test_entity_reference.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_namespace.rb
+++ b/test/xml/test_namespace.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 require 'stringio'

--- a/test/xml/test_node_attributes.rb
+++ b/test/xml/test_node_attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_node_encoding.rb
+++ b/test/xml/test_node_encoding.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_node_inheritance.rb
+++ b/test/xml/test_node_inheritance.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # issue#560
 
 require 'helper'

--- a/test/xml/test_node_reparenting.rb
+++ b/test/xml/test_node_reparenting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_parse_options.rb
+++ b/test/xml/test_parse_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_processing_instruction.rb
+++ b/test/xml/test_processing_instruction.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_reader_encoding.rb
+++ b/test/xml/test_reader_encoding.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_relax_ng.rb
+++ b/test/xml/test_relax_ng.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_syntax_error.rb
+++ b/test/xml/test_syntax_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_text.rb
+++ b/test/xml/test_text.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_unparented_node.rb
+++ b/test/xml/test_unparented_node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 require 'stringio'

--- a/test/xml/test_xinclude.rb
+++ b/test/xml/test_xinclude.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri

--- a/test/xslt/test_custom_functions.rb
+++ b/test/xslt/test_custom_functions.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 
 require "helper"
 

--- a/test/xslt/test_exception_handling.rb
+++ b/test/xslt/test_exception_handling.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri


### PR DESCRIPTION
Turns on frozen string literals in 2.3.0+ and fixes code for it.
