### PR TITLE
Made documentation better for ParseOptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Issue and Pull Request Guidlines
+# Issue and Pull Request Guidelines
 
 Thank you for getting involved in making Nokogiri better!
 

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -2,6 +2,28 @@ module Nokogiri
   module XML
     ###
     # Parse options for passing to Nokogiri.XML or Nokogiri.HTML
+    #
+    # == Building combinations of parse options
+    # You can build your own combinations of these parse options by using any of the following methods:
+    # *Note*: All examples attempt to set the +RECOVER+ & +NOENT+ options. All examples use Ruby 2 optional parameter syntax.
+    # [Ruby's bitwise operators] You can use the Ruby bitwise operators to set various combinations.
+    #   <code>Nokogiri.XML('<content>Chapter 1</content', options: Nokogiri::XML::ParseOptions.new((1 << 0) | (1 << 1)))</code>
+    # [Method chaining] Every option has an equivalent method in lowercase. You can chain these methods together to set various combinations.
+    #   <code>Nokogiri.XML('<content>Chapter 1</content', options: Nokogiri::XML::ParseOptions.new.recover.noent)</code>
+    # [Using Ruby Blocks] You can also setup parse combinations in the block passed to Nokogiri.XML or Nokogiri.HTML
+    #   <code>Nokogiri.XML('<content>Chapter 1</content') {|config| config.recover.noent}</code>
+    #
+    # == Removing particular parse options
+    # You can also remove options from an instance of +ParseOptions+ dynamically.
+    # Every option has an equivalent <code>no{option}</code> method in lowercase. You can call these methods on an instance of +ParseOptions+ to remove the option.
+    # Note that this is not available for +STRICT+.
+    #
+    #   # Setting the RECOVER & NOENT options...
+    #   options = Nokogiri::XML::ParseOptions.new.recover.noent
+    #   # later...
+    #   options.norecover # Removes the Nokogiri::XML::ParseOptions::RECOVER option
+    #   options.nonoent # Removes the Nokogiri::XML::ParseOptions::NOENT option
+    #
     class ParseOptions
       # Strict parsing
       STRICT      = 0


### PR DESCRIPTION
Hello,

We were working with Nokogiri, when we found that the ParseOptions class was hard to understand. In the [documentation](http://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri/XML/ParseOptions), available methods were not documented, so we thought we can improve it. Hope you accept it.

Regards,
Shivasubramanian A