### PR TITLE
Set CC as the RbConfig's one

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -364,6 +364,8 @@ when arg_config('--clean')
 end
 
 RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
+# use same c compiler for libxml and libxslt
+ENV['CC'] = RbConfig::MAKEFILE_CONFIG['CC']
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'macruby'
   $LIBRUBYARG_STATIC.gsub!(/-static/, '')


### PR DESCRIPTION
To use the same C compiler with the Ruby.
If they are different, it may cause an issue.

For example a FreeBSD environment which has gcc and libiconv from
pkg/ports, which are installed in /usr/local.
The normal Ruby installation uses cc (clang).
But when nokogiri runs extconf.rb, libxml uses gcc by its configure,
and it uses libiconv (-liconv), instead of FreeBSD libc's iconv
because port's gcc sees /usr/local by default.
Then extconf.rb runs have_library('xml2', 'xmlParseDoc', 'libxml/parser.h')
but it fails to find -liconv because extconf.rb's try_compile uses
Ruby's CC (cc) and which doesn't see /usr/local.