### PR TITLE
Double quotes in HTML attributes should be escaped as &quot; not %22

### DIFF
--- a/ext/java/nokogiri/XmlAttr.java
+++ b/ext/java/nokogiri/XmlAttr.java
@@ -129,9 +129,7 @@ public class XmlAttr extends XmlNode{
             case '\n': buffer.append("&#10;"); break;
             case '\r': buffer.append("&#13;"); break;
             case '\t': buffer.append("&#9;"); break;
-            case '"': if (htmlDoc) buffer.append("%22"); 
-                else buffer.append("&quot;");
-                break;
+            case '"': buffer.append("&quot;"); break;
             case '<': buffer.append("&lt;"); break;
             case '>': buffer.append("&gt;"); break;
             case '&': buffer.append("&amp;"); break;

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -312,9 +312,7 @@ public class SaveContextVisitor {
             case '\n': buffer.append("&#10;"); break;
             case '\r': buffer.append("&#13;"); break;
             case '\t': buffer.append("&#9;"); break;
-            case '"': if (htmlDoc) buffer.append("%22");
-                else buffer.append("&quot;");
-                break;
+            case '"': buffer.append("&quot;"); break;
             case '<': buffer.append("&lt;"); break;
             case '>': buffer.append("&gt;"); break;
             case '&': buffer.append("&amp;"); break;

--- a/test/html/test_node.rb
+++ b/test/html/test_node.rb
@@ -31,7 +31,7 @@ module Nokogiri
         assert_equal 'baz', element.get_attribute('class')
         assert_equal 'baz', element['class']
         element['href'] = "javascript:alert(\"AGGA-KA-BOO!\")"
-        assert_match(/%22AGGA-KA-BOO!%22/, element.to_html)
+        assert_match(/&quot;AGGA-KA-BOO!&quot;/, element.to_html)
       end
 
       # The HTML parser ignores namespaces, so even properly declared namespaces


### PR DESCRIPTION
Hi!

This fixes #1382 , or aims to.  I have searched a lot, but I cannot find any source claiming that double quotes should be escaped as `%22` in HTML attributes.  `&quot;` seems to be the common escape sequence, although there are others.

I have not found where the C-based Nokogiri does the escaping, yet.  I'd like to fix that too, but I could need some pointers.

As described in issue #1382 , the C-based Rubies work as expected in IRB, but they fail the modified unit test (test/html/test_node.rb#test_get_attribute).  They still escape the double quote to `%22`.

Anyway, I'm looking forward to the discussion on this PR.  I will learn something either way. 😄 
