### PR TITLE
add example to NodeSet#inner_text

### DIFF
--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -190,6 +190,17 @@ module Nokogiri
 
       ###
       # Get the inner text of all contained Node objects
+      #
+      # Note: This joins the text of all Node objects in the NodeSet:
+      #
+      #    doc = Nokogiri::XML('<xml><a><d>foo</d><d>bar</d></a></xml>')
+      #    doc.css('d').text # => "foobar"
+      #
+      # Instead, if you want to return the text of all nodes in the NodeSet:
+      #
+      #    doc.css('d').map(&:text) # => ["foo", "bar"]
+      #
+      # See Nokogiri::XML::Node#content for more information.
       def inner_text
         collect(&:inner_text).join('')
       end


### PR DESCRIPTION
There have been innumerable questions on Stack Overflow about `NodeSet.text` not returning the expected results of individual text elements from the NodeSet items. This change adds an example of the difference and references `Node.inner_text`.