### PR TITLE
Make the pkg-config gem optional.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@
 source "https://rubygems.org/"
 
 gem "mini_portile2", "~>2.1.0"
-gem "pkg-config", "~>1.1.7"
 
 gem "rdoc", "~>4.0", :group => [:development, :test]
 gem "hoe-bundler", "~>1.2.0", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -126,7 +126,6 @@ HOE = Hoe.spec 'nokogiri' do
   unless java?
     self.extra_deps += [
       ["mini_portile2",    "~> 2.1.0"], # keep version in sync with extconf.rb
-      ["pkg-config",       "~> 1.1.7"], # keep version in sync with extconf.rb
     ]
   end
 

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -106,27 +106,28 @@ def do_clean
   exit! 0
 end
 
-# The gem version constraint in the Rakefile is not respected at install time.
-# Keep this version in sync with the one in the Rakefile !
-require 'rubygems'
-gem 'pkg-config', '~> 1.1.7'
-require 'pkg-config'
-message "Using pkg-config version #{PKGConfig::VERSION}\n"
-
 def package_config pkg, options={}
   package = pkg_config(pkg)
   return package if package
 
-  return nil unless PKGConfig.have_package(pkg)
+  begin
+    require 'rubygems'
+    gem 'pkg-config', (gem_ver='~> 1.1.7')
+    require 'pkg-config' and message("Using pkg-config gem version #{PKGConfig::VERSION}\n")
+  rescue LoadError
+    message "pkg-config could not be used to find #{pkg}\nPlease install either `pkg-config` or the pkg-config gem per\n\n    gem install pkg-config -v #{gem_ver.inspect}\n\n"
+  else
+    return nil unless PKGConfig.have_package(pkg)
 
-  cflags  = PKGConfig.cflags(pkg)
-  ldflags = PKGConfig.libs_only_L(pkg)
-  libs    = PKGConfig.libs_only_l(pkg)
+    cflags  = PKGConfig.cflags(pkg)
+    ldflags = PKGConfig.libs_only_L(pkg)
+    libs    = PKGConfig.libs_only_l(pkg)
 
-  Logging::message "PKGConfig package configuration for %s\n", pkg
-  Logging::message "cflags: %s\nldflags: %s\nlibs: %s\n\n", cflags, ldflags, libs
+    Logging::message "PKGConfig package configuration for %s\n", pkg
+    Logging::message "cflags: %s\nldflags: %s\nlibs: %s\n\n", cflags, ldflags, libs
 
-  [cflags, ldflags, libs]
+    [cflags, ldflags, libs]
+  end
 end
 
 def nokogiri_try_compile


### PR DESCRIPTION
Using the pkg-config gem as a runtime dependency of nokogiri results in a license conflict. pkg-config is LGPL but nokogiri is MIT.

Making the pkg-config gem optional solves this issue.

Fixes #1488 and #1496 .
