### PR TITLE
NodeSet#clone is now an alias for #dup.

### DIFF
--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -11,6 +11,8 @@ module Nokogiri
       # The Document this NodeSet is associated with
       attr_accessor :document
 
+      alias :clone :dup
+
       # Create a NodeSet with +document+ defaulting to +list+
       def initialize document, list = []
         @document = document


### PR DESCRIPTION
See https://github.com/sparklemotion/nokogiri/commit/708d62f3c91c3eb21c949c48f5475ce90a525df1
