### PR TITLE
Introduce a GitHub Issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+**What difficulties are you experiencing?**
+
+**Have you tried following [the installation tutorial][tutorial]?**
+
+**What is the output of `gem install`?**
+
+**What are the contents of the `mkmf.log` file?**
+
+**What operating system are you using?**
+
+[tutorial]: http://www.nokogiri.org/tutorials/installing_nokogiri.html


### PR DESCRIPTION
https://github.com/sparklemotion/nokogiri/issues/1504#issuecomment-231713864

In @flavorjones response to #1504, he describes the proper way to open a
Nokogiri installation issue.

In an effort to improve the quality of issues opened against the
repository, this commit introduces a [GitHub Issue Template][blog].

[blog]: https://github.com/blog/2111-issue-and-pull-request-templates