### PR TITLE
Avoid Fixnum deprecation warning on Ruby trunk

### DIFF
--- a/lib/nokogiri/html/document.rb
+++ b/lib/nokogiri/html/document.rb
@@ -161,7 +161,7 @@ module Nokogiri
         # Nokogiri::XML::ParseOptions.
         def parse string_or_io, url = nil, encoding = nil, options = XML::ParseOptions::DEFAULT_HTML
 
-          options = Nokogiri::XML::ParseOptions.new(options) if Fixnum === options
+          options = Nokogiri::XML::ParseOptions.new(options) if Integer === options
           # Give the options to the user
           yield options if block_given?
 

--- a/lib/nokogiri/xml.rb
+++ b/lib/nokogiri/xml.rb
@@ -48,7 +48,7 @@ module Nokogiri
       # Nokogiri::XML::Reader for mor information
       def Reader string_or_io, url = nil, encoding = nil, options = ParseOptions::STRICT
 
-        options = Nokogiri::XML::ParseOptions.new(options) if Fixnum === options
+        options = Nokogiri::XML::ParseOptions.new(options) if Integer === options
         # Give the options to the user
         yield options if block_given?
 

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -41,7 +41,7 @@ module Nokogiri
       # Nokogiri.XML() is a convenience method which will call this method.
       #
       def self.parse string_or_io, url = nil, encoding = nil, options = ParseOptions::DEFAULT_XML, &block
-        options = Nokogiri::XML::ParseOptions.new(options) if Fixnum === options
+        options = Nokogiri::XML::ParseOptions.new(options) if Integer === options
         # Give the options to the user
         yield options if block_given?
 

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -387,7 +387,7 @@ module Nokogiri
         end
 
         options ||= (document.html? ? ParseOptions::DEFAULT_HTML : ParseOptions::DEFAULT_XML)
-        if Fixnum === options
+        if Integer === options
           options = Nokogiri::XML::ParseOptions.new(options)
         end
         # Give the options to the user
@@ -739,7 +739,7 @@ module Nokogiri
       # Nokogiri::XML::ParseOptions object initialized from +options+, will be
       # passed to it, allowing more convenient modification of the parser options.
       def do_xinclude options = XML::ParseOptions::DEFAULT_XML, &block
-        options = Nokogiri::XML::ParseOptions.new(options) if Fixnum === options
+        options = Nokogiri::XML::ParseOptions.new(options) if Integer === options
 
         # give options to user
         yield options if block_given?


### PR DESCRIPTION
These conditionals don't seem to particularly care whether the value is a Bignum, so it looks like it's safe to just switch to Integer... the only result is that ParseOptions could see some additional unused bits set.