### PR TITLE
Remove MAYBE_UNUSED() macro, which is no longer in use.

### DIFF
--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -34,16 +34,6 @@ int vasprintf (char **strp, const char *fmt, va_list ap);
 #include <ruby/st.h>
 #include <ruby/encoding.h>
 
-#ifndef UNUSED
-# if defined(__GNUC__)
-#  define MAYBE_UNUSED(name) name __attribute__((unused))
-#  define UNUSED(name) MAYBE_UNUSED(UNUSED_ ## name)
-# else
-#  define MAYBE_UNUSED(name) name
-#  define UNUSED(name) name
-# endif
-#endif
-
 #ifndef NORETURN
 # if defined(__GNUC__)
 #  define NORETURN(name) __attribute__((noreturn)) name


### PR DESCRIPTION
Was introduced in c24b3d7a19f but code changed in 55e4ad72646 so that it's no longer in use now.

Moreover MAYBE_UNUSED() is defined in ruby-2.4 as well, so that it causes compiler warnings.