### PR TITLE
Remove test case for libxml2 old version.

### DIFF
--- a/test/xml/test_entity_reference.rb
+++ b/test/xml/test_entity_reference.rb
@@ -236,14 +236,7 @@ EOF
         reader = Nokogiri::XML::Reader html, path do |cfg|
           cfg.default_xml
         end
-        if Nokogiri.uses_libxml? && Nokogiri::LIBXML_PARSER_VERSION.to_i >= 20900
-          # Unknown entity is not fatal in libxml2 >= 2.9
-          assert_equal 8, reader.count
-        else
-          assert_raises(Nokogiri::XML::SyntaxError) {
-            assert_equal 5, reader.count
-          }
-        end
+        assert_equal 8, reader.count
         assert_operator reader.errors.size, :>, 0
       end
     end


### PR DESCRIPTION
I found that there was a test case for old (maybe officially unsupported) libxml2 in the test suite.

I changed libxml2 version to 2.7.6 as a trial to check the case, then I got error in the test suite.
As we do not test for old version's libraries that are not in dependencies.yml in Travis Ci, the test case for the libxml2 old version might be not useful.
Is there any reason to keep the test case?
If not, I would like to remove the test logic.

```
diff --git a/dependencies.yml b/dependencies.yml
index fccaeef..9cfb517 100644
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,6 +1,6 @@
 libxml2:
-  version: "2.9.4"
-  md5: "ae249165c173b1ff386ee8ad676815f5" # manually confirmed via `gpg --verify`
+  version: "2.7.6"
+  md5: "7740a8ec23878a2f50120e1faa2730f2" # manually confirmed via `gpg --verify`
```


```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ bundler -v
Bundler version 1.13.7

$ bundle install --path vendor/bundle

$ bundle exec rake test
...
[BUG] Segmentation fault at 0x007faf00000000
...
[NOTE]
You may have encountered a bug in the Ruby interpreter or extension libraries.
Bug reports are welcome.
For details: http://www.ruby-lang.org/bugreport.html

rake aborted
...
```

The test works with libxml2 2.9.4 that is in dependencies.yml.

