### PR TITLE
Look for bundled libs in lib64 else lib

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -628,9 +628,11 @@ EOM
     $libs = $libs.shellsplit.map do |arg|
       case arg
       when '-lxml2'
-        File.join(libxml2_recipe.path, 'lib', lib_a(arg))
+        # look in lib64 first, else fall back to lib
+        (lib64 = File.join(libxml2_recipe.path, 'lib64', lib_a(arg))) && File.exist?(lib64) ? lib64 : File.join(libxml2_recipe.path, 'lib', lib_a(arg))
       when '-lxslt', '-lexslt'
-        File.join(libxslt_recipe.path, 'lib', lib_a(arg))
+        # look in lib64 first, else fall back to lib
+        (lib64 = File.join(libxslt_recipe.path, 'lib64', lib_a(arg))) && File.exist?(lib64) ? lib64 : File.join(libxslt_recipe.path, 'lib', lib_a(arg))
       else
         arg
       end


### PR DESCRIPTION
This adds awareness of the lib64 build convention. On openSUSE, MacOS, and perhaps other distros, the bundled libxml2 and libxslt libraries get built in a lib64 subdirectory per distro convention.  This commit changes Nokogiri's hardcoded 'lib' convention to first check for bundled library existence in lib64, and if not found, falls back to lib.

See issue #1562 for details.