### PR TITLE
Add tests for HTML SAX parsing of br tag from string and io

### DIFF
--- a/test/html/sax/test_parser.rb
+++ b/test/html/sax/test_parser.rb
@@ -132,6 +132,34 @@ module Nokogiri
           ], @parser.document.start_elements
         end
 
+        HTML_WITH_BR_TAG = <<-EOF
+        <html>
+          <head></head>
+          <body>
+            <div>
+              hello
+              <br>
+            </div>
+
+            <div>
+              hello again
+            </div>
+          </body>
+        </html>
+        EOF
+
+        def test_parsing_dom_error_from_string
+         @parser.parse(HTML_WITH_BR_TAG)
+         assert_equal 6, @parser.document.start_elements.length
+        end
+
+        def test_parsing_dom_error_from_io
+         @parser.parse(StringIO.new(HTML_WITH_BR_TAG))
+
+         assert_equal 6, @parser.document.start_elements.length
+        end
+
+
         def test_empty_processing_instruction
           @parser.parse_memory("<strong>this will segfault<?strong>")
         end


### PR DESCRIPTION
I've added a test to show a bug in HTML SAX parsing. When parsed from a simple string it works  fine. When parsed from IO it fails on the first invalid tag.