### PR TITLE
Only require ports GCC on OpenBSD if not using system libraries (Fixes #1515)

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -391,7 +391,7 @@ when arg_config('--clean')
   do_clean
 end
 
-if openbsd?
+if openbsd? && !using_system_libraries?
   ENV['CC'] ||= find_executable('egcc') or
     abort "Please install gcc 4.9+ from ports using `pkg_add -v gcc`"
 end


### PR DESCRIPTION
The OpenBSD system compiler (gcc 4.2.1) cannot compile libxml
without patches, but compiles nokogiri itself fine. If using
system libraries, there is no need to compile libxml, and
therefore the system compiler will work and should be used.
If not using system libraries, the code should stay so that
compilation of libxml will succeed.