### PR TITLE
jruby improvements + weaker xpath caching

### DIFF
--- a/ext/java/nokogiri/NokogiriService.java
+++ b/ext/java/nokogiri/NokogiriService.java
@@ -468,9 +468,7 @@ public class NokogiriService implements BasicLibraryService {
                 clone.setMetaClass(klazz);
                 return clone;
             } catch (CloneNotSupportedException e) {
-                xmlNodeSet = new XmlNodeSet(runtime, klazz);
-                xmlNodeSet.setNodes(RubyArray.newEmptyArray(runtime));
-                return xmlNodeSet;
+                return new XmlNodeSet(runtime, klazz);
             }
         }
     };

--- a/ext/java/nokogiri/NokogiriService.java
+++ b/ext/java/nokogiri/NokogiriService.java
@@ -596,17 +596,9 @@ public class NokogiriService implements BasicLibraryService {
         }
     };
 
-    public static ObjectAllocator XML_XPATHCONTEXT_ALLOCATOR = new ObjectAllocator() {
-        private XmlXpathContext xmlXpathContext = null;
+    public static final ObjectAllocator XML_XPATHCONTEXT_ALLOCATOR = new ObjectAllocator() {
         public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-            if (xmlXpathContext == null) xmlXpathContext = new XmlXpathContext(runtime, klazz);
-            try {
-                XmlXpathContext clone  = (XmlXpathContext) xmlXpathContext.clone();
-                clone.setMetaClass(klazz);
-                return clone;
-            } catch (CloneNotSupportedException e) {
-                return new XmlXpathContext(runtime, klazz);
-            }
+            return new XmlXpathContext(runtime, klazz);
         }
     };
 

--- a/ext/java/nokogiri/XmlEntityDecl.java
+++ b/ext/java/nokogiri/XmlEntityDecl.java
@@ -37,7 +37,6 @@ import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
-import org.jruby.RubyNil;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
@@ -117,7 +116,7 @@ public class XmlEntityDecl extends XmlNode {
     @JRubyMethod
     public IRubyObject node_name(ThreadContext context) {
         IRubyObject value = getAttribute(context, "name");
-        if (value instanceof RubyNil) value = name;
+        if (value.isNil()) value = name;
         return value;
     }
 
@@ -131,7 +130,7 @@ public class XmlEntityDecl extends XmlNode {
     @JRubyMethod
     public IRubyObject content(ThreadContext context) {
         IRubyObject value = getAttribute(context, "value");
-        if (value instanceof RubyNil) value = content;
+        if (value.isNil()) value = content;
         return value;
     }
 
@@ -144,14 +143,14 @@ public class XmlEntityDecl extends XmlNode {
     @JRubyMethod
     public IRubyObject system_id(ThreadContext context) {
         IRubyObject value = getAttribute(context, "sysid");
-        if (value instanceof RubyNil) value = system_id;
+        if (value.isNil()) value = system_id;
         return value;
     }
 
     @JRubyMethod
     public IRubyObject external_id(ThreadContext context) {
         IRubyObject value = getAttribute(context, "pubid");
-        if (value instanceof RubyNil) value = external_id;
+        if (value.isNil()) value = external_id;
         return value;
     }
 

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1261,7 +1261,7 @@ public class XmlNode extends RubyObject {
         String encString = encoding.isNil() ? null : rubyStringToString(encoding);
 
         SaveContextVisitor visitor = 
-            new SaveContextVisitor((Integer) options.toJava(Integer.class), rubyStringToString(indentString), encString, isHtmlDoc(context), isFragment(), 0);
+            new SaveContextVisitor(RubyFixnum.fix2int(options), rubyStringToString(indentString), encString, isHtmlDoc(context), isFragment(), 0);
         accept(context, visitor);
 
         final IRubyObject rubyString;

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -877,9 +877,13 @@ public class XmlNode extends RubyObject {
 
     @JRubyMethod(name = {"content", "text", "inner_text"})
     public IRubyObject content(ThreadContext context) {
+        return stringOrNil(context.getRuntime(), getContentImpl());
+    }
+
+    public CharSequence getContentImpl() {
         if (!node.hasChildNodes() && node.getNodeValue() == null &&
             (node.getNodeType() == Node.TEXT_NODE || node.getNodeType() == Node.CDATA_SECTION_NODE)) {
-            return context.nil;
+            return null;
         }
         CharSequence textContent;
         if (this instanceof XmlDocument) {
@@ -894,7 +898,7 @@ public class XmlNode extends RubyObject {
             textContent = getTextContentRecursively(new StringBuilder(), node);
         }
         // textContent = NokogiriHelpers.convertEncodingByNKFIfNecessary(context, (XmlDocument) document(context), textContent);
-        return convertString(context.getRuntime(), textContent);
+        return textContent;
     }
 
     private StringBuilder getTextContentRecursively(StringBuilder buffer, Node currentNode) {

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -36,6 +36,7 @@ import static java.lang.Math.max;
 import static nokogiri.internals.NokogiriHelpers.getCachedNodeOrCreate;
 import static nokogiri.internals.NokogiriHelpers.clearCachedNode;
 import static nokogiri.internals.NokogiriHelpers.clearXpathContext;
+import static nokogiri.internals.NokogiriHelpers.convertEncoding;
 import static nokogiri.internals.NokogiriHelpers.convertString;
 import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
 import static nokogiri.internals.NokogiriHelpers.nodeArrayToRubyArray;
@@ -1262,10 +1263,10 @@ public class XmlNode extends RubyObject {
 
         final IRubyObject rubyString;
         if (NokogiriHelpers.isUTF8(encString)) {
-            rubyString = stringOrNil(context.getRuntime(), visitor.toString());
+            rubyString = convertString(context.getRuntime(), visitor.getInternalBuffer());
         } else {
             try {
-                ByteBuffer bytes = NokogiriHelpers.convertEncoding(Charset.forName(encString), visitor.toString());
+                ByteBuffer bytes = convertEncoding(Charset.forName(encString), visitor.toString());
                 ByteList str = new ByteList(bytes.array(), bytes.arrayOffset(), bytes.remaining());
                 rubyString = RubyString.newString(context.getRuntime(), str);
             }

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1268,14 +1268,9 @@ public class XmlNode extends RubyObject {
         if (NokogiriHelpers.isUTF8(encString)) {
             rubyString = convertString(context.getRuntime(), visitor.getInternalBuffer());
         } else {
-            try {
-                ByteBuffer bytes = convertEncoding(Charset.forName(encString), visitor.toString());
-                ByteList str = new ByteList(bytes.array(), bytes.arrayOffset(), bytes.remaining());
-                rubyString = RubyString.newString(context.getRuntime(), str);
-            }
-            catch (CharacterCodingException e) {
-                throw context.getRuntime().newRuntimeError(e.getMessage());
-            }
+            ByteBuffer bytes = convertEncoding(Charset.forName(encString), visitor.toString());
+            ByteList str = new ByteList(bytes.array(), bytes.arrayOffset(), bytes.remaining());
+            rubyString = RubyString.newString(context.getRuntime(), str);
         }
         RuntimeHelpers.invoke(context, io, "write", rubyString);
 

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1268,7 +1268,7 @@ public class XmlNode extends RubyObject {
         if (NokogiriHelpers.isUTF8(encString)) {
             rubyString = convertString(context.getRuntime(), visitor.getInternalBuffer());
         } else {
-            ByteBuffer bytes = convertEncoding(Charset.forName(encString), visitor.toString());
+            ByteBuffer bytes = convertEncoding(Charset.forName(encString), visitor.getInternalBuffer());
             ByteList str = new ByteList(bytes.array(), bytes.arrayOffset(), bytes.remaining());
             rubyString = RubyString.newString(context.getRuntime(), str);
         }

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -898,7 +898,7 @@ public class XmlNode extends RubyObject {
     }
 
     private StringBuilder getTextContentRecursively(StringBuilder buffer, Node currentNode) {
-        String textContent = currentNode.getNodeValue();
+        CharSequence textContent = currentNode.getNodeValue();
         if (textContent != null && NokogiriHelpers.shouldDecode(currentNode)) {
             textContent = NokogiriHelpers.decodeJavaString(textContent);
         }
@@ -962,10 +962,9 @@ public class XmlNode extends RubyObject {
         return clone;
     }
 
-    public static IRubyObject encode_special_chars(ThreadContext context, IRubyObject string) {
-        String s = rubyStringToString(string);
-        String enc = NokogiriHelpers.encodeJavaString(s);
-        return context.getRuntime().newString(enc);
+    public static RubyString encode_special_chars(ThreadContext context, IRubyObject string) {
+        CharSequence str = NokogiriHelpers.encodeJavaString( rubyStringToString(string) );
+        return RubyString.newString(context.getRuntime(), str);
     }
 
     /**

--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -134,40 +134,40 @@ public class XmlNodeSet extends RubyObject implements NodeList {
     }
 
     @JRubyMethod(name="&")
-    public IRubyObject and(ThreadContext context, IRubyObject nodeSet){
+    public IRubyObject and(ThreadContext context, IRubyObject nodeSet) {
         if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
         return newXmlNodeSet(context, (RubyArray) nodes.op_and(asXmlNodeSet(context, nodeSet).nodes));
     }
 
     @JRubyMethod
-    public IRubyObject delete(ThreadContext context, IRubyObject node_or_namespace){
+    public IRubyObject delete(ThreadContext context, IRubyObject node_or_namespace) {
         if (nodes == null) return context.getRuntime().getNil();
         if (node_or_namespace instanceof XmlNamespace) {
-            ((XmlNamespace)node_or_namespace).deleteHref();
+            ((XmlNamespace) node_or_namespace).deleteHref();
         }
         return nodes.delete(context, asXmlNodeOrNamespace(context, node_or_namespace), Block.NULL_BLOCK);
     }
 
     @JRubyMethod
     public IRubyObject dup(ThreadContext context){
-        if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
+        if (nodes == null) return newEmptyNodeSet(context);
         return newXmlNodeSet(context, nodes.aryDup());
     }
 
     @JRubyMethod(name = "include?")
-    public IRubyObject include_p(ThreadContext context, IRubyObject node_or_namespace){
-        if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
-        return nodes.include_p(context, asXmlNodeOrNamespace(context, node_or_namespace));
+    public IRubyObject include_p(ThreadContext context, IRubyObject node_or_namespace) {
+        node_or_namespace = asXmlNodeOrNamespace(context, node_or_namespace);
+        if (nodes == null) return context.getRuntime().getFalse();
+        return nodes.include_p(context, node_or_namespace);
     }
 
     @JRubyMethod(name = {"length", "size"})
     public IRubyObject length(ThreadContext context) {
-        if (nodes != null) return nodes.length();
-        else return context.getRuntime().newFixnum(0);
+        return nodes != null ? nodes.length() : context.getRuntime().newFixnum(0);
     }
 
     @JRubyMethod(name="-")
-    public IRubyObject op_diff(ThreadContext context, IRubyObject nodeSet){
+    public IRubyObject op_diff(ThreadContext context, IRubyObject nodeSet) {
         XmlNodeSet xmlNodeSet = newXmlNodeSet(context, this);
         if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
         xmlNodeSet.setNodes((RubyArray) nodes.op_diff(asXmlNodeSet(context, nodeSet).nodes));
@@ -175,14 +175,14 @@ public class XmlNodeSet extends RubyObject implements NodeList {
     }
 
     @JRubyMethod(name={"|", "+"})
-    public IRubyObject op_or(ThreadContext context, IRubyObject nodeSet){
+    public IRubyObject op_or(ThreadContext context, IRubyObject nodeSet) {
         if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
         return newXmlNodeSet(context, (RubyArray) nodes.op_or(asXmlNodeSet(context, nodeSet).nodes));
     }
 
     @JRubyMethod(name = {"push", "<<"})
     public IRubyObject push(ThreadContext context, IRubyObject node_or_namespace) {
-        if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
+        if (nodes == null) setNodes(RubyArray.newArray(context.getRuntime()));
         nodes.append(asXmlNodeOrNamespace(context, node_or_namespace));
         return this;
     }
@@ -197,10 +197,9 @@ public class XmlNodeSet extends RubyObject implements NodeList {
             result = nodes.aref(indexOrRange);
         }
         if (result instanceof RubyArray) {
-            return newXmlNodeSet(context, (RubyArray)result);
-        } else {
-            return result;
+            return newXmlNodeSet(context, (RubyArray) result);
         }
+        return result;
     }
 
     @JRubyMethod(name={"[]", "slice"})
@@ -212,8 +211,10 @@ public class XmlNodeSet extends RubyObject implements NodeList {
         } else {
             result = nodes.aref(start, length);
         }
-        if (result instanceof RubyArray) return newXmlNodeSet(context, (RubyArray)result);
-        else return context.getRuntime().getNil();
+        if (result instanceof RubyArray) {
+            return newXmlNodeSet(context, (RubyArray) result);
+        }
+        return context.getRuntime().getNil();
     }
 
     @JRubyMethod(name = {"to_a", "to_ary"})
@@ -223,10 +224,9 @@ public class XmlNodeSet extends RubyObject implements NodeList {
 
     @JRubyMethod(name = {"unlink", "remove"})
     public IRubyObject unlink(ThreadContext context){
-        if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
-        IRubyObject[] arr = this.nodes.toJavaArrayUnsafe();
-        long length = arr.length;
-        for (int i = 0; i < length; i++) {
+        if (nodes == null) return this;
+        IRubyObject[] arr = nodes.toJavaArrayUnsafe();
+        for (int i = 0; i < arr.length; i++) {
             if (arr[i] instanceof XmlNode) {
                 ((XmlNode) arr[i] ).unlink(context);
             }
@@ -234,13 +234,13 @@ public class XmlNodeSet extends RubyObject implements NodeList {
         return this;
     }
 
-    private XmlNodeSet newXmlNodeSet(ThreadContext context, XmlNodeSet reference) {
+    private static XmlNodeSet newXmlNodeSet(ThreadContext context, XmlNodeSet reference) {
         XmlNodeSet xmlNodeSet = create(context.getRuntime());
         xmlNodeSet.setReference(reference);
         return xmlNodeSet;
     }
 
-    private IRubyObject asXmlNodeOrNamespace(ThreadContext context, IRubyObject possibleNode) {
+    private static IRubyObject asXmlNodeOrNamespace(ThreadContext context, IRubyObject possibleNode) {
         if (possibleNode instanceof XmlNode || possibleNode instanceof XmlNamespace) {
             return possibleNode;
         } else {
@@ -248,7 +248,7 @@ public class XmlNodeSet extends RubyObject implements NodeList {
         }
     }
 
-    private XmlNodeSet asXmlNodeSet(ThreadContext context, IRubyObject possibleNodeSet) {
+    private static XmlNodeSet asXmlNodeSet(ThreadContext context, IRubyObject possibleNodeSet) {
 //        if(!(possibleNodeSet instanceof XmlNodeSet)) {
         if(!RuntimeHelpers.invoke(context, possibleNodeSet, "is_a?",
                 getNokogiriClass(context.getRuntime(), "Nokogiri::XML::NodeSet")).isTrue()) {
@@ -260,12 +260,11 @@ public class XmlNodeSet extends RubyObject implements NodeList {
     }
     
     public int getLength() {
-        if (nodes == null) return 0 ;
-        return nodes.size();
+        return nodes == null ? 0 : nodes.size();
     }
     
     public Node item(int index) {
-        if (nodes == null) return null ;
+        if (nodes == null) return null;
         Object n = nodes.get(index);
         if (n instanceof XmlNode) return ((XmlNode)n).node;
         if (n instanceof XmlNamespace) return ((XmlNamespace)n).getNode();

--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -66,6 +66,24 @@ public class XmlNodeSet extends RubyObject implements NodeList {
         super(ruby, klazz);
     }
 
+    public static XmlNodeSet create(final Ruby runtime) {
+        return (XmlNodeSet) NokogiriService.XML_NODESET_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::NodeSet"));
+    }
+
+    public static XmlNodeSet newEmptyNodeSet(ThreadContext context) {
+        return create(context.getRuntime());
+    }
+
+    public static XmlNodeSet newXmlNodeSet(final Ruby runtime, RubyArray nodes) {
+        XmlNodeSet xmlNodeSet = create(runtime);
+        xmlNodeSet.setNodes(nodes);
+        return xmlNodeSet;
+    }
+
+    static XmlNodeSet newXmlNodeSet(ThreadContext context, RubyArray nodes) {
+        return newXmlNodeSet(context.getRuntime(), nodes);
+    }
+
     /**
      * Create and return a copy of this object.
      *
@@ -92,17 +110,12 @@ public class XmlNodeSet extends RubyObject implements NodeList {
     public void setNodeList(NodeList nodeList) {
         setNodes(nodeListToRubyArray(getRuntime(), nodeList));
     }
-    
-    public void initialize(Ruby runtime, IRubyObject refNode) {
+
+    final void initialize(Ruby runtime, IRubyObject refNode) {
         if (refNode instanceof XmlNode) {
-            XmlNode n = (XmlNode)refNode;
-            IRubyObject doc = n.document(runtime);
+            IRubyObject doc = ((XmlNode) refNode).document(runtime);
             setDocumentAndDecorate(runtime.getCurrentContext(), this, doc);
         }
-    }
-
-    public static XmlNodeSet newEmptyNodeSet(ThreadContext context) {
-        return (XmlNodeSet)NokogiriService.XML_NODESET_ALLOCATOR.allocate(context.getRuntime(), getNokogiriClass(context.getRuntime(), "Nokogiri::XML::NodeSet"));
     }
 
     public long length() {
@@ -221,14 +234,8 @@ public class XmlNodeSet extends RubyObject implements NodeList {
         return this;
     }
 
-    public static XmlNodeSet newXmlNodeSet(ThreadContext context, RubyArray array) {
-        XmlNodeSet xmlNodeSet = (XmlNodeSet)NokogiriService.XML_NODESET_ALLOCATOR.allocate(context.getRuntime(), getNokogiriClass(context.getRuntime(), "Nokogiri::XML::NodeSet"));
-        xmlNodeSet.setNodes(array);
-        return xmlNodeSet;
-    }
-
     private XmlNodeSet newXmlNodeSet(ThreadContext context, XmlNodeSet reference) {
-        XmlNodeSet xmlNodeSet = (XmlNodeSet)NokogiriService.XML_NODESET_ALLOCATOR.allocate(context.getRuntime(), getNokogiriClass(context.getRuntime(), "Nokogiri::XML::NodeSet"));
+        XmlNodeSet xmlNodeSet = create(context.getRuntime());
         xmlNodeSet.setReference(reference);
         return xmlNodeSet;
     }

--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -136,7 +136,7 @@ public class XmlNodeSet extends RubyObject implements NodeList {
     @JRubyMethod(name="&")
     public IRubyObject and(ThreadContext context, IRubyObject nodeSet) {
         if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
-        return newXmlNodeSet(context, (RubyArray) nodes.op_and(asXmlNodeSet(context, nodeSet).nodes));
+        return newXmlNodeSet(context, (RubyArray) nodes.op_and(getNodes(context, nodeSet)));
     }
 
     @JRubyMethod
@@ -170,14 +170,14 @@ public class XmlNodeSet extends RubyObject implements NodeList {
     public IRubyObject op_diff(ThreadContext context, IRubyObject nodeSet) {
         XmlNodeSet xmlNodeSet = newXmlNodeSet(context, this);
         if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
-        xmlNodeSet.setNodes((RubyArray) nodes.op_diff(asXmlNodeSet(context, nodeSet).nodes));
+        xmlNodeSet.setNodes((RubyArray) nodes.op_diff(getNodes(context, nodeSet)));
         return xmlNodeSet;
     }
 
     @JRubyMethod(name={"|", "+"})
     public IRubyObject op_or(ThreadContext context, IRubyObject nodeSet) {
         if (nodes == null) setNodes(RubyArray.newEmptyArray(context.getRuntime()));
-        return newXmlNodeSet(context, (RubyArray) nodes.op_or(asXmlNodeSet(context, nodeSet).nodes));
+        return newXmlNodeSet(context, (RubyArray) nodes.op_or(getNodes(context, nodeSet)));
     }
 
     @JRubyMethod(name = {"push", "<<"})
@@ -243,20 +243,16 @@ public class XmlNodeSet extends RubyObject implements NodeList {
     private static IRubyObject asXmlNodeOrNamespace(ThreadContext context, IRubyObject possibleNode) {
         if (possibleNode instanceof XmlNode || possibleNode instanceof XmlNamespace) {
             return possibleNode;
-        } else {
-            throw context.getRuntime().newArgumentError("node must be a Nokogiri::XML::Node or Nokogiri::XML::Namespace");
         }
+        throw context.getRuntime().newArgumentError("node must be a Nokogiri::XML::Node or Nokogiri::XML::Namespace");
     }
 
-    private static XmlNodeSet asXmlNodeSet(ThreadContext context, IRubyObject possibleNodeSet) {
-//        if(!(possibleNodeSet instanceof XmlNodeSet)) {
-        if(!RuntimeHelpers.invoke(context, possibleNodeSet, "is_a?",
-                getNokogiriClass(context.getRuntime(), "Nokogiri::XML::NodeSet")).isTrue()) {
-            throw context.getRuntime().newArgumentError("node must be a Nokogiri::XML::NodeSet");
+    private static RubyArray getNodes(ThreadContext context, IRubyObject possibleNodeSet) {
+        if (possibleNodeSet instanceof XmlNodeSet) {
+            RubyArray nodes = ((XmlNodeSet) possibleNodeSet).nodes;
+            return nodes == null ? RubyArray.newEmptyArray(context.getRuntime()) : nodes;
         }
-        XmlNodeSet xmlNodeSet = (XmlNodeSet)possibleNodeSet;
-        if (xmlNodeSet.nodes == null) xmlNodeSet.setNodes(RubyArray.newEmptyArray(context.getRuntime()));
-        return xmlNodeSet;
+        throw context.getRuntime().newArgumentError("node must be a Nokogiri::XML::NodeSet");
     }
     
     public int getLength() {

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -145,9 +145,14 @@ public class XmlXpathContext extends RubyObject {
         String src = expr.convertToString().asJavaString();
         if (!handler.isNil()) {
             if (!isContainsPrefix(src)) {
+                StringBuilder replacement = new StringBuilder();
                 Set<String> methodNames = handler.getMetaClass().getMethods().keySet();
+                final String PREFIX = NokogiriNamespaceContext.NOKOGIRI_PREFIX;
                 for (String name : methodNames) {
-                    src = src.replaceAll(name, NokogiriNamespaceContext.NOKOGIRI_PREFIX + ':' + name);
+                    replacement.setLength(0);
+                    replacement.ensureCapacity(PREFIX.length() + 1 + name.length());
+                    replacement.append(PREFIX).append(':').append(name);
+                    src = src.replace(name, replacement); // replace(name, NOKOGIRI_PREFIX + ':' + name)
                 }
             }
         }

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -72,7 +72,11 @@ import org.apache.xpath.objects.XObject;
  */
 @JRubyClass(name="Nokogiri::XML::XPathContext")
 public class XmlXpathContext extends RubyObject {
-    public final static String XPATH_CONTEXT = "CACHCED_XPATH_CONTEXT";
+
+    /**
+     * user-data key for (cached) {@link XPathContext}
+     */
+    public static final String XPATH_CONTEXT = "CACHED_XPATH_CONTEXT";
 
     private XmlNode context;
     private final NokogiriXPathFunctionResolver functionResolver;

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -220,10 +220,13 @@ public class XmlXpathContext extends RubyObject {
         }
     }
 
-    private boolean isContainsPrefix(String str) {
-        Set<String> prefixes = nsContext.getAllPrefixes();
-        for (String prefix : prefixes) {
-            if (str.contains(prefix + ':')) {
+    private boolean isContainsPrefix(final String str) {
+        final StringBuilder prefix_ = new StringBuilder();
+        for ( String prefix : nsContext.getAllPrefixes() ) {
+            prefix_.setLength(0);
+            prefix_.ensureCapacity(prefix.length() + 1);
+            prefix_.append(prefix).append(':');
+            if ( str.contains(prefix_) ) { // prefix + ':'
                 return true;
             }
         }

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -159,7 +159,7 @@ public class XmlXpathContext extends RubyObject {
             return tryGetNodeSet(context, expr);
         }
         catch (TransformerException ex) {
-            throw new RaiseException(XmlSyntaxError.createXMLXPathSyntaxError(context.runtime, ex)); // Nokogiri::XML::XPath::SyntaxError
+            throw new RaiseException(XmlSyntaxError.createXMLXPathSyntaxError(context.runtime, expr, ex)); // Nokogiri::XML::XPath::SyntaxError
         }
     }
 

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -85,8 +85,8 @@ public class XmlXpathContext extends RubyObject {
     private XPathContext xpathSupport = null;
     private NokogiriNamespaceContext nsContext;
 
-    public XmlXpathContext(Ruby runtime, RubyClass rubyClass) {
-        super(runtime, rubyClass);
+    public XmlXpathContext(Ruby runtime, RubyClass klass) {
+        super(runtime, klass);
         functionResolver = NokogiriXPathFunctionResolver.create(runtime.getNil());
         variableResolver = NokogiriXPathVariableResolver.create();
     }
@@ -119,27 +119,14 @@ public class XmlXpathContext extends RubyObject {
         return new JAXPExtensionsProvider(functionResolver, false);
     }
 
-    /**
-     * Create and return a copy of this object.
-     *
-     * @return a clone of this object
-     */
-    @Override
-    public Object clone() throws CloneNotSupportedException {
-        return super.clone();
-    }
-
     @JRubyMethod(name = "new", meta = true)
     public static IRubyObject rbNew(ThreadContext context, IRubyObject klazz, IRubyObject node) {
-        XmlNode xmlNode = (XmlNode) node;
-        XmlXpathContext xmlXpathContext = (XmlXpathContext) NokogiriService.XML_XPATHCONTEXT_ALLOCATOR.allocate(context.getRuntime(), (RubyClass)klazz);
         try {
-            xmlXpathContext.initNode(xmlNode);
+            return new XmlXpathContext(context.runtime, (RubyClass) klazz, (XmlNode) node);
         }
         catch (IllegalArgumentException e) {
             throw context.getRuntime().newRuntimeError(e.getMessage());
         }
-        return xmlXpathContext;
     }
 
     @JRubyMethod

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -32,8 +32,6 @@
 
 package nokogiri;
 
-import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
-
 import java.util.Set;
 
 import javax.xml.transform.TransformerException;
@@ -51,7 +49,6 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import org.apache.xml.dtm.DTM;
 import org.apache.xpath.XPath;
@@ -178,9 +175,8 @@ public class XmlXpathContext extends RubyObject {
             case XObject.CLASS_BOOLEAN : return context.getRuntime().newBoolean(xobj.bool());
             case XObject.CLASS_NUMBER :  return context.getRuntime().newFloat(xobj.num());
             case XObject.CLASS_NODESET :
-                NodeList nodeList = xobj.nodelist();
-                XmlNodeSet xmlNodeSet = (XmlNodeSet) NokogiriService.XML_NODESET_ALLOCATOR.allocate(getRuntime(), getNokogiriClass(getRuntime(), "Nokogiri::XML::NodeSet"));
-                xmlNodeSet.setNodeList(nodeList);
+                XmlNodeSet xmlNodeSet = XmlNodeSet.create(context.getRuntime());
+                xmlNodeSet.setNodeList(xobj.nodelist());
                 xmlNodeSet.initialize(context.getRuntime(), this.context);
                 return xmlNodeSet;
             default : return context.getRuntime().newString(xobj.str());

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -91,7 +91,12 @@ public class XmlXpathContext extends RubyObject {
         variableResolver = NokogiriXPathVariableResolver.create();
     }
 
-    private void setNode(XmlNode node) {
+    public XmlXpathContext(Ruby runtime, RubyClass klass, XmlNode node) {
+        this(runtime, klass);
+        initNode(node);
+    }
+
+    private void initNode(XmlNode node) {
         Node doc = node.getNode().getOwnerDocument();
         if (doc == null) {
             doc = node.getNode();
@@ -126,11 +131,10 @@ public class XmlXpathContext extends RubyObject {
 
     @JRubyMethod(name = "new", meta = true)
     public static IRubyObject rbNew(ThreadContext context, IRubyObject klazz, IRubyObject node) {
-        XmlNode xmlNode = (XmlNode)node;
+        XmlNode xmlNode = (XmlNode) node;
         XmlXpathContext xmlXpathContext = (XmlXpathContext) NokogiriService.XML_XPATHCONTEXT_ALLOCATOR.allocate(context.getRuntime(), (RubyClass)klazz);
-        XPathFactory.newInstance().newXPath();
         try {
-            xmlXpathContext.setNode(xmlNode);
+            xmlXpathContext.initNode(xmlNode);
         }
         catch (IllegalArgumentException e) {
             throw context.getRuntime().newRuntimeError(e.getMessage());

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -34,8 +34,6 @@ package nokogiri;
 
 import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Set;
 
 import javax.xml.transform.TransformerException;
@@ -89,7 +87,7 @@ public class XmlXpathContext extends RubyObject {
         variableResolver = NokogiriXPathVariableResolver.create();
     }
 
-    private void setNode(XmlNode node) throws IllegalArgumentException, InstantiationException, IllegalAccessException, InvocationTargetException {
+    private void setNode(XmlNode node) {
         Node doc = node.getNode().getOwnerDocument();
         if (doc == null) {
             doc = node.getNode();
@@ -108,17 +106,8 @@ public class XmlXpathContext extends RubyObject {
         prefixResolver = new JAXPPrefixResolver(nsContext);
     }
 
-    private JAXPExtensionsProvider getProviderInstance() throws IllegalArgumentException, InstantiationException, IllegalAccessException, InvocationTargetException {
-        Constructor[] constructors = JAXPExtensionsProvider.class.getDeclaredConstructors();
-        for (int i = 0; i < constructors.length; i++) {
-            Class[] parameterTypes = constructors[i].getParameterTypes();
-            if (parameterTypes.length == 2) {
-                return (JAXPExtensionsProvider) constructors[i].newInstance(functionResolver, false);
-            } else if (parameterTypes.length == 1) {
-                return (JAXPExtensionsProvider) constructors[i].newInstance(functionResolver);
-            }
-        }
-        return null;
+    private JAXPExtensionsProvider getProviderInstance() {
+        return new JAXPExtensionsProvider(functionResolver, false);
     }
 
     /**
@@ -132,20 +121,15 @@ public class XmlXpathContext extends RubyObject {
     }
 
     @JRubyMethod(name = "new", meta = true)
-    public static IRubyObject rbNew(ThreadContext thread_context, IRubyObject klazz, IRubyObject node) {
+    public static IRubyObject rbNew(ThreadContext context, IRubyObject klazz, IRubyObject node) {
         XmlNode xmlNode = (XmlNode)node;
-        XmlXpathContext xmlXpathContext = (XmlXpathContext) NokogiriService.XML_XPATHCONTEXT_ALLOCATOR.allocate(thread_context.getRuntime(), (RubyClass)klazz);
+        XmlXpathContext xmlXpathContext = (XmlXpathContext) NokogiriService.XML_XPATHCONTEXT_ALLOCATOR.allocate(context.getRuntime(), (RubyClass)klazz);
         XPathFactory.newInstance().newXPath();
         try {
             xmlXpathContext.setNode(xmlNode);
-        } catch (IllegalArgumentException e) {
-            throw thread_context.getRuntime().newRuntimeError(e.getMessage());
-        } catch (InstantiationException e) {
-            throw thread_context.getRuntime().newRuntimeError(e.getMessage());
-        } catch (IllegalAccessException e) {
-            throw thread_context.getRuntime().newRuntimeError(e.getMessage());
-        } catch (InvocationTargetException e) {
-            throw thread_context.getRuntime().newRuntimeError(e.getMessage());
+        }
+        catch (IllegalArgumentException e) {
+            throw context.getRuntime().newRuntimeError(e.getMessage());
         }
         return xmlXpathContext;
     }

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -39,9 +39,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -722,8 +720,8 @@ public class NokogiriHelpers {
         return Charset.forName(encoding).compareTo(UTF8) == 0;
     }
 
-    public static ByteBuffer convertEncoding(Charset output_charset, String input_string) {
-        return output_charset.encode(input_string); // does replace implicitly on un-mappable characters
+    public static ByteBuffer convertEncoding(Charset output_charset, CharSequence input_string) {
+        return output_charset.encode(CharBuffer.wrap(input_string)); // does replace implicitly on un-mappable characters
     }
 
     public static CharSequence convertEncodingByNKFIfNecessary(ThreadContext context, XmlDocument doc, CharSequence str) {

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -722,9 +722,8 @@ public class NokogiriHelpers {
     }
 
     public static boolean isUTF8(String encoding) {
-        if (encoding == null) return true;   // no need to convert encoding
-        int ret = Charset.forName(encoding).compareTo(Charset.forName("UTF-8"));
-        return ret == 0;
+        if (encoding == null) return true; // no need to convert encoding
+        return Charset.forName(encoding).compareTo(UTF8) == 0;
     }
 
     public static ByteBuffer convertEncoding(Charset output_charset, String input_string) throws CharacterCodingException {

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -722,10 +722,8 @@ public class NokogiriHelpers {
         return Charset.forName(encoding).compareTo(UTF8) == 0;
     }
 
-    public static ByteBuffer convertEncoding(Charset output_charset, String input_string) throws CharacterCodingException {
-        CharsetEncoder encoder = output_charset.newEncoder();
-        CharBuffer charBuffer = CharBuffer.wrap(input_string);
-        return encoder.encode(charBuffer);
+    public static ByteBuffer convertEncoding(Charset output_charset, String input_string) {
+        return output_charset.encode(input_string); // does replace implicitly on un-mappable characters
     }
 
     public static CharSequence convertEncodingByNKFIfNecessary(ThreadContext context, XmlDocument doc, CharSequence str) {

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -606,13 +606,11 @@ public class NokogiriHelpers {
     }
 
     public static boolean isWhitespaceText(ThreadContext context, IRubyObject obj) {
-        if (obj == null || obj.isNil()) return false;
+        //if (obj == null || obj.isNil()) return false;
+        if ( !(obj instanceof XmlText) ) return false;
 
-        XmlNode node = (XmlNode) obj;
-        if (!(node instanceof XmlText)) return false;
-
-        String content = rubyStringToString(node.content(context));
-        return content == null || content.trim().length() == 0;
+        CharSequence content = ((XmlNode) obj).getContentImpl();
+        return content == null || isWhitespaceText(content);
     }
 
     public static boolean isWhitespaceText(CharSequence str) {

--- a/ext/java/nokogiri/internals/NokogiriNamespaceContext.java
+++ b/ext/java/nokogiri/internals/NokogiriNamespaceContext.java
@@ -33,11 +33,11 @@
 package nokogiri.internals;
 
 import java.util.ArrayList;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
@@ -54,14 +54,14 @@ public final class NokogiriNamespaceContext implements NamespaceContext {
     public static final String NOKOGIRI_URI = "http://www.nokogiri.org/default_ns/ruby/extensions_functions";
     public static final String NOKOGIRI_TEMPORARY_ROOT_TAG = "nokogiri-temporary-root-tag";
     
-    private Hashtable<String,String> register;
+    private final Map<String,String> register;
 
     public static NokogiriNamespaceContext create() {
         return new NokogiriNamespaceContext();
     }
     
     private NokogiriNamespaceContext() {
-        this.register = new Hashtable<String,String>();
+        register = new HashMap<String, String>(6, 1);
         register.put(NOKOGIRI_PREFIX, NOKOGIRI_URI);
         register.put("xml", "http://www.w3.org/XML/1998/namespace");
         register.put("xhtml", "http://www.w3.org/1999/xhtml");
@@ -87,21 +87,19 @@ public final class NokogiriNamespaceContext implements NamespaceContext {
     public String getPrefix(String uri) {
     	if (uri == null) {
             throw new IllegalArgumentException("uri is null");
-        } else {
-            Set<Entry<String, String>> entries = register.entrySet();
-            for (Entry<String, String> entry : entries) {
-                if (uri.equals(entry.getValue())) {
-                    return entry.getKey();
-                }
+        }
+        Set<Entry<String, String>> entries = register.entrySet();
+        for (Entry<String, String> entry : entries) {
+            if (uri.equals(entry.getValue())) {
+                return entry.getKey();
             }
         }
         return null;
     }
 
     public Iterator<String> getPrefixes(String uri) {
-        if (register == null) return null;
         Set<Entry<String, String>> entries = register.entrySet();
-        List<String> list = new ArrayList<String>();
+        ArrayList<String> list = new ArrayList<String>(entries.size());
         for (Entry<String, String> entry : entries) {
             if (uri.equals(entry.getValue())) {
                 list.add(entry.getKey());
@@ -111,12 +109,12 @@ public final class NokogiriNamespaceContext implements NamespaceContext {
     }
     
     public Set<String> getAllPrefixes() {
-        if (register == null) return null;
         return register.keySet();
     }
 
     public void registerNamespace(String prefix, String uri) {
-        if("xmlns".equals(prefix)) prefix = "";
-        this.register.put(prefix, uri);
+        if ("xmlns".equals(prefix)) prefix = "";
+        register.put(prefix, uri);
     }
+
 }

--- a/ext/java/nokogiri/internals/NokogiriXPathFunctionResolver.java
+++ b/ext/java/nokogiri/internals/NokogiriXPathFunctionResolver.java
@@ -44,7 +44,7 @@ import org.jruby.runtime.builtin.IRubyObject;
  * @author sergio
  * @author Yoko Harada <yokolet@gmail.com>
  */
-public class NokogiriXPathFunctionResolver implements XPathFunctionResolver {
+public final class NokogiriXPathFunctionResolver implements XPathFunctionResolver {
 
     private IRubyObject handler;
     
@@ -55,7 +55,11 @@ public class NokogiriXPathFunctionResolver implements XPathFunctionResolver {
     }
     
     private NokogiriXPathFunctionResolver() {}
-    
+
+    public final IRubyObject getHandler() {
+        return handler;
+    }
+
     public void setHandler(IRubyObject handler) {
         this.handler = handler;
     }

--- a/ext/java/nokogiri/internals/ReaderNode.java
+++ b/ext/java/nokogiri/internals/ReaderNode.java
@@ -293,8 +293,6 @@ public abstract class ReaderNode {
 
     public static class ElementNode extends ReaderNode {
 
-        private final List<String> attributeStrings = new ArrayList<String>();
-
         // public ElementNode() {}
 
         ElementNode(Ruby runtime, String uri, String localName, String qName, XMLAttributes attrs, int depth, Stack<String> langStack, Stack<String> xmlBaseStack) {
@@ -328,7 +326,6 @@ public abstract class ReaderNode {
                     if (xmlBase == null) xmlBase = resolveXmlBase(n, v, xmlBaseStack);
                 }
                 attributeList.add(u, n, v);
-                attributeStrings.add(n + "=\"" + v + "\"");
             }
         }
 
@@ -382,23 +379,26 @@ public abstract class ReaderNode {
 
         @Override
         public String getString() {
-            StringBuffer sb = new StringBuffer();
-            sb.append("<").append(name);
+            StringBuffer sb = new StringBuffer(24);
+            sb.append('<').append(name);
             if (attributeList != null) {
                 for (int i=0; i<attributeList.length; i++) {
-                    sb.append(" ").append(attributeStrings.get(i));
+                    String n = attributeList.names.get(i);
+                    String v = attributeList.values.get(i);
+                    sb.append(' ').append(n).append('=')
+                      .append('"').append(v).append('"');
                 }
             }
-            if (hasChildren) sb.append(">");
+            if (hasChildren) sb.append('>');
             else sb.append("/>");
-            return new String(sb);
+            return sb.toString();
         }
     }
 
     private static class ReaderAttributeList {
-        List<String> namespaces  = new ArrayList<String>();
-        List<String> names  = new ArrayList<String>();
-        List<String> values = new ArrayList<String>();
+        final List<String> namespaces  = new ArrayList<String>();
+        final List<String> names  = new ArrayList<String>();
+        final List<String> values = new ArrayList<String>();
         int length = 0;
 
         void add(String namespace, String name, String value) {

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -39,14 +39,7 @@ import static nokogiri.internals.NokogiriHelpers.isWhitespaceText;
 
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Stack;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -276,7 +269,7 @@ public class SaveContextVisitor {
         return true;
     }
 
-    private static Pattern p =
+    private static final Pattern CHARSET =
         Pattern.compile("charset(()|\\s+)=(()|\\s+)(\\w|\\_|\\.|\\-)+", Pattern.CASE_INSENSITIVE);
 
     private String replaceCharsetIfNecessary(Attr attr) {
@@ -284,23 +277,24 @@ public class SaveContextVisitor {
         if (encoding == null) return value;   // unable to replace in any case
         if (!"content".equals(attr.getName().toLowerCase())) return value;  // must be content attr
         if (!"meta".equals(attr.getOwnerElement().getNodeName().toLowerCase())) return value;
-        Matcher m = p.matcher(value);
+        Matcher m = CHARSET.matcher(value);
         if (!m.find()) return value;
         if (value.contains(encoding)) return value;  // no need to replace
         return value.replace(m.group(), "charset=" + encoding);
     }
 
-    public static final String[] HTML_BOOLEAN_ATTRS = {
-        "checked", "compact", "declare", "defer", "disabled", "ismap",
-        "multiple", "nohref", "noresize", "noshade", "nowrap", "readonly",
-        "selected"
-    };
+    static final Set<String> HTML_BOOLEAN_ATTRS;
+    static {
+        final String[] _HTML_BOOLEAN_ATTRS = {
+            "checked", "compact", "declare", "defer", "disabled", "ismap",
+            "multiple", "nohref", "noresize", "noshade", "nowrap", "readonly",
+            "selected"
+        };
+        HTML_BOOLEAN_ATTRS = new HashSet<String>(Arrays.asList(_HTML_BOOLEAN_ATTRS));
+    }
 
-    private boolean isHtmlBooleanAttr(String name) {
-        for (String s : HTML_BOOLEAN_ATTRS) {
-            if (s.equals(name)) return true;
-        }
-        return false;
+    private static boolean isHtmlBooleanAttr(String name) {
+        return HTML_BOOLEAN_ATTRS.contains(name);
     }
 
     private static CharSequence serializeAttrTextContent(String str, boolean htmlDoc) {

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -32,7 +32,7 @@
 
 package nokogiri.internals;
 
-import static nokogiri.internals.NokogiriHelpers.canonicalizeWhitespce;
+import static nokogiri.internals.NokogiriHelpers.canonicalizeWhitespace;
 import static nokogiri.internals.NokogiriHelpers.encodeJavaString;
 import static nokogiri.internals.NokogiriHelpers.isNamespace;
 import static nokogiri.internals.NokogiriHelpers.isWhitespaceText;
@@ -733,20 +733,19 @@ public class SaveContextVisitor {
     }
 
     private boolean isHtmlScript(Text text) {
-      return htmlDoc && text.getParentNode().getNodeName().equals("script");
+        return htmlDoc && text.getParentNode().getNodeName().equals("script");
     }
 
     private boolean isHtmlStyle(Text text) {
-      return htmlDoc && text.getParentNode().getNodeName().equals("style");
+        return htmlDoc && text.getParentNode().getNodeName().equals("style");
     }
 
-    private static char lineSeparator = '\n'; // System.getProperty("line.separator"); ?
     public boolean enter(Text text) {
-        String textContent = text.getNodeValue();
+        CharSequence textContent = text.getNodeValue();
         if (canonical) {
             c14nNodeList.add(text);
             if (isWhitespaceText(textContent)) {
-                buffer.append(canonicalizeWhitespce(textContent));
+                buffer.append(canonicalizeWhitespace(textContent));
                 return true;
             }
         }
@@ -760,25 +759,26 @@ public class SaveContextVisitor {
         return true;
     }
 
-    private String encodeStringToHtmlEntity(String text) {
-        if (encoding == null)
-          return text;
+    private CharSequence encodeStringToHtmlEntity(CharSequence text) {
+        if (encoding == null) return text;
+
         CharsetEncoder encoder = Charset.forName(encoding).newEncoder();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder(text.length() + 16);
         // make sure we can handle code points that are higher than 2 bytes
-        for (int i = 0; i < text.length();) {
-            int code = text.codePointAt(i);
+        for ( int i = 0; i < text.length(); ) {
+            int code = Character.codePointAt(text, i);
             // TODO not sure about bigger offset then 2 ?!
             int offset = code > 65535 ? 2 : 1;
-            boolean canEncode = encoder.canEncode(text.substring(i, i + offset));
+            CharSequence substr = text.subSequence(i, i + offset);
+            boolean canEncode = encoder.canEncode(substr);
             if (canEncode) {
-                sb.append(text.substring(i, i + offset));
+                sb.append(substr);
             }
             else {
                 sb.append("&#x").append(Integer.toHexString(code)).append(';');
             }
             i += offset;
         }
-        return new String(sb);
+        return sb;
     }
 }

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -74,7 +74,7 @@ import org.w3c.dom.Text;
  */
 public class SaveContextVisitor {
 
-    private final StringBuffer buffer;
+    private final StringBuilder buffer;
     private final Stack<String> indentation;
     private String encoding;
     private final String indentString;
@@ -118,7 +118,7 @@ public class SaveContextVisitor {
     public static final int EXCLUSIVE = 16;
 
     public SaveContextVisitor(int options, String indent, String encoding, boolean htmlDoc, boolean fragment, int canonicalOpts) {
-        buffer = new StringBuffer();
+        buffer = new StringBuilder();
         this.encoding = encoding;
         indentation = new Stack<String>(); indentation.push("");
         this.htmlDoc = htmlDoc;
@@ -150,8 +150,10 @@ public class SaveContextVisitor {
 
     @Override
     public String toString() {
-        return (new String(buffer));
+        return buffer.toString();
     }
+
+    public StringBuilder getInternalBuffer() { return buffer; }
 
     public void setHtmlDoc(boolean htmlDoc) {
         this.htmlDoc = htmlDoc;

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -70,7 +70,7 @@ public class SaveContextVisitor {
     private final StringBuilder buffer;
     private final Stack<String> indentation;
     private String encoding;
-    private final String indentString;
+    private final CharSequence indentString;
     private boolean format;
     private final boolean noDecl;
     private final boolean noEmpty;
@@ -87,7 +87,8 @@ public class SaveContextVisitor {
     private final List<Node> c14nNodeList;
     private final Deque<Attr[]> c14nNamespaceStack;
     private final Deque<Attr[]> c14nAttrStack;
-    private List<String> c14nExclusiveInclusivePrefixes = null;
+    //private List<String> c14nExclusiveInclusivePrefixes = null;
+
     /*
      * U can't touch this.
      * http://www.youtube.com/watch?v=WJ2ZFVx6A4Q
@@ -110,7 +111,7 @@ public class SaveContextVisitor {
     public static final int SUBSETS = 8;
     public static final int EXCLUSIVE = 16;
 
-    public SaveContextVisitor(int options, String indent, String encoding, boolean htmlDoc, boolean fragment, int canonicalOpts) {
+    public SaveContextVisitor(int options, CharSequence indent, String encoding, boolean htmlDoc, boolean fragment, int canonicalOpts) {
         buffer = new StringBuilder();
         this.encoding = encoding;
         indentation = new Stack<String>(); indentation.push("");
@@ -155,14 +156,6 @@ public class SaveContextVisitor {
     public void setEncoding(String encoding) {
         this.encoding = encoding;
     }
-
-    public List<Node> getC14nNodeList() {
-        return c14nNodeList;
-    }
-
-   public void setC14nExclusiveInclusivePrefixes(List<String> prefixes) {
-       c14nExclusiveInclusivePrefixes = prefixes;
-   }
 
     public boolean enter(Node node) {
         if (node instanceof Document) {
@@ -438,7 +431,7 @@ public class SaveContextVisitor {
             if (isEmpty(name)) {
                 buffer.append(" />"); // see http://www.w3.org/TR/xhtml1/#C_2
             } else {
-                buffer.append(">");
+                buffer.append('>');
             }
         } else {
             buffer.append("/>");

--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -696,6 +696,17 @@ eohtml
         node = html.xpath("//style").first
         assert_equal("tr > div { display:block; }", node.inner_html)
       end
+
+      it "does not fail when converting to_html using explicit encoding" do
+        html_fragment=<<-eos
+  <img width="16" height="16" src="images/icon.gif" border="0" alt="Inactive hide details for &quot;User&quot; ---19/05/2015 12:55:29---Provvediamo subito nell&#8217;integrare">
+        eos
+        doc = Nokogiri::HTML(html_fragment, nil, 'ISO-8859-1')
+        html = doc.to_html
+        assert html.index("src=\"images/icon.gif\"")
+        assert_equal 'ISO-8859-1', html.encoding.name
+      end
+
     end
   end
 end

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -56,6 +56,10 @@ module Nokogiri
           def value
             123.456
           end
+
+          def anint
+            1230456
+          end
         }.new
       end
 
@@ -339,6 +343,15 @@ module Nokogiri
           value = @xml.xpath('nokogiri:value()', @ns, @handler)
         end
         assert_equal 123.456, value
+      end
+
+      def test_custom_xpath_without_arguments_returning_int
+        if Nokogiri.uses_libxml?
+          value = @xml.xpath('anint()', @handler)
+        else
+          value = @xml.xpath('nokogiri:anint()', @ns, @handler)
+        end
+        assert_equal 1230456, value
       end
 
       def test_custom_xpath_with_bullshit_arguments


### PR DESCRIPTION
managed to run into more common problems such as cloning non-cloneable (Java) objects.
a bit ugly pattern in general but for the rest of Ruby object cloning it would need a justification.

further I realized some xpath problems : 
- using a Ruby function which returns an `Integer` was not supported (resolved #1595) 
- xpath-context caching would not work for xpath-s using binds or a custom fn-handler

this is now avoided (such expressions always create a new xpath context) - they are less common. 
`xpath(expr)` still caches as before, but I realized the cache makes `xpath()` not thread-safe #1596 

UPDATE: also added a fix for #1440 (also resolves #1281 which is a duplicate - had the same cause)