### PR TITLE
gemspec for -java version of the gem should specify >= 1.9.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -144,7 +144,10 @@ HOE = Hoe.spec 'nokogiri' do
   ]
 
   if java?
-    self.spec_extras = { :platform => 'java' }
+    self.spec_extras = {
+        :platform => 'java',
+        :required_ruby_version => '>= 1.9.3' # JRuby >= 1.7
+    }
   else
     self.spec_extras = {
       :extensions => ["ext/nokogiri/extconf.rb"],


### PR DESCRIPTION
... JRuby 1.7 is still supported but not in --1.8 mode