### PR TITLE
Add missing constant LIB_DIRS to nokogiri/extconf.rb

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -4,6 +4,7 @@ ENV['RC_ARCHS'] = '' if RUBY_PLATFORM =~ /darwin/
 require 'mkmf'
 
 ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+LIB_DIRS = [RbConfig::CONFIG['libdir']]
 
 #
 # functions


### PR DESCRIPTION
I have a custom path set with the `CPUPROFILE` environment variable.  Because of this, I consistently get the following when trying to install the gem:

```
extconf.rb:661:in `<main>': uninitialized constant LIB_DIRS (NameError)
```

Grepping the entire source tree I confirmed that this constant is never declared.

I'm using ruby 2.3.3.