### PR TITLE
Add ruby-head as allow_failures in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,22 @@ matrix:
     env:
       - RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
   - os: linux
+    rvm: ruby-head
+    env:
+      - RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
+  - os: osx
+    rvm: ruby-head
+    env:
+      - RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
+  - os: linux
     rvm: jruby-1.7
   - os: linux
     rvm: jruby-9.1.5.0
   - os: linux
     rvm: rbx-3
+  allow_failures:
+  - rvm: ruby-head
+  fast_finish: true
 
 notifications:
   irc:


### PR DESCRIPTION
I want to add `ruby-head` as allow_failures in .travis.yml.
I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
We can support the next version as faster

I found the code in `rails` and `rspec`.
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml

Thanks