### PR TITLE
Add release date to v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * [JRuby] Merged nodes no longer results in Java exceptions during XPath queries. [#1320] (Thanks, @kares!)
 
 
-# 1.7.1 / unreleased
+# 1.7.1 / 2017-03-20
 
 ## Security Notes
 


### PR DESCRIPTION
The release date of `v1.7.1` was missing in the changelog.