### PR TITLE
Download zlib tar from 'fossils' directory.

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -474,7 +474,7 @@ else
   if cross_build_p || windows?
     zlib_recipe = process_recipe("zlib", dependencies["zlib"]["version"], static_p, cross_build_p) do |recipe|
       recipe.files = [{
-          url: "http://zlib.net/#{recipe.name}-#{recipe.version}.tar.gz",
+          url: "http://zlib.net/fossils/#{recipe.name}-#{recipe.version}.tar.gz",
           sha256: dependencies["zlib"]["sha256"]
         }]
       class << recipe


### PR DESCRIPTION
The usual download path contains only the latest version of zlib
and older versions are available at the 'fossils' path only.
If a new version of zlib arrives, all current nokogiri source gems
are immediately no longer installable, when running on Windows.
Fetching the zlib tar from the fossils directory solves this.

The latest zlib version is available in both directories.

The downside is, that we need to have an eye on zlib updates,
because appveyor will no longer fail when newer versions were released.
However this is the same as with the other bundled tar files.