### PR TITLE
Backport USN-3235-1 to 1.6.8.x stream

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,16 @@
+=== 1.6.8.1 / 2016-10-03
+
+==== Dependency License Notes
+
+Removes required dependency on the `pkg-config` gem. This dependency
+was introduced in v1.6.8 and, because it's distributed under LGPL, was
+objectionable to many Nokogiri users (#1488, #1496).
+
+This version makes `pkg-config` an optional dependency. If it's
+installed, it's used; but otherwise Nokogiri will attempt to work
+around its absence.
+
+
 === 1.6.8 / 2016-06-06
 
 ==== Security Notes

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,17 @@
+=== 1.6.8.2 / unreleased
+
+==== Security Notes
+
+[MRI] Upstream libxml2 patches are applied to the vendored libxml 2.9.4 which address CVE-2016-4658 and CVE-2016-5131.
+
+For more information:
+
+* https://github.com/sparklemotion/nokogiri/issues/1615
+* http://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-4658.html
+* http://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-5131.html
+
+
+
 === 1.6.8.1 / 2016-10-03
 
 ==== Dependency License Notes

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@
 source "https://rubygems.org/"
 
 gem "mini_portile2", "~>2.1.0"
-gem "pkg-config", "~>1.1.7"
 
 gem "rdoc", "~>4.0", :group => [:development, :test]
 gem "hoe-bundler", "~>1.2.0", :group => [:development, :test]

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -246,6 +246,9 @@ lib/xalan.jar
 lib/xercesImpl.jar
 lib/xml-apis.jar
 lib/xsd/xmlparser/nokogiri.rb
+patches/libxml2/0001-Fix-comparison-with-root-node-in-xmlXPathCmpNodes.patch
+patches/libxml2/0002-Fix-XPointer-paths-beginning-with-range-to.patch
+patches/libxml2/0003-Disallow-namespace-nodes-in-XPointer-ranges.patch
 patches/sort-patches-by-date
 suppressions/README.txt
 suppressions/nokogiri_ree-1.8.7.358.supp

--- a/Rakefile
+++ b/Rakefile
@@ -128,7 +128,6 @@ HOE = Hoe.spec 'nokogiri' do
   unless java?
     self.extra_deps += [
       ["mini_portile2",    "~> 2.1.0"], # keep version in sync with extconf.rb
-      ["pkg-config",       "~> 1.1.7"], # keep version in sync with extconf.rb
     ]
   end
 

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -106,27 +106,28 @@ def do_clean
   exit! 0
 end
 
-# The gem version constraint in the Rakefile is not respected at install time.
-# Keep this version in sync with the one in the Rakefile !
-require 'rubygems'
-gem 'pkg-config', '~> 1.1.7'
-require 'pkg-config'
-message "Using pkg-config version #{PKGConfig::VERSION}\n"
-
 def package_config pkg, options={}
   package = pkg_config(pkg)
   return package if package
 
-  return nil unless PKGConfig.have_package(pkg)
+  begin
+    require 'rubygems'
+    gem 'pkg-config', (gem_ver='~> 1.1.7')
+    require 'pkg-config' and message("Using pkg-config gem version #{PKGConfig::VERSION}\n")
+  rescue LoadError
+    message "pkg-config could not be used to find #{pkg}\nPlease install either `pkg-config` or the pkg-config gem per\n\n    gem install pkg-config -v #{gem_ver.inspect}\n\n"
+  else
+    return nil unless PKGConfig.have_package(pkg)
 
-  cflags  = PKGConfig.cflags(pkg)
-  ldflags = PKGConfig.libs_only_L(pkg)
-  libs    = PKGConfig.libs_only_l(pkg)
+    cflags  = PKGConfig.cflags(pkg)
+    ldflags = PKGConfig.libs_only_L(pkg)
+    libs    = PKGConfig.libs_only_l(pkg)
 
-  Logging::message "PKGConfig package configuration for %s\n", pkg
-  Logging::message "cflags: %s\nldflags: %s\nlibs: %s\n\n", cflags, ldflags, libs
+    Logging::message "PKGConfig package configuration for %s\n", pkg
+    Logging::message "cflags: %s\nldflags: %s\nlibs: %s\n\n", cflags, ldflags, libs
 
-  [cflags, ldflags, libs]
+    [cflags, ldflags, libs]
+  end
 end
 
 def nokogiri_try_compile

--- a/lib/nokogiri/version.rb
+++ b/lib/nokogiri/version.rb
@@ -1,6 +1,6 @@
 module Nokogiri
   # The version of Nokogiri you are using
-  VERSION = '1.6.8'
+  VERSION = '1.6.8.1'
 
   class VersionInfo # :nodoc:
     def jruby?

--- a/patches/libxml2/0001-Fix-comparison-with-root-node-in-xmlXPathCmpNodes.patch
+++ b/patches/libxml2/0001-Fix-comparison-with-root-node-in-xmlXPathCmpNodes.patch
@@ -1,0 +1,34 @@
+From a005199330b86dada19d162cae15ef9bdcb6baa8 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Tue, 28 Jun 2016 14:19:58 +0200
+Subject: [PATCH] Fix comparison with root node in xmlXPathCmpNodes
+
+This change has already been made in xmlXPathCmpNodesExt but not in
+xmlXPathCmpNodes.
+---
+ xpath.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xpath.c b/xpath.c
+index 751665b..d992841 100644
+--- a/xpath.c
++++ b/xpath.c
+@@ -3342,13 +3342,13 @@ xmlXPathCmpNodes(xmlNodePtr node1, xmlNodePtr node2) {
+      * compute depth to root
+      */
+     for (depth2 = 0, cur = node2;cur->parent != NULL;cur = cur->parent) {
+-	if (cur == node1)
++	if (cur->parent == node1)
+ 	    return(1);
+ 	depth2++;
+     }
+     root = cur;
+     for (depth1 = 0, cur = node1;cur->parent != NULL;cur = cur->parent) {
+-	if (cur == node2)
++	if (cur->parent == node2)
+ 	    return(-1);
+ 	depth1++;
+     }
+-- 
+2.9.3
+

--- a/patches/libxml2/0002-Fix-XPointer-paths-beginning-with-range-to.patch
+++ b/patches/libxml2/0002-Fix-XPointer-paths-beginning-with-range-to.patch
@@ -1,0 +1,174 @@
+From 9ab01a277d71f54d3143c2cf333c5c2e9aaedd9e Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Tue, 28 Jun 2016 14:22:23 +0200
+Subject: [PATCH] Fix XPointer paths beginning with range-to
+
+The old code would invoke the broken xmlXPtrRangeToFunction. range-to
+isn't really a function but a special kind of location step. Remove
+this function and always handle range-to in the XPath code.
+
+The old xmlXPtrRangeToFunction could also be abused to trigger a
+use-after-free error with the potential for remote code execution.
+
+Found with afl-fuzz.
+
+Fixes CVE-2016-5131.
+---
+ result/XPath/xptr/vidbase | 13 ++++++++
+ test/XPath/xptr/vidbase   |  1 +
+ xpath.c                   |  7 ++++-
+ xpointer.c                | 76 ++++-------------------------------------------
+ 4 files changed, 26 insertions(+), 71 deletions(-)
+
+diff --git a/result/XPath/xptr/vidbase b/result/XPath/xptr/vidbase
+index 8b9e92d..f19193e 100644
+--- a/result/XPath/xptr/vidbase
++++ b/result/XPath/xptr/vidbase
+@@ -17,3 +17,16 @@ Object is a Location Set:
+   To node
+     ELEMENT p
+ 
++
++========================
++Expression: xpointer(range-to(id('chapter2')))
++Object is a Location Set:
++1 :   Object is a range :
++  From node
++     /
++  To node
++    ELEMENT chapter
++      ATTRIBUTE id
++        TEXT
++          content=chapter2
++
+diff --git a/test/XPath/xptr/vidbase b/test/XPath/xptr/vidbase
+index b146383..884b106 100644
+--- a/test/XPath/xptr/vidbase
++++ b/test/XPath/xptr/vidbase
+@@ -1,2 +1,3 @@
+ xpointer(id('chapter1')/p)
+ xpointer(id('chapter1')/p[1]/range-to(following-sibling::p[2]))
++xpointer(range-to(id('chapter2')))
+diff --git a/xpath.c b/xpath.c
+index d992841..5a01b1b 100644
+--- a/xpath.c
++++ b/xpath.c
+@@ -10691,13 +10691,18 @@ xmlXPathCompPathExpr(xmlXPathParserContextPtr ctxt) {
+ 		    lc = 1;
+ 		    break;
+ 		} else if ((NXT(len) == '(')) {
+-		    /* Note Type or Function */
++		    /* Node Type or Function */
+ 		    if (xmlXPathIsNodeType(name)) {
+ #ifdef DEBUG_STEP
+ 		        xmlGenericError(xmlGenericErrorContext,
+ 				"PathExpr: Type search\n");
+ #endif
+ 			lc = 1;
++#ifdef LIBXML_XPTR_ENABLED
++                    } else if (ctxt->xptr &&
++                               xmlStrEqual(name, BAD_CAST "range-to")) {
++                        lc = 1;
++#endif
+ 		    } else {
+ #ifdef DEBUG_STEP
+ 		        xmlGenericError(xmlGenericErrorContext,
+diff --git a/xpointer.c b/xpointer.c
+index 676c510..d74174a 100644
+--- a/xpointer.c
++++ b/xpointer.c
+@@ -1332,8 +1332,6 @@ xmlXPtrNewContext(xmlDocPtr doc, xmlNodePtr here, xmlNodePtr origin) {
+     ret->here = here;
+     ret->origin = origin;
+ 
+-    xmlXPathRegisterFunc(ret, (xmlChar *)"range-to",
+-	                 xmlXPtrRangeToFunction);
+     xmlXPathRegisterFunc(ret, (xmlChar *)"range",
+ 	                 xmlXPtrRangeFunction);
+     xmlXPathRegisterFunc(ret, (xmlChar *)"range-inside",
+@@ -2243,76 +2241,14 @@ xmlXPtrRangeInsideFunction(xmlXPathParserContextPtr ctxt, int nargs) {
+  * @nargs:  the number of args
+  *
+  * Implement the range-to() XPointer function
++ *
++ * Obsolete. range-to is not a real function but a special type of location
++ * step which is handled in xpath.c.
+  */
+ void
+-xmlXPtrRangeToFunction(xmlXPathParserContextPtr ctxt, int nargs) {
+-    xmlXPathObjectPtr range;
+-    const xmlChar *cur;
+-    xmlXPathObjectPtr res, obj;
+-    xmlXPathObjectPtr tmp;
+-    xmlLocationSetPtr newset = NULL;
+-    xmlNodeSetPtr oldset;
+-    int i;
+-
+-    if (ctxt == NULL) return;
+-    CHECK_ARITY(1);
+-    /*
+-     * Save the expression pointer since we will have to evaluate
+-     * it multiple times. Initialize the new set.
+-     */
+-    CHECK_TYPE(XPATH_NODESET);
+-    obj = valuePop(ctxt);
+-    oldset = obj->nodesetval;
+-    ctxt->context->node = NULL;
+-
+-    cur = ctxt->cur;
+-    newset = xmlXPtrLocationSetCreate(NULL);
+-
+-    for (i = 0; i < oldset->nodeNr; i++) {
+-	ctxt->cur = cur;
+-
+-	/*
+-	 * Run the evaluation with a node list made of a single item
+-	 * in the nodeset.
+-	 */
+-	ctxt->context->node = oldset->nodeTab[i];
+-	tmp = xmlXPathNewNodeSet(ctxt->context->node);
+-	valuePush(ctxt, tmp);
+-
+-	xmlXPathEvalExpr(ctxt);
+-	CHECK_ERROR;
+-
+-	/*
+-	 * The result of the evaluation need to be tested to
+-	 * decided whether the filter succeeded or not
+-	 */
+-	res = valuePop(ctxt);
+-	range = xmlXPtrNewRangeNodeObject(oldset->nodeTab[i], res);
+-	if (range != NULL) {
+-	    xmlXPtrLocationSetAdd(newset, range);
+-	}
+-
+-	/*
+-	 * Cleanup
+-	 */
+-	if (res != NULL)
+-	    xmlXPathFreeObject(res);
+-	if (ctxt->value == tmp) {
+-	    res = valuePop(ctxt);
+-	    xmlXPathFreeObject(res);
+-	}
+-
+-	ctxt->context->node = NULL;
+-    }
+-
+-    /*
+-     * The result is used as the new evaluation set.
+-     */
+-    xmlXPathFreeObject(obj);
+-    ctxt->context->node = NULL;
+-    ctxt->context->contextSize = -1;
+-    ctxt->context->proximityPosition = -1;
+-    valuePush(ctxt, xmlXPtrWrapLocationSet(newset));
++xmlXPtrRangeToFunction(xmlXPathParserContextPtr ctxt,
++                       int nargs ATTRIBUTE_UNUSED) {
++    XP_ERROR(XPATH_EXPR_ERROR);
+ }
+ 
+ /**
+-- 
+2.9.3
+

--- a/patches/libxml2/0003-Disallow-namespace-nodes-in-XPointer-ranges.patch
+++ b/patches/libxml2/0003-Disallow-namespace-nodes-in-XPointer-ranges.patch
@@ -1,0 +1,249 @@
+From c1d1f7121194036608bf555f08d3062a36fd344b Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Tue, 28 Jun 2016 18:34:52 +0200
+Subject: [PATCH] Disallow namespace nodes in XPointer ranges
+
+Namespace nodes must be copied to avoid use-after-free errors.
+But they don't necessarily have a physical representation in a
+document, so simply disallow them in XPointer ranges.
+
+Found with afl-fuzz.
+
+Fixes CVE-2016-4658.
+---
+ xpointer.c | 149 +++++++++++++++++++++++--------------------------------------
+ 1 file changed, 56 insertions(+), 93 deletions(-)
+
+diff --git a/xpointer.c b/xpointer.c
+index a7b03fb..694d120 100644
+--- a/xpointer.c
++++ b/xpointer.c
+@@ -319,6 +319,45 @@ xmlXPtrRangesEqual(xmlXPathObjectPtr range1, xmlXPathObjectPtr range2) {
+     return(1);
+ }
+ 
++/**
++ * xmlXPtrNewRangeInternal:
++ * @start:  the starting node
++ * @startindex:  the start index
++ * @end:  the ending point
++ * @endindex:  the ending index
++ *
++ * Internal function to create a new xmlXPathObjectPtr of type range
++ *
++ * Returns the newly created object.
++ */
++static xmlXPathObjectPtr
++xmlXPtrNewRangeInternal(xmlNodePtr start, int startindex,
++                        xmlNodePtr end, int endindex) {
++    xmlXPathObjectPtr ret;
++
++    /*
++     * Namespace nodes must be copied (see xmlXPathNodeSetDupNs).
++     * Disallow them for now.
++     */
++    if ((start != NULL) && (start->type == XML_NAMESPACE_DECL))
++	return(NULL);
++    if ((end != NULL) && (end->type == XML_NAMESPACE_DECL))
++	return(NULL);
++
++    ret = (xmlXPathObjectPtr) xmlMalloc(sizeof(xmlXPathObject));
++    if (ret == NULL) {
++        xmlXPtrErrMemory("allocating range");
++	return(NULL);
++    }
++    memset(ret, 0, sizeof(xmlXPathObject));
++    ret->type = XPATH_RANGE;
++    ret->user = start;
++    ret->index = startindex;
++    ret->user2 = end;
++    ret->index2 = endindex;
++    return(ret);
++}
++
+ /**
+  * xmlXPtrNewRange:
+  * @start:  the starting node
+@@ -344,17 +383,7 @@ xmlXPtrNewRange(xmlNodePtr start, int startindex,
+     if (endindex < 0)
+ 	return(NULL);
+ 
+-    ret = (xmlXPathObjectPtr) xmlMalloc(sizeof(xmlXPathObject));
+-    if (ret == NULL) {
+-        xmlXPtrErrMemory("allocating range");
+-	return(NULL);
+-    }
+-    memset(ret, 0 , (size_t) sizeof(xmlXPathObject));
+-    ret->type = XPATH_RANGE;
+-    ret->user = start;
+-    ret->index = startindex;
+-    ret->user2 = end;
+-    ret->index2 = endindex;
++    ret = xmlXPtrNewRangeInternal(start, startindex, end, endindex);
+     xmlXPtrRangeCheckOrder(ret);
+     return(ret);
+ }
+@@ -381,17 +410,8 @@ xmlXPtrNewRangePoints(xmlXPathObjectPtr start, xmlXPathObjectPtr end) {
+     if (end->type != XPATH_POINT)
+ 	return(NULL);
+ 
+-    ret = (xmlXPathObjectPtr) xmlMalloc(sizeof(xmlXPathObject));
+-    if (ret == NULL) {
+-        xmlXPtrErrMemory("allocating range");
+-	return(NULL);
+-    }
+-    memset(ret, 0 , (size_t) sizeof(xmlXPathObject));
+-    ret->type = XPATH_RANGE;
+-    ret->user = start->user;
+-    ret->index = start->index;
+-    ret->user2 = end->user;
+-    ret->index2 = end->index;
++    ret = xmlXPtrNewRangeInternal(start->user, start->index, end->user,
++                                  end->index);
+     xmlXPtrRangeCheckOrder(ret);
+     return(ret);
+ }
+@@ -416,17 +436,7 @@ xmlXPtrNewRangePointNode(xmlXPathObjectPtr start, xmlNodePtr end) {
+     if (start->type != XPATH_POINT)
+ 	return(NULL);
+ 
+-    ret = (xmlXPathObjectPtr) xmlMalloc(sizeof(xmlXPathObject));
+-    if (ret == NULL) {
+-        xmlXPtrErrMemory("allocating range");
+-	return(NULL);
+-    }
+-    memset(ret, 0 , (size_t) sizeof(xmlXPathObject));
+-    ret->type = XPATH_RANGE;
+-    ret->user = start->user;
+-    ret->index = start->index;
+-    ret->user2 = end;
+-    ret->index2 = -1;
++    ret = xmlXPtrNewRangeInternal(start->user, start->index, end, -1);
+     xmlXPtrRangeCheckOrder(ret);
+     return(ret);
+ }
+@@ -453,17 +463,7 @@ xmlXPtrNewRangeNodePoint(xmlNodePtr start, xmlXPathObjectPtr end) {
+     if (end->type != XPATH_POINT)
+ 	return(NULL);
+ 
+-    ret = (xmlXPathObjectPtr) xmlMalloc(sizeof(xmlXPathObject));
+-    if (ret == NULL) {
+-        xmlXPtrErrMemory("allocating range");
+-	return(NULL);
+-    }
+-    memset(ret, 0 , (size_t) sizeof(xmlXPathObject));
+-    ret->type = XPATH_RANGE;
+-    ret->user = start;
+-    ret->index = -1;
+-    ret->user2 = end->user;
+-    ret->index2 = end->index;
++    ret = xmlXPtrNewRangeInternal(start, -1, end->user, end->index);
+     xmlXPtrRangeCheckOrder(ret);
+     return(ret);
+ }
+@@ -486,17 +486,7 @@ xmlXPtrNewRangeNodes(xmlNodePtr start, xmlNodePtr end) {
+     if (end == NULL)
+ 	return(NULL);
+ 
+-    ret = (xmlXPathObjectPtr) xmlMalloc(sizeof(xmlXPathObject));
+-    if (ret == NULL) {
+-        xmlXPtrErrMemory("allocating range");
+-	return(NULL);
+-    }
+-    memset(ret, 0 , (size_t) sizeof(xmlXPathObject));
+-    ret->type = XPATH_RANGE;
+-    ret->user = start;
+-    ret->index = -1;
+-    ret->user2 = end;
+-    ret->index2 = -1;
++    ret = xmlXPtrNewRangeInternal(start, -1, end, -1);
+     xmlXPtrRangeCheckOrder(ret);
+     return(ret);
+ }
+@@ -516,17 +506,7 @@ xmlXPtrNewCollapsedRange(xmlNodePtr start) {
+     if (start == NULL)
+ 	return(NULL);
+ 
+-    ret = (xmlXPathObjectPtr) xmlMalloc(sizeof(xmlXPathObject));
+-    if (ret == NULL) {
+-        xmlXPtrErrMemory("allocating range");
+-	return(NULL);
+-    }
+-    memset(ret, 0 , (size_t) sizeof(xmlXPathObject));
+-    ret->type = XPATH_RANGE;
+-    ret->user = start;
+-    ret->index = -1;
+-    ret->user2 = NULL;
+-    ret->index2 = -1;
++    ret = xmlXPtrNewRangeInternal(start, -1, NULL, -1);
+     return(ret);
+ }
+ 
+@@ -541,6 +521,8 @@ xmlXPtrNewCollapsedRange(xmlNodePtr start) {
+  */
+ xmlXPathObjectPtr
+ xmlXPtrNewRangeNodeObject(xmlNodePtr start, xmlXPathObjectPtr end) {
++    xmlNodePtr endNode;
++    int endIndex;
+     xmlXPathObjectPtr ret;
+ 
+     if (start == NULL)
+@@ -549,7 +531,12 @@ xmlXPtrNewRangeNodeObject(xmlNodePtr start, xmlXPathObjectPtr end) {
+ 	return(NULL);
+     switch (end->type) {
+ 	case XPATH_POINT:
++	    endNode = end->user;
++	    endIndex = end->index;
++	    break;
+ 	case XPATH_RANGE:
++	    endNode = end->user2;
++	    endIndex = end->index2;
+ 	    break;
+ 	case XPATH_NODESET:
+ 	    /*
+@@ -557,39 +544,15 @@ xmlXPtrNewRangeNodeObject(xmlNodePtr start, xmlXPathObjectPtr end) {
+ 	     */
+ 	    if (end->nodesetval->nodeNr <= 0)
+ 		return(NULL);
++	    endNode = end->nodesetval->nodeTab[end->nodesetval->nodeNr - 1];
++	    endIndex = -1;
+ 	    break;
+ 	default:
+ 	    /* TODO */
+ 	    return(NULL);
+     }
+ 
+-    ret = (xmlXPathObjectPtr) xmlMalloc(sizeof(xmlXPathObject));
+-    if (ret == NULL) {
+-        xmlXPtrErrMemory("allocating range");
+-	return(NULL);
+-    }
+-    memset(ret, 0 , (size_t) sizeof(xmlXPathObject));
+-    ret->type = XPATH_RANGE;
+-    ret->user = start;
+-    ret->index = -1;
+-    switch (end->type) {
+-	case XPATH_POINT:
+-	    ret->user2 = end->user;
+-	    ret->index2 = end->index;
+-	    break;
+-	case XPATH_RANGE:
+-	    ret->user2 = end->user2;
+-	    ret->index2 = end->index2;
+-	    break;
+-	case XPATH_NODESET: {
+-	    ret->user2 = end->nodesetval->nodeTab[end->nodesetval->nodeNr - 1];
+-	    ret->index2 = -1;
+-	    break;
+-	}
+-	default:
+-	    STRANGE
+-	    return(NULL);
+-    }
++    ret = xmlXPtrNewRangeInternal(start, -1, endNode, endIndex);
+     xmlXPtrRangeCheckOrder(ret);
+     return(ret);
+ }
+-- 
+2.9.3
+


### PR DESCRIPTION
⚠️  ⚠️  ⚠️  ⚠️  ⚠️  
The 	f2dd079, 3b9ee4b and 002e4d8 commits shouldn't appear, but do because this was created from the `v1.6.8.1` tag. Ideally I'd like to target a branch off the `v1.6.8.1` tag (e.g. `v1.6.8.x`). I'll happily clean up this changeset and retarget the base branch once that exists.
⚠️  ⚠️  ⚠️  ⚠️  ⚠️  

💁  These changes backport the patches for [USN-3235-1](https://www.ubuntu.com/usn/usn-3235-1/) back to the 1.6.8.x series.