### PR TITLE
Clamp results of NodeSet#first to length of NodeSet

### DIFF
--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -26,7 +26,7 @@ module Nokogiri
       def first n = nil
         return self[0] unless n
         list = []
-        n.times { |i| list << self[i] }
+        [n, length].min.times { |i| list << self[i] }
         list
       end
 

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -251,6 +251,11 @@ module Nokogiri
         assert node_set = @xml.xpath('//employee')
         assert_equal 2, node_set.first(2).length
       end
+      
+      def test_first_clamps_arguments
+        assert node_set = @xml.xpath('//employee[position() < 3]')
+        assert_equal 2, node_set.first(5).length
+      end
 
       [:dup, :clone].each do |method_name|
         define_method "test_#{method_name}" do


### PR DESCRIPTION
NodeSet#first did not perform the same as Enumberable#first

An example from ruby doc being:

%w[foo bar baz].first(10) #=> ["foo", "bar", "baz"] 

What was expected:

Nokogiri::HTML('<a></a><a></a>').css('a').first(3)
[#<Nokogiri::XML::Element:0x3fc3dfd5f1c8 name="a">, #<Nokogiri::XML::Element:0x3fc3dfd5f1b4 name="a">]

What was received:

Nokogiri::HTML('<a></a><a></a>').css('a').first(3)
[#<Nokogiri::XML::Element:0x3fc3dfd5f1c8 name="a">, #<Nokogiri::XML::Element:0x3fc3dfd5f1b4 name="a">, nil]