### PR TITLE
get rid of C99ism

### DIFF
--- a/ext/nokogiri/xml_sax_parser.c
+++ b/ext/nokogiri/xml_sax_parser.c
@@ -19,15 +19,16 @@ static void start_document(void * ctx)
   if(NULL != ctxt && ctxt->html != 1) {
     if(ctxt->standalone != -1) {  /* -1 means there was no declaration */
       VALUE encoding = Qnil ;
+      VALUE standalone = Qnil;
+      VALUE version;
       if (ctxt->encoding) {
         encoding = NOKOGIRI_STR_NEW2(ctxt->encoding) ;
       } else if (ctxt->input && ctxt->input->encoding) {
         encoding = NOKOGIRI_STR_NEW2(ctxt->input->encoding) ;
       }
 
-      VALUE version = ctxt->version ? NOKOGIRI_STR_NEW2(ctxt->version) : Qnil;
+      version = ctxt->version ? NOKOGIRI_STR_NEW2(ctxt->version) : Qnil;
 
-      VALUE standalone = Qnil;
       switch(ctxt->standalone)
       {
         case 0:


### PR DESCRIPTION
We know that it is a good custom to keep the scope of variables narrower.
But, sadly, Visual C++ does not support such style.