### PR TITLE
Add API to set line number, fixes #1657

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1254,6 +1254,30 @@ static VALUE native_write_to(
 
 /*
  * call-seq:
+ *  line=
+ *
+ * Sets the line number for this Node to +line+
+ */
+static VALUE set_line(VALUE self, VALUE line)
+{
+  xmlNodePtr node;
+  int line_int = NUM2INT(line);
+  
+  Data_Get_Struct(self, xmlNode, node);
+
+  if (line_int < 65535)
+    node->line = (unsigned short)line;
+  else {
+    node->line = 65535;
+    if (node->type == XML_TEXT_NODE)
+      node->psvi = (void *)line;
+  }
+  
+  return self;
+}
+
+/*
+ * call-seq:
  *  line
  *
  * Returns the line for this Node
@@ -1657,6 +1681,7 @@ void init_xml_node()
   rb_define_method(klass, "create_external_subset", create_external_subset, 3);
   rb_define_method(klass, "pointer_id", pointer_id, 0);
   rb_define_method(klass, "line", line, 0);
+  rb_define_method(klass, "line=", set_line, 1);
   rb_define_method(klass, "content", get_native_content, 0);
   rb_define_method(klass, "native_content=", set_native_content, 1);
   rb_define_method(klass, "lang", get_lang, 0);

--- a/test/xml/test_attribute_decl.rb
+++ b/test/xml/test_attribute_decl.rb
@@ -63,6 +63,12 @@ module Nokogiri
         end
       end
 
+      def test_set_line
+        assert_raise NoMethodError do
+          @attr_decl.line = 42
+        end
+      end
+
       def test_attribute_type
         if Nokogiri.uses_libxml?
           assert_equal 1, @attr_decl.attribute_type

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -310,6 +310,12 @@ module Nokogiri
         end
       end
 
+      def test_set_line
+        assert_raise NoMethodError do
+          @xml.line = 42
+        end
+      end
+
       def test_empty_node_converted_to_html_is_not_self_closing
         doc = Nokogiri::XML('<a></a>')
         assert_equal "<a></a>", doc.inner_html

--- a/test/xml/test_dtd.rb
+++ b/test/xml/test_dtd.rb
@@ -147,6 +147,12 @@ module Nokogiri
         end
       end
 
+      def test_set_line
+        assert_raise NoMethodError do
+          @dtd.line = 42
+        end
+      end
+
       def test_validate
         if Nokogiri.uses_libxml?
           list = @xml.internal_subset.validate @xml

--- a/test/xml/test_element_decl.rb
+++ b/test/xml/test_element_decl.rb
@@ -40,6 +40,12 @@ module Nokogiri
         end
       end
 
+      def test_set_line
+        assert_raise NoMethodError do
+          @elements.first.line = 42
+        end
+      end
+
       def test_namespace
         assert_raise NoMethodError do
           @elements.first.namespace

--- a/test/xml/test_entity_decl.rb
+++ b/test/xml/test_entity_decl.rb
@@ -111,6 +111,12 @@ module Nokogiri
         end
       end
 
+      def test_set_line
+        assert_raise NoMethodError do
+          @entity_decl.line = 42
+        end
+      end
+
       def test_inspect
         assert_equal(
           "#<#{@entity_decl.class.name}:#{sprintf("0x%x", @entity_decl.object_id)} #{@entity_decl.to_s.inspect}>",

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -1094,6 +1094,21 @@ EOXML
         assert_equal 2, node.line
       end
 
+      def test_set_line
+        xml = Nokogiri::XML(<<-eoxml)
+        <root>
+          <a>
+            Hello world
+          </a>
+        </root>
+        eoxml
+
+        set = xml.search("//a")
+        node = set.first
+        node.line = 42
+        assert_equal 42, node.line
+      end
+
       def test_xpath_results_have_document_and_are_decorated
         x = Module.new do
           def awesome! ; end


### PR DESCRIPTION
This adds a way to set XML node line numbers.

Why would you want to do that? Constructed nodes. See one implementation that needs this here https://github.com/rubys/nokogumbo/issues/53#issuecomment-309504802

Sorry, this is maybe a useless contribution, I don't actually know Ruby, just pretending.

This fixes issue #1657.