### PR TITLE
Add missing closing parenthesis in rubydoc

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -679,7 +679,7 @@ module Nokogiri
       #
       # To save indented with two dashes:
       #
-      #   node.write_to(io, :indent_text => '-', :indent => 2
+      #   node.write_to(io, :indent_text => '-', :indent => 2)
       #
       def write_to io, *options
         options       = options.first.is_a?(Hash) ? options.shift : {}


### PR DESCRIPTION
^ What it says on the tin