### PR TITLE
Use UTF-8 as default encoding for Node#serialize

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -624,9 +624,7 @@ module Nokogiri
         options[:encoding] = encoding
 
         outstring = String.new
-        if encoding && outstring.respond_to?(:force_encoding)
-          outstring.force_encoding(Encoding.find(encoding))
-        end
+        outstring.force_encoding(Encoding.find(encoding || 'utf-8'))
         io = StringIO.new(outstring)
         write_to io, options, &block
         io.string

--- a/test/html/test_node_encoding.rb
+++ b/test/html/test_node_encoding.rb
@@ -26,6 +26,12 @@ module Nokogiri
         assert_equal @html.serialize, @doc.serialize
       end
 
+      def test_default_encoding
+        doc = Nokogiri::HTML(nil)
+        assert_nil doc.encoding
+        assert_equal 'UTF-8', doc.serialize.encoding.name
+      end
+
       def test_encode_special_chars
         foo = @html.css('a').first.encode_special_chars('foo')
         assert_equal 'UTF-8', foo.encoding.name

--- a/test/xml/test_node_encoding.rb
+++ b/test/xml/test_node_encoding.rb
@@ -13,6 +13,12 @@ module Nokogiri
         assert_equal @xml.serialize, @doc.serialize
       end
 
+      def test_default_encoding
+        doc = Nokogiri::XML(VEHICLE_XML)
+        assert_nil doc.encoding
+        assert_equal 'UTF-8', doc.serialize.encoding.name
+      end
+
       def test_encoding_GH_1113
         utf8 = '<frag>shahid ὡ 𐄣 𢂁</frag>'
         hex = '<frag>shahid &#x1f61; &#x10123; &#x22081;</frag>'


### PR DESCRIPTION
`Node#serialize` used to return UTF-8 if no encoding was given. However this got broken in commit 53f9b66ee6.

Since UTF-8 is the default in XML and HTML5 specs, it makes sense to use UTF-8 in `serialize` as well and enforce this in the tests.

Fixes #1659