### PR TITLE
Replaced character stack with string buffer

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -298,6 +298,7 @@ test/helper.rb
 test/html/sax/test_parser.rb
 test/html/sax/test_parser_context.rb
 test/html/sax/test_push_parser.rb
+test/html/sax/test_parser_text.rb
 test/html/test_builder.rb
 test/html/test_document.rb
 test/html/test_document_encoding.rb
@@ -325,6 +326,7 @@ test/xml/node/test_subclass.rb
 test/xml/sax/test_parser.rb
 test/xml/sax/test_parser_context.rb
 test/xml/sax/test_push_parser.rb
+test/xml/sax/test_parser_text.rb
 test/xml/test_attr.rb
 test/xml/test_attribute_decl.rb
 test/xml/test_builder.rb

--- a/ext/java/nokogiri/internals/NokogiriHandler.java
+++ b/ext/java/nokogiri/internals/NokogiriHandler.java
@@ -61,7 +61,7 @@ import org.xml.sax.ext.DefaultHandler2;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
-    StringBuffer charactersBuffer;
+    StringBuilder charactersBuilder;
     private final Ruby ruby;
     private final RubyClass attrClass;
     private final IRubyObject object;
@@ -99,7 +99,7 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
     @Override
     public void startDocument() throws SAXException {
         call("start_document");
-        charactersBuffer = new StringBuffer();
+        charactersBuilder = new StringBuilder();
     }
 
     @Override
@@ -233,7 +233,7 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
 
     @Override
     public void characters(char[] ch, int start, int length) throws SAXException {
-        charactersBuffer.append(new String(ch, start, length));
+        charactersBuilder.append(ch, start, length);
     }
 
     @Override
@@ -249,8 +249,8 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
 
     @Override
     public void endCDATA() throws SAXException {
-        call("cdata_block", ruby.newString(charactersBuffer.toString()));
-        charactersBuffer.setLength(0);
+        call("cdata_block", ruby.newString(charactersBuilder.toString()));
+        charactersBuilder.setLength(0);
     }
 
     @Override
@@ -330,9 +330,9 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
     }
 
     protected void populateCharacters() {
-        if (charactersBuffer.length() > 0) {
-            call("characters", ruby.newString(charactersBuffer.toString()));
-            charactersBuffer.setLength(0);
+        if (charactersBuilder.length() > 0) {
+            call("characters", ruby.newString(charactersBuilder.toString()));
+            charactersBuilder.setLength(0);
         }
     }
 }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -201,14 +201,14 @@ module Nokogiri
           @items = Items.new
         end
 
-        %i[
-          xmldecl
-          start_document end_document
-          start_element end_element
-          start_element_namespace end_element_namespace
-          characters comment cdata_block
-          processing_instruction
-          error warning
+        [
+          :xmldecl,
+          :start_document, :end_document,
+          :start_element, :end_element,
+          :start_element_namespace, :end_element_namespace,
+          :characters, :comment, :cdata_block,
+          :processing_instruction,
+          :error, :warning
         ]
         .each do |name|
           define_method name do |*arguments|

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -186,6 +186,86 @@ module Nokogiri
           @processing_instructions << [name, content]
         end
       end
+
+      # This document will help us to test the strict order of items.
+
+      class DocWithOrderedItems < XML::SAX::Document
+        attr_reader :items
+
+        def initialize
+          # [
+          #   [ :method_1, argument_1, ... ],
+          #   [ :method_2, argument_2, ... ],
+          #   ...
+          # ]
+          @items = Items.new
+        end
+
+        %i[
+          xmldecl
+          start_document end_document
+          start_element end_element
+          start_element_namespace end_element_namespace
+          characters comment cdata_block
+          processing_instruction
+          error warning
+        ]
+        .each do |name|
+          define_method name do |*arguments|
+            @items << [name, *arguments]
+            super *arguments
+          end
+        end
+
+        class Items < Array
+          def get_root_content root_name
+            items          = clone
+            is_inside_root = false
+
+            items.select! do |item|
+              method_name  = item[0]
+              element_name = item[1]
+
+              case method_name
+              when :start_element, :start_element_namespace
+                if element_name == root_name
+                  is_inside_root = true
+                  next false
+                end
+
+              when :end_element, :end_element_namespace
+                is_inside_root = false if element_name == root_name and is_inside_root
+              end
+
+              is_inside_root
+            end
+
+            items
+          end
+
+          def select_methods(names)
+            items = clone
+
+            items.select! do |item|
+              name = item[0]
+              names.include? name
+            end
+
+            items
+          end
+
+          def strip_text! method_names
+            each do |item|
+              method_name = item[0]
+              text        = item[1]
+
+              text.strip! if method_names.include? method_name
+            end
+
+            nil
+          end
+        end
+      end
     end
   end
 end

--- a/test/html/sax/test_parser_text.rb
+++ b/test/html/sax/test_parser_text.rb
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+require "helper"
+
+module Nokogiri
+  module HTML
+    module SAX
+      class TestParserText < Nokogiri::SAX::TestCase
+        def setup
+          super
+          @doc    = DocWithOrderedItems.new
+          @parser = HTML::SAX::Parser.new @doc
+        end
+
+        def test_texts_order
+          html = <<-eohtml
+            <!DOCTYPE html>
+            <html>
+              <head></head>
+              <body>
+                text 0
+                <p>
+                  text 1
+                  <span>text 2</span>
+                  text 3
+                </p>
+
+                text 4
+                <!--
+                text 5
+                -->
+
+                <p>
+                  <!-- text 6 -->
+                  <span><!-- text 7 --></span>
+                  <!-- text 8 -->
+                </p>
+
+                <!-- text 9 -->
+              </body>
+            </html>
+          eohtml
+
+          @parser.parse html
+          items = @doc.items.get_root_content "body"
+          items = items.select_methods %i[
+            start_element end_element
+            characters comment
+          ]
+          items.strip_text! %i[characters comment]
+
+          assert_equal [
+            [:characters, 'text 0'],
+
+            [:start_element, 'p', []],
+            [:characters, 'text 1'],
+
+            [:start_element, 'span', []],
+            [:characters, 'text 2'],
+            [:end_element, 'span'],
+
+            [:characters, 'text 3'],
+            [:end_element, 'p'],
+
+            [:characters, 'text 4'],
+            [:comment, 'text 5'],
+            [:characters, ''],
+
+            [:start_element, 'p', []],
+            [:characters, ''],
+            [:comment, 'text 6'],
+            [:characters, ''],
+
+            [:start_element, 'span', []],
+            [:comment, 'text 7'],
+            [:end_element, 'span'],
+            [:characters, ''],
+
+            [:comment, 'text 8'],
+            [:characters, ''],
+            [:end_element, 'p'],
+            [:characters, ''],
+
+            [:comment, 'text 9'],
+            [:characters, '']
+          ], items
+
+          nil
+        end
+
+        def text_whitespace
+          html = <<-eohtml
+            <!DOCTYPE html>
+            <html>
+              <head></head>
+              <body>
+                <p>
+                  <span></span>
+                  <span> </span>
+                  <span>
+
+                  </span>
+                </p>
+                <p>
+                  <!---->
+                  <!-- -->
+                  <!--
+
+                  -->
+                </p>
+              </body>
+            </html>
+          eohtml
+
+          @parser.parse html
+          items = @doc.items.get_root_content "body"
+          items = items.select_methods %i[
+            start_element end_element
+            characters comment
+          ]
+          items.strip_text! %i[characters comment]
+
+          assert_equal [
+            [:characters, ''],
+            [:start_element, 'p', []],
+
+            [:characters, ''],
+            [:start_element, 'span', []],
+            [:end_element, 'span'],
+            [:characters, ''],
+
+            [:start_element, 'span', []],
+            [:characters, ''],
+            [:end_element, 'span'],
+            [:characters, ''],
+
+            [:start_element, 'span', []],
+            [:characters, ''],
+            [:end_element, 'span'],
+            [:characters, ''],
+
+            [:end_element, 'p'],
+            [:characters, ''],
+
+            [:start_element, 'p', []],
+            [:characters, ''],
+
+            [:comment, ''],
+            [:characters, ''],
+            [:comment, ''],
+            [:characters, ''],
+            [:comment, ''],
+            [:characters, ''],
+
+            [:end_element, 'p'],
+            [:characters, '']
+          ], items
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/test/html/sax/test_parser_text.rb
+++ b/test/html/sax/test_parser_text.rb
@@ -42,11 +42,11 @@ module Nokogiri
 
           @parser.parse html
           items = @doc.items.get_root_content "body"
-          items = items.select_methods %i[
-            start_element end_element
-            characters comment
+          items = items.select_methods [
+            :start_element, :end_element,
+            :characters, :comment
           ]
-          items.strip_text! %i[characters comment]
+          items.strip_text! [:characters, :comment]
 
           assert_equal [
             [:characters, 'text 0'],
@@ -113,11 +113,11 @@ module Nokogiri
 
           @parser.parse html
           items = @doc.items.get_root_content "body"
-          items = items.select_methods %i[
-            start_element end_element
-            characters comment
+          items = items.select_methods [
+            :start_element, :end_element,
+            :characters, :comment
           ]
-          items.strip_text! %i[characters comment]
+          items.strip_text! [:characters, :comment]
 
           assert_equal [
             [:characters, ''],

--- a/test/xml/sax/test_parser_text.rb
+++ b/test/xml/sax/test_parser_text.rb
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+require "helper"
+
+module Nokogiri
+  module XML
+    module SAX
+      class TestParserText < Nokogiri::SAX::TestCase
+        def setup
+          super
+          @doc    = DocWithOrderedItems.new
+          @parser = XML::SAX::Parser.new @doc
+        end
+
+        def test_texts_order
+          xml = <<-eoxml
+<?xml version="1.0" ?>
+<root>
+  text 0
+  <p>
+    text 1
+    <span>text 2</span>
+    text 3
+  </p>
+
+  text 4
+  <!--
+  text 5
+  -->
+
+  <p>
+    <!-- text 6 -->
+    <span><!-- text 7 --></span>
+    <!-- text 8 -->
+  </p>
+
+  <!-- text 9 -->
+  <![CDATA[ text 10 ]]>
+
+  <p>
+    <![CDATA[ text 11 ]]>
+    <span><![CDATA[ text 12 ]]></span>
+    <![CDATA[ text 13 ]]>
+  </p>
+</root>
+          eoxml
+
+          @parser.parse xml
+          items = @doc.items.get_root_content "root"
+          items = items.select_methods %i[
+            start_element end_element
+            characters comment cdata_block
+          ]
+          items.strip_text! %i[characters comment cdata_block]
+
+          assert_equal [
+            [:characters, 'text 0'],
+
+            [:start_element, 'p', []],
+            [:characters, 'text 1'],
+
+            [:start_element, 'span', []],
+            [:characters, 'text 2'],
+            [:end_element, 'span'],
+
+            [:characters, 'text 3'],
+            [:end_element, 'p'],
+
+            [:characters, 'text 4'],
+            [:comment, 'text 5'],
+            [:characters, ''],
+
+            [:start_element, 'p', []],
+            [:characters, ''],
+            [:comment, 'text 6'],
+            [:characters, ''],
+
+            [:start_element, 'span', []],
+            [:comment, 'text 7'],
+            [:end_element, 'span'],
+            [:characters, ''],
+
+            [:comment, 'text 8'],
+            [:characters, ''],
+            [:end_element, 'p'],
+            [:characters, ''],
+
+            [:comment, 'text 9'],
+            [:characters, ''],
+            [:cdata_block, 'text 10'],
+            [:characters, ''],
+
+            [:start_element, 'p', []],
+            [:characters, ''],
+            [:cdata_block, 'text 11'],
+            [:characters, ''],
+
+            [:start_element, 'span', []],
+            [:cdata_block, 'text 12'],
+            [:end_element, 'span'],
+            [:characters, ''],
+
+            [:cdata_block, 'text 13'],
+            [:characters, ''],
+
+            [:end_element, 'p'],
+            [:characters, '']
+          ], items
+
+          nil
+        end
+
+        def text_whitespace
+          xml = <<-eoxml
+<?xml version="1.0" ?>
+<root>
+  <p>
+    <span></span>
+    <span> </span>
+    <span>
+
+    </span>
+  </p>
+  <p>
+    <!---->
+    <!-- -->
+    <!--
+
+    -->
+  </p>
+  <p>
+    <![CDATA[]]>
+    <![CDATA[ ]]>
+    <![CDATA[
+
+    ]]>
+  </p>
+</root>
+          eoxml
+
+          @parser.parse xml
+          items = @doc.items.get_root_content "root"
+          items = items.select_methods %i[
+            start_element end_element
+            characters comment cdata_block
+          ]
+          items.strip_text! %i[characters comment cdata_block]
+
+          assert_equal [
+            [:characters, ''],
+            [:start_element, 'p', []],
+
+            [:characters, ''],
+            [:start_element, 'span', []],
+            [:end_element, 'span'],
+            [:characters, ''],
+
+            [:start_element, 'span', []],
+            [:characters, ''],
+            [:end_element, 'span'],
+            [:characters, ''],
+
+            [:start_element, 'span', []],
+            [:characters, ''],
+            [:end_element, 'span'],
+            [:characters, ''],
+
+            [:end_element, 'p'],
+            [:characters, ''],
+
+            [:start_element, 'p', []],
+            [:characters, ''],
+
+            [:comment, ''],
+            [:characters, ''],
+            [:comment, ''],
+            [:characters, ''],
+            [:comment, ''],
+            [:characters, ''],
+
+            [:end_element, 'p'],
+            [:characters, ''],
+
+            [:start_element, 'p', []],
+            [:characters, ''],
+
+            [:cdata_block, ''],
+            [:characters, ''],
+            [:cdata_block, ''],
+            [:characters, ''],
+            [:cdata_block, ''],
+            [:characters, ''],
+
+            [:end_element, 'p'],
+            [:characters, '']
+          ], items
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/test/xml/sax/test_parser_text.rb
+++ b/test/xml/sax/test_parser_text.rb
@@ -46,11 +46,11 @@ module Nokogiri
 
           @parser.parse xml
           items = @doc.items.get_root_content "root"
-          items = items.select_methods %i[
-            start_element end_element
-            characters comment cdata_block
+          items = items.select_methods [
+            :start_element, :end_element,
+            :characters, :comment, :cdata_block
           ]
-          items.strip_text! %i[characters comment cdata_block]
+          items.strip_text! [:characters, :comment, :cdata_block]
 
           assert_equal [
             [:characters, 'text 0'],
@@ -139,11 +139,11 @@ module Nokogiri
 
           @parser.parse xml
           items = @doc.items.get_root_content "root"
-          items = items.select_methods %i[
-            start_element end_element
-            characters comment cdata_block
+          items = items.select_methods [
+            :start_element, :end_element,
+            :characters, :comment, :cdata_block
           ]
-          items.strip_text! %i[characters comment cdata_block]
+          items.strip_text! [:characters, :comment, :cdata_block]
 
           assert_equal [
             [:characters, ''],


### PR DESCRIPTION
I've found an inconsistency between `c` and `java` version of html and xml sax parsers.

Let it be an html:
```
<p>
  text 1
  <span>text 2</span>
  text 3
</p>
```

We can expect that our sax parser will receive the following information:
```
start_element "p"
characters "text 1"
start_element "span"
characters "text 2"
end_element "span"
characters "text 3"
end_element "p"
```

`c` version works perfect but `java` does not. I've found a `characterStack` in `ext/java/nokogiri/internals/NokogiriHandler.java` that is actually a bug. I couldn't understand the reason of using stack for characters.

I was thinking for a long time about this stack and I've found the only reason for it: we will receive a list of character strings anyway when xml or html syntax is broken at the end of the document. But nokogiri has absolutely another methods of handling broken syntax. I think nokogiri should not keep this stack in the code.

So I've removed characters stack and added simple string buffer. The fix itself is very small.

Than I've added a special document to the test helper in order to test the strict order of parsed items. I've implemented 2 tests with regular text and whitespace for html and xml sax parsers.

Text nodes are regular text and comments for html parser. Xml test received a bonus: cdata blocks.