### PR TITLE
Add an options parameter to all the methods that allow creation of an HTML document fragment

### DIFF
--- a/ext/java/nokogiri/XmlDocumentFragment.java
+++ b/ext/java/nokogiri/XmlDocumentFragment.java
@@ -17,10 +17,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -52,6 +52,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.util.RuntimeHelpers;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.w3c.dom.Attr;
@@ -59,7 +60,7 @@ import org.w3c.dom.NamedNodeMap;
 
 /**
  * Class for Nokogiri::XML::DocumentFragment
- * 
+ *
  * @author sergio
  * @author Yoko Harada <yokolet@gmail.com>
  */
@@ -75,9 +76,9 @@ public class XmlDocumentFragment extends XmlNode {
         super(ruby, klazz);
     }
 
-    @JRubyMethod(name="new", meta = true, required=1, optional=2)
-    public static IRubyObject rbNew(ThreadContext context, IRubyObject cls, IRubyObject[] args) {
-        
+    @JRubyMethod(name="new", meta = true, required=1, optional=3)
+    public static IRubyObject rbNew(ThreadContext context, IRubyObject cls, IRubyObject[] args, Block block) {
+
         if(args.length < 1) {
             throw context.getRuntime().newArgumentError(args.length, 1);
         }
@@ -87,7 +88,7 @@ public class XmlDocumentFragment extends XmlNode {
         }
 
         XmlDocument doc = (XmlDocument) args[0];
-        
+
         // make wellformed fragment, ignore invalid namespace, or add appropriate namespace to parse
         if (args.length > 1 && args[1] instanceof RubyString) {
             if (XmlDocumentFragment.isTag((RubyString)args[1])) {
@@ -159,10 +160,10 @@ public class XmlDocumentFragment extends XmlNode {
                 tags = tags.replace(e.getKey(), e.getValue());
             }
         }
-        
+
         return tags;
     }
-    
+
     private static CharSequence getNamespaceDecl(final String prefix, NamedNodeMap nodeMap) {
         for (int i=0; i < nodeMap.getLength(); i++) {
             Attr attr = (Attr) nodeMap.item(i);

--- a/ext/nokogiri/xml_document_fragment.c
+++ b/ext/nokogiri/xml_document_fragment.c
@@ -25,8 +25,6 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
   rb_node = Nokogiri_wrap_xml_node(klass, node);
   rb_obj_call_init(rb_node, argc, argv);
 
-  if(rb_block_given_p()) rb_yield(rb_node);
-
   return rb_node;
 }
 

--- a/lib/nokogiri/html.rb
+++ b/lib/nokogiri/html.rb
@@ -26,8 +26,8 @@ module Nokogiri
 
       ####
       # Parse a fragment from +string+ in to a NodeSet.
-      def fragment string, encoding = nil
-        HTML::DocumentFragment.parse string, encoding
+      def fragment string, encoding = nil, options = nil, &block
+        HTML::DocumentFragment.parse string, encoding, options, &block
       end
     end
 

--- a/lib/nokogiri/html.rb
+++ b/lib/nokogiri/html.rb
@@ -26,7 +26,7 @@ module Nokogiri
 
       ####
       # Parse a fragment from +string+ in to a NodeSet.
-      def fragment string, encoding = nil, options = nil, &block
+      def fragment string, encoding = nil, options = XML::ParseOptions::DEFAULT_HTML, &block
         HTML::DocumentFragment.parse string, encoding, options, &block
       end
     end

--- a/lib/nokogiri/html/document_fragment.rb
+++ b/lib/nokogiri/html/document_fragment.rb
@@ -3,7 +3,7 @@ module Nokogiri
     class DocumentFragment < Nokogiri::XML::DocumentFragment
       ####
       # Create a Nokogiri::XML::DocumentFragment from +tags+, using +encoding+
-      def self.parse tags, encoding = nil
+      def self.parse tags, encoding = nil, options = nil
         doc = HTML::Document.new
 
         encoding ||= if tags.respond_to?(:encoding)
@@ -19,10 +19,10 @@ module Nokogiri
 
         doc.encoding = encoding
 
-        new(doc, tags)
+        new(doc, tags, nil, options)
       end
 
-      def initialize document, tags = nil, ctx = nil
+      def initialize document, tags = nil, ctx = nil, options = nil, &block
         return self unless tags
 
         if ctx
@@ -38,7 +38,7 @@ module Nokogiri
             path = "/html/body/node()"
           end
 
-          temp_doc = HTML::Document.parse "<html><body>#{tags}", nil, document.encoding
+          temp_doc = HTML::Document.parse "<html><body>#{tags}", nil, document.encoding, options, &block
           temp_doc.xpath(path).each { |child| child.parent = self }
           self.errors = temp_doc.errors
         end

--- a/lib/nokogiri/html/document_fragment.rb
+++ b/lib/nokogiri/html/document_fragment.rb
@@ -3,7 +3,7 @@ module Nokogiri
     class DocumentFragment < Nokogiri::XML::DocumentFragment
       ####
       # Create a Nokogiri::XML::DocumentFragment from +tags+, using +encoding+
-      def self.parse tags, encoding = nil, options = nil
+      def self.parse tags, encoding = nil, options = XML::ParseOptions::DEFAULT_HTML, &block
         doc = HTML::Document.new
 
         encoding ||= if tags.respond_to?(:encoding)
@@ -19,10 +19,10 @@ module Nokogiri
 
         doc.encoding = encoding
 
-        new(doc, tags, nil, options)
+        new(doc, tags, nil, options, &block)
       end
 
-      def initialize document, tags = nil, ctx = nil, options = nil, &block
+      def initialize document, tags = nil, ctx = nil, options = XML::ParseOptions::DEFAULT_HTML, &block
         return self unless tags
 
         if ctx

--- a/test/html/test_document_fragment.rb
+++ b/test/html/test_document_fragment.rb
@@ -38,6 +38,14 @@ module Nokogiri
         assert_match(/3:30/, doc.to_s)
       end
 
+      def test_passed_options_have_an_effect
+        html = "<span>test</span"
+        doc = Nokogiri::HTML::DocumentFragment.parse(html) do |options|
+          options.norecover
+        end
+        assert_equal "<span>test</span>", doc.to_html
+      end
+
       def test_parse_encoding
         fragment = "<div>hello world</div>"
         f = Nokogiri::HTML::DocumentFragment.parse fragment, 'ISO-8859-1'


### PR DESCRIPTION
We are facing an issue where we cannot provide a DocumentFragment with the `XML::ParseOptions::HUGE` option because it doesn't take the `options` int like the regular `Document` class does. This adds an optional parameter for passing that down.

Let me know if there need to be extra tests to ensure this is working :-)