### PR TITLE
remove ruby 1.9.3 and 2.0 from appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,3 @@ environment:
     - ruby_version: "22-x64"
     - ruby_version: "21"
     - ruby_version: "21-x64"
-    - ruby_version: "200"
-    - ruby_version: "200-x64"
-    - ruby_version: "193"


### PR DESCRIPTION
Ref: 84870381847cb