### PR TITLE
v1.7.x: allow jruby failures on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
     rvm: 2.3.1
   - os: linux
     rvm: rbx
+  - os: linux
+    rvm: jruby
   exclude:
   - os: osx
     rvm: jruby-1.7


### PR DESCRIPTION
Travis tries to install jruby-9.1.15.0200, then test failed.