### PR TITLE
Update appveyor.yml with 2.4 & trunk, remove 1.93

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,12 @@
+init:
+  - if %ruby_version%==_trunk (
+      appveyor DownloadFile https://ci.appveyor.com/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z -FileName C:\ruby_trunk.7z &
+      7z x C:\ruby_trunk.7z -oC:\ruby_trunk
+    )
+
 install:
-  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - SET PATH=C:\MinGW\bin;%PATH%
-  - SET RAKEOPT=-rdevkit
+  # Standard AV path has a lot of items
+  - SET PATH=C:\ruby%ruby_version%\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32
   - ruby --version
   - gem --version
   - bundle install
@@ -9,16 +14,25 @@ install:
 build: off
 
 test_script:
-  - bundle exec rake
+  - bundle exec rake -rdevkit
+
+on_finish:
+- ruby -v
 
 environment:
   matrix:
-    - ruby_version: "23"
-    - ruby_version: "23-x64"
-    - ruby_version: "22"
-    - ruby_version: "22-x64"
-    - ruby_version: "21"
-    - ruby_version: "21-x64"
-    - ruby_version: "200"
-    - ruby_version: "200-x64"
-    - ruby_version: "193"
+    - ruby_version: _trunk
+    - ruby_version: 24
+    - ruby_version: 24-x64
+    - ruby_version: 23
+    - ruby_version: 23-x64
+    - ruby_version: 22
+    - ruby_version: 22-x64
+    - ruby_version: 21
+    - ruby_version: 21-x64
+    - ruby_version: 200
+    - ruby_version: 200-x64
+
+matrix:
+  allow_failures:
+    - ruby_version: _trunk


### PR DESCRIPTION
Testing could be quickened up with either (or both) of the following:

1. Cache gems.
2. MSYS2 currently has packages matching libiconv, libxml2, libxslt, & zlib.  These could be used with ruby 2.4 and trunk, and shortly, 2.5.  These would need to be updated, as the installed AV packages are not always the most recently available MSYS2 packages.