### PR TITLE
Remove mysterious clearCachedNode call in JRuby that breaks Blather

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -464,9 +464,6 @@ public class XmlNode extends RubyObject {
             return;
         }
 
-        // TODO: this feels kind of weird, why are we clearing the XmlNode
-        // cache here !!!
-        clearCachedNode(node);
         Element e = (Element) node;
 
         // disable error checking to prevent lines like the following


### PR DESCRIPTION
It was previously described at "weird" and even the original author cannot remember why it is there. Its presence causes Blather's `Blather::XMPPNode` subclass instances to be recreated where they become generic `Nokogiri::XML::Element` instances instead.

Closes #1708.