### PR TITLE
Bunch of changes to make XmlSaxPushParser on JRuby compatible with the MRI implementation

### DIFF
--- a/ext/java/nokogiri/HtmlSaxPushParser.java
+++ b/ext/java/nokogiri/HtmlSaxPushParser.java
@@ -160,7 +160,7 @@ public class HtmlSaxPushParser extends RubyObject {
 
         if (!options.recover && parserTask.getErrorCount() > errorCount0) {
             terminateTask(context);
-            throw new RaiseException(parserTask.getLastError(), true);
+            throw parserTask.getLastError();
         }
 
         return this;
@@ -233,8 +233,8 @@ public class HtmlSaxPushParser extends RubyObject {
             else return parser.getNokogiriHandler().getErrorCount();
         }
 
-        private synchronized RubyException getLastError() {
-            return (RubyException) parser.getNokogiriHandler().getLastError();
+        private synchronized RaiseException getLastError() {
+            return parser.getNokogiriHandler().getLastError();
         }
     }
 }

--- a/ext/java/nokogiri/XmlSaxPushParser.java
+++ b/ext/java/nokogiri/XmlSaxPushParser.java
@@ -206,6 +206,10 @@ public class XmlSaxPushParser extends RubyObject {
     }
 
     private synchronized void terminateTask(ThreadContext context) {
+        if (futureTask == null || stream == null) {
+            return;
+        }
+
         try {
           Future<Void> task = stream.addChunk(NokogiriBlockingQueueInputStream.END);
           task.get();

--- a/ext/java/nokogiri/XmlSaxPushParser.java
+++ b/ext/java/nokogiri/XmlSaxPushParser.java
@@ -146,8 +146,7 @@ public class XmlSaxPushParser extends RubyObject {
         }
         final ByteArrayInputStream data = NokogiriHelpers.stringBytesToStream(chunk);
         if (data == null) {
-            terminateTask(context);
-            throw new RaiseException(XmlSyntaxError.createXMLSyntaxError(context.runtime)); // Nokogiri::XML::SyntaxError
+            return this;
         }
 
         int errorCount0 = parserTask.getErrorCount();

--- a/ext/java/nokogiri/XmlSaxPushParser.java
+++ b/ext/java/nokogiri/XmlSaxPushParser.java
@@ -176,7 +176,7 @@ public class XmlSaxPushParser extends RubyObject {
 
         if (!options.recover && parserTask.getErrorCount() > errorCount0) {
             terminateTask(context);
-            throw new RaiseException(parserTask.getLastError(), true);
+            throw parserTask.getLastError();
         }
 
         return this;
@@ -248,8 +248,8 @@ public class XmlSaxPushParser extends RubyObject {
             else return parser.getNokogiriHandler().getErrorCount();
         }
 
-        private synchronized RubyException getLastError() {
-            return (RubyException) parser.getNokogiriHandler().getLastError();
+        private synchronized RaiseException getLastError() {
+            return parser.getNokogiriHandler().getLastError();
         }
     }
 }

--- a/ext/java/nokogiri/XmlSaxPushParser.java
+++ b/ext/java/nokogiri/XmlSaxPushParser.java
@@ -157,6 +157,14 @@ public class XmlSaxPushParser extends RubyObject {
 
         int errorCount0 = parserTask.getErrorCount();
 
+        try {
+            Future<Void> task = stream.addChunk(data);
+            task.get();
+        } catch (ClosedStreamException ex) {
+            // this means the stream is closed, ignore this exception
+        } catch (Exception e) {
+            throw context.runtime.newRuntimeError(e.toString());
+        }
 
         if (isLast.isTrue()) {
             try {
@@ -167,18 +175,6 @@ public class XmlSaxPushParser extends RubyObject {
             } finally {
                 terminateTask(context);
             }
-        } else {
-            try {
-                Future<Void> task = stream.addChunk(data);
-                task.get();
-            }
-            catch (ClosedStreamException ex) {
-                // this means the stream is closed, ignore this exception
-            }
-            catch (Exception e) {
-                throw context.runtime.newRuntimeError(e.toString());
-            }
-
         }
 
         if (!options.recover && parserTask.getErrorCount() > errorCount0) {

--- a/test/xml/sax/test_push_parser.rb
+++ b/test/xml/sax/test_push_parser.rb
@@ -21,6 +21,24 @@ module Nokogiri
           end
         end
 
+        def test_should_throw_error_returned_by_document
+          doc = Doc.new
+          class << doc
+            def error msg
+              raise "parse error"
+            end
+          end
+
+          @parser = XML::SAX::PushParser.new(doc)
+          begin
+            @parser << "</foo>"
+          rescue => e
+            actual = e
+          end
+
+          assert_equal actual.message, "parse error"
+        end
+
         def test_writing_nil
           assert_equal @parser.write(nil), @parser
         end

--- a/test/xml/sax/test_push_parser.rb
+++ b/test/xml/sax/test_push_parser.rb
@@ -21,6 +21,14 @@ module Nokogiri
           end
         end
 
+        def test_write_last_chunk
+          @parser << "<foo>"
+          @parser.write "</foo>", true
+          assert_equal [["foo", []]], @parser.document.start_elements
+          assert_equal [["foo"]], @parser.document.end_elements
+        end
+
+
         def test_finish_should_rethrow_last_error
           begin
             @parser << "</foo>"

--- a/test/xml/sax/test_push_parser.rb
+++ b/test/xml/sax/test_push_parser.rb
@@ -21,6 +21,22 @@ module Nokogiri
           end
         end
 
+        def test_finish_should_rethrow_last_error
+          begin
+            @parser << "</foo>"
+          rescue => e
+            expected = e
+          end
+
+          begin
+            @parser.finish
+          rescue => e
+            actual = e
+          end
+
+          assert_equal actual.message, expected.message
+        end
+
         def test_should_throw_error_returned_by_document
           doc = Doc.new
           class << doc

--- a/test/xml/sax/test_push_parser.rb
+++ b/test/xml/sax/test_push_parser.rb
@@ -21,6 +21,13 @@ module Nokogiri
           end
         end
 
+        def test_early_finish
+          @parser << "<foo>"
+          assert_raises(SyntaxError) do
+            @parser.finish
+          end
+        end
+
         def test_write_last_chunk
           @parser << "<foo>"
           @parser.write "</foo>", true

--- a/test/xml/sax/test_push_parser.rb
+++ b/test/xml/sax/test_push_parser.rb
@@ -21,6 +21,10 @@ module Nokogiri
           end
         end
 
+        def test_writing_nil
+          assert_equal @parser.write(nil), @parser
+        end
+
         def test_end_document_called
           @parser.<<(<<-eoxml)
             <p id="asdfasdf">


### PR DESCRIPTION
This pr should fix #1710 and fix the differences in the push parser implementations on MRI and JRuby. Each change is split in its own commit along with the test that fails on JRuby.