### PR TITLE
CI against jruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,12 @@ matrix:
   - os: linux
     rvm: jruby-9.1.5.0
   - os: linux
+    rvm: jruby-head
+  - os: linux
     rvm: rbx-3
   allow_failures:
   - rvm: ruby-head
+  - rvm: jruby-head
   fast_finish: true
 
 # notifications:


### PR DESCRIPTION
Rails 6 will require CRuby 2.4.1 or higher https://github.com/rails/rails/pull/32034. It means JRuby 9.2 will be necessary to support Rails 6.

Then I have opened a pull request https://github.com/rails/rails/pull/32064 to run CI with`jruby-head`and it gets `java.lang.ClassFormatError` below.

https://travis-ci.org/rails/rails/jobs/343639864

```ruby
LoadError: load error: nokogiri/nokogiri -- java.lang.ClassFormatError: Duplicate method name&signature in class file nokogiri/XmlSyntaxError$INVOKER$i$to_s19
``` 

I have opened a pull request to run nokogiri CI with jruby-head to see if this error reproduces without Rails. 