### PR TITLE
[fix] avoid potential (legacy) issues booting on newer JRubies 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -292,14 +292,6 @@ task :java_debug do
   ENV['JAVA_OPTS'] = '-Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=y' if ENV['JAVA_DEBUG']
 end
 
-if java?
-  task :test_19 => :test
-  task :test_20 do
-    ENV['JRUBY_OPTS'] = "--2.0"
-    Rake::Task["test"].invoke
-  end
-end
-
 Rake::Task[:test].prerequisites << :compile
 Rake::Task[:test].prerequisites << :java_debug
 Rake::Task[:test].prerequisites << :check_extra_deps unless java?

--- a/ext/java/nokogiri/XmlSyntaxError.java
+++ b/ext/java/nokogiri/XmlSyntaxError.java
@@ -34,10 +34,10 @@ package nokogiri;
 
 import static nokogiri.internals.NokogiriHelpers.stringOrNil;
 
-import org.jruby.CompatVersion;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyException;
+import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
@@ -120,26 +120,18 @@ public class XmlSyntaxError extends RubyException {
         setInstanceVariable("@file", stringOrNil(runtime, exception.getSystemId()));
     }
 
-    //@Override
-    //"to_s" method was branched in 1.8 and 1.9 since JRuby 1.6.6
-    // to support older version of JRuby, the annotation is commented out
+    // NOTE: special care - due JRuby 1.7.x
+    
     @Override
-    @JRubyMethod(name = "to_s", compat = CompatVersion.RUBY1_8)
-    public IRubyObject to_s(ThreadContext context) {
-        IRubyObject msg = msg(context.runtime);
-        return msg != null ? msg : super.to_s(context);
+    public IRubyObject to_s(ThreadContext context) { return to_s19(context); }
+
+    @JRubyMethod(name = "to_s")
+    public RubyString to_s19(ThreadContext context) {
+        RubyString msg = msg(context.runtime);
+        return msg != null ? msg : super.to_s(context).asString();
     }
 
-    //@Override
-    //"to_s" method was branched in 1.8 and 1.9 since JRuby 1.6.6
-    // to support older version of JRuby, the annotation is commented out
-    @JRubyMethod(name = "to_s", compat = CompatVersion.RUBY1_9)
-    public IRubyObject to_s19(ThreadContext context) {
-        IRubyObject msg = msg(context.runtime);
-        return msg != null ? msg : super.to_s19(context);
-    }
-
-    private IRubyObject msg(final Ruby runtime) {
+    private RubyString msg(final Ruby runtime) {
         if (exception != null && exception.getMessage() != null) {
             if (messageSet) return null;
             return runtime.newString( exception.getMessage() );


### PR DESCRIPTION
this change makes Nokogiri's JRuby ext backwards compatible as well as future compatible

see #1720 where JRuby (head) 9.2 had to work around 1.8 compat mode