### PR TITLE
Enable Nokogiri::XML::NodeSet#index to pass a block

### DIFF
--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -43,9 +43,14 @@ module Nokogiri
       end
 
       ###
-      # Returns the index of the first node in self that is == to +node+. Returns nil if no match is found.
-      def index(node)
-        each_with_index { |member, j| return j if member == node }
+      # Returns the index of the first node in self that is == to +node+ or meets the given block. Returns nil if no match is found.
+      def index(node = nil, &block)
+        if node
+          warn "given block not used" if block_given?
+          each_with_index { |member, j| return j if member == node }
+        elsif block_given?
+          each_with_index { |member, j| return j if yield(member) }
+        end
         nil
       end
 

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -563,6 +563,8 @@ module Nokogiri
 
         assert_equal 3, employees.index(employees[3])
         assert_nil employees.index(other)
+        assert_equal 3, employees.index {|employee| employee.search("employeeId/text()").to_s == "EMP0004" }
+        assert_nil employees.index {|employee| employee.search("employeeId/text()").to_s == "EMP0000" }
       end
 
       def test_slice_too_far


### PR DESCRIPTION
It's expected to have the same interface as Array#index.