### PR TITLE
fix a monkey patch introduced in #1251

### DIFF
--- a/ext/java/nokogiri/NokogiriService.java
+++ b/ext/java/nokogiri/NokogiriService.java
@@ -63,7 +63,9 @@ public class NokogiriService implements BasicLibraryService {
             Element[] array = ELEMENTS_ARRAY['T'-'A'];
             for(int i = 0; i < array.length; i++) {
                 if (array[i].name.equals("TR")) {
-                    array[i] = new Element(TR, "TR", Element.BLOCK, TABLE, new short[]{TD,TH,TR,COLGROUP,DIV});
+                    array[i] = new Element(TR, "TR", Element.BLOCK, null, new short[]{TD,TH,TR,COLGROUP,DIV});
+                    array[i].parent = new Element[]{getElement(TABLE)};
+                    break;
                 }
             }
         }


### PR DESCRIPTION
the patch accidentally removed the parents of the TR element. This caused any
document fragment with a dangling (i.e. with no parent) TD or TR element to
cause a stack overflow

fixes #1501