### PR TITLE
address compiler warnings on libxml2 2.9.8

### DIFF
--- a/ext/nokogiri/xml_dtd.c
+++ b/ext/nokogiri/xml_dtd.c
@@ -1,6 +1,6 @@
 #include <xml_dtd.h>
 
-static void notation_copier(void *payload, void *data, xmlChar *name)
+static void notation_copier(void *payload, void *data, const xmlChar *name)
 {
   VALUE hash = (VALUE)data;
   VALUE klass = rb_const_get(mNokogiriXml, rb_intern("Notation"));
@@ -17,7 +17,7 @@ static void notation_copier(void *payload, void *data, xmlChar *name)
   rb_hash_aset(hash, NOKOGIRI_STR_NEW2(name),notation);
 }
 
-static void element_copier(void *_payload, void *data, xmlChar *name)
+static void element_copier(void *_payload, void *data, const xmlChar *name)
 {
   VALUE hash = (VALUE)data;
   xmlNodePtr payload = (xmlNodePtr)_payload;


### PR DESCRIPTION
note that this causes compiler warnings on libxml2 < 2.9.8, which is
just something we'll have to deal with. :-(