### PR TITLE
Alias NodeSet#remove_attribute to NodeSet#remove_attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ If you're offended by what happened here, I'd kindly ask that you comment on the
 * [MRI] libxml2 is updated from 2.9.7 to 2.9.8
 
 
+## Features
+
+* NodeSet#remove_attribute is a new alias for NodeSet#remove_attr.
+
 ## Bug fixes
 
 * CSS attribute selectors now gracefully handle queries using integers. [#711]

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -187,6 +187,7 @@ module Nokogiri
         each { |el| el.delete name }
         self
       end
+      alias remove_attribute remove_attr
 
       ###
       # Iterate over each node, yielding  to +block+

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -51,6 +51,12 @@ module Nokogiri
         @list.each { |x| assert_nil x['class'] }
       end
 
+      def test_remove_attribute
+        @list.each { |x| x['class'] = 'blah' }
+        assert_equal @list, @list.remove_attribute('class')
+        @list.each { |x| assert_nil x['class'] }
+      end
+
       def test_add_class
         assert_equal @list, @list.add_class('bar')
         @list.each { |x| assert_equal 'bar', x['class'] }


### PR DESCRIPTION
The name `remove_attr` was a loanword from Hpricot::Elements, but it is confusing when we have `Node#remove_attribute`.