### PR TITLE
Add methods for class name manipulation to Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ If you're offended by what happened here, I'd kindly ask that you comment on the
 * [MRI] libxml2 is updated from 2.9.7 to 2.9.8
 
 
+## Features
+
+* Node#classes, #add_class, #append_class, and #remove_class are added.
+* NodeSet#append_class is added.
+
+
 ## Bug fixes
 
 * CSS attribute selectors now gracefully handle queries using integers. [#711]

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -351,6 +351,64 @@ module Nokogiri
       end
 
       ###
+      # Get the list of class names of this Node, without
+      # deduplication or sorting.
+      def classes
+        self['class'].to_s.scan(/\S+/)
+      end
+
+      ###
+      # Add +name+ to the "class" attribute value of this Node and
+      # return self.  If the value is already in the current value, it
+      # is not added.  If no "class" attribute exists yet, one is
+      # created with the given value.
+      #
+      # More than one class may be added at a time, separated by a
+      # space.
+      def add_class name
+        names = classes
+        self['class'] = (names + (name.scan(/\S+/) - names)).join(' ')
+        self
+      end
+
+      ###
+      # Append +name+ to the "class" attribute value of this Node and
+      # return self.  The value is simply appended without checking if
+      # it is already in the current value.  If no "class" attribute
+      # exists yet, one is created with the given value.
+      #
+      # More than one class may be appended at a time, separated by a
+      # space.
+      def append_class name
+        self['class'] = (classes + name.scan(/\S+/)).join(' ')
+        self
+      end
+
+      ###
+      # Remove +name+ from the "class" attribute value of this Node
+      # and return self.  If there are many occurrences of the name,
+      # they are all removed.
+      #
+      # More than one class may be removed at a time, separated by a
+      # space.
+      #
+      # If no class name is left after removal, or when +name+ is nil,
+      # the "class" attribute is removed from this Node.
+      def remove_class name = nil
+        if name
+          names = classes - name.scan(/\S+/)
+          if names.empty?
+            delete 'class'
+          else
+            self['class'] = names.join(' ')
+          end
+        else
+          delete "class"
+        end
+        self
+      end
+
+      ###
       # Remove the attribute named +name+
       def remove_attribute name
         attr = attributes[name].remove if key? name

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -135,31 +135,37 @@ module Nokogiri
       end
 
       ###
-      # Append the class attribute +name+ to all Node objects in the NodeSet.
+      # Add the class attribute +name+ to all Node objects in the
+      # NodeSet.
+      #
+      # See Nokogiri::XML::Node#add_class for more information.
       def add_class name
         each do |el|
-          classes = el['class'].to_s.split(/\s+/)
-          el['class'] = classes.push(name).uniq.join " "
+          el.add_class(name)
         end
         self
       end
 
       ###
-      # Remove the class attribute +name+ from all Node objects in the NodeSet.
-      # If +name+ is nil, remove the class attribute from all Nodes in the
+      # Append the class attribute +name+ to all Node objects in the
       # NodeSet.
+      #
+      # See Nokogiri::XML::Node#append_class for more information.
+      def append_class name
+        each do |el|
+          el.append_class(name)
+        end
+        self
+      end
+
+      ###
+      # Remove the class attribute +name+ from all Node objects in the
+      # NodeSet.
+      #
+      # See Nokogiri::XML::Node#remove_class for more information.
       def remove_class name = nil
         each do |el|
-          if name
-            classes = el['class'].to_s.split(/\s+/)
-            if classes.empty?
-              el.delete 'class'
-            else
-              el['class'] = (classes - [name]).uniq.join " "
-            end
-          else
-            el.delete "class"
-          end
+          el.remove_class(name)
         end
         self
       end

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -680,6 +680,89 @@ module Nokogiri
         assert_nil address['domestic']
       end
 
+      def test_classes
+        xml = Nokogiri::XML(<<-eoxml)
+        <div>
+          <p class=" foo  bar foo ">test</p>
+          <p class="">test</p>
+        </div>
+        eoxml
+        div = xml.at_xpath('//div')
+        p1, p2 = xml.xpath('//p')
+
+        assert_equal [], div.classes
+        assert_equal %w[foo bar foo], p1.classes
+        assert_equal [], p2.classes
+      end
+
+      def test_add_class
+        xml = Nokogiri::XML(<<-eoxml)
+        <div>
+          <p class=" foo  bar foo ">test</p>
+          <p class="">test</p>
+        </div>
+        eoxml
+        div = xml.at_xpath('//div')
+        p1, p2 = xml.xpath('//p')
+
+        assert_same div, div.add_class('main')
+        assert_equal 'main', div['class']
+
+        assert_same p1, p1.add_class('baz foo')
+        assert_equal 'foo bar foo baz', p1['class']
+
+        assert_same p2, p2.add_class('foo baz foo')
+        assert_equal 'foo baz foo', p2['class']
+      end
+
+      def test_append_class
+        xml = Nokogiri::XML(<<-eoxml)
+        <div>
+          <p class=" foo  bar foo ">test</p>
+          <p class="">test</p>
+        </div>
+        eoxml
+        div = xml.at_xpath('//div')
+        p1, p2 = xml.xpath('//p')
+
+        assert_same div, div.append_class('main')
+        assert_equal 'main', div['class']
+
+        assert_same p1, p1.append_class('baz foo')
+        assert_equal 'foo bar foo baz foo', p1['class']
+
+        assert_same p2, p2.append_class('foo baz foo')
+        assert_equal 'foo baz foo', p2['class']
+      end
+
+      def test_remove_class
+        xml = Nokogiri::XML(<<-eoxml)
+        <div>
+          <p class=" foo  bar baz foo ">test</p>
+          <p class=" foo  bar baz foo ">test</p>
+          <p class="foo foo">test</p>
+          <p class="">test</p>
+        </div>
+        eoxml
+        div = xml.at_xpath('//div')
+        p1, p2, p3, p4 = xml.xpath('//p')
+
+        assert_same div, div.remove_class('main')
+        assert_nil div['class']
+
+        assert_same p1, p1.remove_class('bar baz')
+        assert_equal 'foo foo', p1['class']
+
+        assert_same p2, p2.remove_class()
+        assert_nil p2['class']
+
+        assert_same p3, p3.remove_class('foo')
+        assert_nil p3['class']
+
+        assert_same p4, p4.remove_class('foo')
+        assert_nil p4['class']
+      end
+
       def test_set_content_with_symbol
         node = @xml.at('//name')
         node.content = :foo

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -62,6 +62,17 @@ module Nokogiri
         @list.each { |x| assert_equal 'bar baz', x['class'] }
       end
 
+      def test_append_class
+        assert_equal @list, @list.append_class('bar')
+        @list.each { |x| assert_equal 'bar', x['class'] }
+
+        @list.append_class('bar')
+        @list.each { |x| assert_equal 'bar bar', x['class'] }
+
+        @list.append_class('baz')
+        @list.each { |x| assert_equal 'bar bar baz', x['class'] }
+      end
+
       def test_remove_class_with_no_class
         assert_equal @list, @list.remove_class('bar')
         @list.each { |e| assert_nil e['class'] }


### PR DESCRIPTION
NodeSet has useful methods `#add_class` and `#remove_class`, but we don't have those in Node.

This PR adds the following methods for easy manipulation of the "class" attribute as a list of words:

- Node#classes
- Node#add_class(name)
- Node#append_class(name)
- Node#remove_class(name)
- NodeSet#append_class(name)

I carefully avoided deduplication because in HTML(5) a class attribute value is just a list of words and some may rely on the exact sequence of words in a class attribute value.