### PR TITLE
'#each' returns enumerator when no block given

### DIFF
--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -198,6 +198,8 @@ module Nokogiri
       ###
       # Iterate over each node, yielding  to +block+
       def each(&block)
+        return to_enum unless block_given?
+
         0.upto(length - 1) do |x|
           yield self[x]
         end

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -672,6 +672,11 @@ module Nokogiri
         assert ! empty_set.include?(employee)
       end
 
+      def test_each
+        employees = @xml.search("//employee")
+        assert_instance_of Enumerator, employees.each
+      end
+
       def test_children
         employees = @xml.search("//employee")
         count = 0


### PR DESCRIPTION
## Overview

The previous code produced an unconditional error unless the blocks were passed to each.

```ruby
headers.each.with_index(1) # returns 'no block given' error
```
So I can't call `Enumerator` methods like with_index

## Codes

- return Enumerator if the block is not given.
- add test code
