### PR TITLE
Remove unused &block argument

### DIFF
--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -41,7 +41,7 @@ module Nokogiri
       #
       # Nokogiri.XML() is a convenience method which will call this method.
       #
-      def self.parse string_or_io, url = nil, encoding = nil, options = ParseOptions::DEFAULT_XML, &block
+      def self.parse string_or_io, url = nil, encoding = nil, options = ParseOptions::DEFAULT_XML
         options = Nokogiri::XML::ParseOptions.new(options) if Integer === options
         # Give the options to the user
         yield options if block_given?

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -795,7 +795,7 @@ module Nokogiri
       # Do xinclude substitution on the subtree below node. If given a block, a
       # Nokogiri::XML::ParseOptions object initialized from +options+, will be
       # passed to it, allowing more convenient modification of the parser options.
-      def do_xinclude options = XML::ParseOptions::DEFAULT_XML, &block
+      def do_xinclude options = XML::ParseOptions::DEFAULT_XML
         options = Nokogiri::XML::ParseOptions.new(options) if Integer === options
 
         # give options to user

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -44,7 +44,7 @@ module Nokogiri
 
       ###
       # Returns the index of the first node in self that is == to +node+ or meets the given block. Returns nil if no match is found.
-      def index(node = nil, &block)
+      def index(node = nil)
         if node
           warn "given block not used" if block_given?
           each_with_index { |member, j| return j if member == node }
@@ -197,7 +197,7 @@ module Nokogiri
 
       ###
       # Iterate over each node, yielding  to +block+
-      def each(&block)
+      def each
         return to_enum unless block_given?
 
         0.upto(length - 1) do |x|
@@ -230,8 +230,8 @@ module Nokogiri
       end
 
       ###
-      # Wrap this NodeSet with +html+ or the results of the builder in +blk+
-      def wrap(html, &blk)
+      # Wrap this NodeSet with +html+
+      def wrap(html)
         each do |j|
           new_parent = document.parse(html).first
           j.add_next_sibling(new_parent)


### PR DESCRIPTION
Removing unused &block argument will prevent creating unnecessary proc.

**Example**:

Script:
```
xml_file = "test/files/staff.xml"
xml = Nokogiri::XML(File.read(xml_file), xml_file)
employees = xml.search("//employee")
MemoryProfiler.report{ employees.collect{|emp| emp.children.collect{|a| a.name}} }.pretty_print

```
Master:
```

Total allocated: 5280 bytes (93 objects)
Total retained:  0 bytes (0 objects)

allocated memory by class
-----------------------------------
      2600  String
      1400  Array
       960  Proc
       320  Nokogiri::XML::NodeSet

allocated objects by class
-----------------------------------
        65  String
        12  Proc
        11  Array
         5  Nokogiri::XML::NodeSet

```

After Changes:
```

Total allocated: 4320 bytes (81 objects)
Total retained:  0 bytes (0 objects)

allocated memory by class
-----------------------------------
      2600  String
      1400  Array
       320  Nokogiri::XML::NodeSet

allocated objects by class
-----------------------------------
        65  String
        11  Array
         5  Nokogiri::XML::NodeSet
```