### PR TITLE
Nokogumbo should be able to compile against Nokogiri by finding headers in extensions directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,32 @@ matrix:
     rvm: jruby-9.1.15.0
   - os: linux
     rvm: rbx-3
+  - name: packaged libraries
+    os: linux
+    rvm: 2.4.2
+    env:
+      - OVERRIDE_GEM_PATH=/tmp/gem_path
+    install:
+      - bundle install --jobs=3 --retry=3 --path vendor/bundle
+      - bundle exec rake
+      - bundle exec rake gem
+      - gem install -i /tmp/gem_path pkg/nokogiri-*.gem
+      - gem install -i /tmp/gem_path minitest
+    script:
+      - bundle exec rake test:package
+  - name: system libraries
+    os: linux
+    rvm: 2.4.2
+    env:
+      - OVERRIDE_GEM_PATH=/tmp/gem_path
+    install:
+      - bundle install --jobs=3 --retry=3 --path vendor/bundle
+      - bundle exec rake
+      - bundle exec rake gem
+      - gem install -i /tmp/gem_path pkg/nokogiri-*.gem -- --use-system-libraries
+      - gem install -i /tmp/gem_path minitest
+    script:
+      - bundle exec rake test:package
   allow_failures:
   - rvm: ruby-head
   fast_finish: true

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -661,6 +661,21 @@ have_func('xmlRelaxNGSetValidStructuredErrors')
 have_func('xmlSchemaSetValidStructuredErrors')
 have_func('xmlSchemaSetParserStructuredErrors')
 
+# Install the header files in the extension directory.
+$INSTALLFILES << ['*.h', '$(archdir)/include']
+
+unless using_system_libraries?
+  # $INSTALLFILES only works for files in this directory for some reason so
+  # copy the headers here first.
+  require 'fileutils'
+  FileUtils.rm_rf('include', secure: true)
+  FileUtils.mkdir('include')
+  [libxml2_recipe, libxslt_recipe].each do |recipe|
+    FileUtils.cp_r(Dir[File.join(recipe.path, 'include/*')], 'include')
+  end
+  $INSTALLFILES << ['include/**/*.h', '$(archdir)']
+end
+
 create_makefile('nokogiri/nokogiri')
 
 if enable_config('clean', true)

--- a/tasks/test.rb
+++ b/tasks/test.rb
@@ -97,4 +97,11 @@ namespace :test do
       puts "repro: #{v[:cmd]}" unless passed
     end
   end
+
+  task :package do
+    Bundler.with_clean_env do
+      env = ENV['OVERRIDE_GEM_PATH'] ? { 'GEM_PATH' => ENV['OVERRIDE_GEM_PATH'] } : {}
+      sh(env, RbConfig.ruby, '-rminitest', 'test/package.rb', { verbose: true })
+    end
+  end
 end

--- a/test/package.rb
+++ b/test/package.rb
@@ -1,0 +1,42 @@
+# These tests are only run by `rake test:package` and are intended to test the
+# installed gem.
+#
+# This isn't called test_package.rb to prevent it being picked up by Hoe as a
+# normal test.
+
+require 'minitest/autorun'
+
+class PackageTest < Minitest::Test
+  def setup
+    ext_dir = Gem::Specification.find_by_name('nokogiri').extension_dir
+    @headers_dir = File.join(ext_dir, 'nokogiri/include')
+  end
+
+  def test_nokogiri_headers
+    assert(File.directory?(@headers_dir))
+    installed_headers = Dir.chdir(@headers_dir) do
+      Dir['*.h'].sort!
+    end
+    source_headers = Dir.chdir(File.expand_path('../../ext/nokogiri', __FILE__)) do
+      Dir['*.h'].sort!
+    end
+    assert_equal(source_headers, installed_headers)
+  end
+
+  def test_packaged_headers
+    require 'nokogiri'
+    if Nokogiri::VERSION_INFO.has_key?('libxml') and
+       Nokogiri::VERSION_INFO['libxml']['source'] == 'packaged'
+      # Look for some files from libxml2 and libxslt
+      %w[libxml2/libxml/tree.h libxslt/xslt.h libexslt/exslt.h].each do |header|
+        assert(File.file?(File.join(@headers_dir, header)))
+      end
+    else
+      # Make sure the headers are not installed when they're not packaged.
+      %w[libxml2 libxslt libexslt].each do |dir|
+        refute(File.directory?(File.join(@headers_dir, dir)))
+      end
+    end
+  end
+end
+# vim: set sw=2 sts=2 ts=8 et:


### PR DESCRIPTION
This is an alternative implementation to https://github.com/sparklemotion/nokogiri/pull/1325. The major differences are
1. Nokogiri headers are placed in `nokogiri/include` inside the nokogiri extension directory rather than directly in `nokogiri`.
2. `libxml2` and `libxslt` headers are placed in `nokogiri/include/libxml2` and `nokogiri/include/libxslt` (and `nokogiri/include/libexslt`) if nokogiri used the packaged rather than system libraries.
3. The presence or absence of the headers is tested by travis-ci.

This will assist downstream projects (like [nokogumbo](https://github.com/rubys/nokogumbo/issues/71)) which need to build against a matching version of these libraries.

cc: @flavorjones