### PR TITLE
Free all unlinked nodes

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -9,6 +9,9 @@ static int dealloc_node_i(xmlNodePtr key, xmlNodePtr node, xmlDocPtr doc)
   case XML_NAMESPACE_DECL:
     xmlFree(node);
     break;
+  case XML_DTD_NODE:
+    xmlFreeDtd((xmlDtdPtr)node);
+    break;
   default:
     if(node->parent == NULL) {
       xmlAddChild((xmlNodePtr)doc, node);


### PR DESCRIPTION
Nodes that have been relinked should not be freed since they will be
freed when their owning document is freed. Every other node can be freed
directly.

Previously, unlinked DTD nodes were leaked because `xmlFreeNodeList`
does not act on DTD nodes. Separately, the `href` and `prefix` members
of `xmlNs` nodes (those of type `XML_NAMESPACE_DECL`) were also being
leaked.

Fixes #1784