### PR TITLE
Rewrite XmlNodeSet (fixes 1795)

### DIFF
--- a/ext/java/nokogiri/XmlElement.java
+++ b/ext/java/nokogiri/XmlElement.java
@@ -32,15 +32,15 @@
 
 package nokogiri;
 
-import nokogiri.internals.SaveContextVisitor;
-
 import org.jruby.Ruby;
-import org.jruby.RubyArray;
 import org.jruby.RubyClass;
 import org.jruby.anno.JRubyClass;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+
+import nokogiri.internals.SaveContextVisitor;
 
 /**
  * Class for Nokogiri::XML::Element
@@ -71,9 +71,9 @@ public class XmlElement extends XmlNode {
         visitor.enter((Element) node);
         XmlNodeSet xmlNodeSet = (XmlNodeSet) children(context);
         if (xmlNodeSet.length() > 0) {
-            RubyArray nodes = xmlNodeSet.nodes;
-            for( int i = 0; i < nodes.size(); i++ ) {
-                Object item = nodes.eltInternal(i);
+            IRubyObject[] nodes = XmlNodeSet.getNodes(context, xmlNodeSet);
+            for( int i = 0; i < nodes.length; i++ ) {
+                Object item = nodes[i];
                 if (item instanceof XmlNode) {
                     ((XmlNode) item).accept(context, visitor);
                 }

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -704,7 +704,7 @@ public class XmlNode extends RubyObject {
 
     @JRubyMethod
     public IRubyObject children(ThreadContext context) {
-        XmlNodeSet xmlNodeSet = XmlNodeSet.create(context.runtime);
+        XmlNodeSet xmlNodeSet = XmlNodeSet.newEmptyNodeSet(context);
 
         NodeList nodeList = node.getChildNodes();
         if (nodeList.getLength() > 0) {
@@ -737,8 +737,8 @@ public class XmlNode extends RubyObject {
     public IRubyObject element_children(ThreadContext context) {
         List<Node> elementNodes = new ArrayList<Node>();
         addElements(node, elementNodes, false);
-        if (elementNodes.size() == 0) return XmlNodeSet.newEmptyNodeSet(context);
-        RubyArray array = NokogiriHelpers.nodeArrayToRubyArray(context.getRuntime(), elementNodes.toArray(new Node[0]));
+        IRubyObject[] array = NokogiriHelpers.nodeArrayToArray(context.runtime,
+                                                               elementNodes.toArray(new Node[0]));
         XmlNodeSet xmlNodeSet = XmlNodeSet.newXmlNodeSet(context, array);
         return xmlNodeSet;
     }
@@ -842,7 +842,7 @@ public class XmlNode extends RubyObject {
                 documentErrors.add(docErrors.entry(i));
             }
             document.setInstanceVariable("@errors", documentErrors);
-            XmlNodeSet xmlNodeSet = XmlNodeSet.newXmlNodeSet(context, RubyArray.newArray(runtime));
+            XmlNodeSet xmlNodeSet = XmlNodeSet.newXmlNodeSet(context, new IRubyObject[0]);
             return xmlNodeSet;
         }
 
@@ -854,10 +854,9 @@ public class XmlNode extends RubyObject {
         } else {
             first = doc.node.getFirstChild();
         }
-        RubyArray nodeArray = RubyArray.newArray(runtime);
-        nodeArray.add(NokogiriHelpers.getCachedNodeOrCreate(runtime, first));
 
-        XmlNodeSet xmlNodeSet = XmlNodeSet.newXmlNodeSet(context, nodeArray);
+        IRubyObject[] nodes = new IRubyObject[]{NokogiriHelpers.getCachedNodeOrCreate(runtime, first)};
+        XmlNodeSet xmlNodeSet = XmlNodeSet.newXmlNodeSet(context, nodes);
         return xmlNodeSet;
     }
 

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -36,10 +36,12 @@ import java.util.Set;
 
 import javax.xml.transform.TransformerException;
 
-import nokogiri.internals.NokogiriNamespaceContext;
-import nokogiri.internals.NokogiriXPathFunctionResolver;
-import nokogiri.internals.NokogiriXPathVariableResolver;
-
+import org.apache.xml.dtm.DTM;
+import org.apache.xpath.XPath;
+import org.apache.xpath.XPathContext;
+import org.apache.xpath.jaxp.JAXPPrefixResolver;
+import org.apache.xpath.jaxp.JAXPVariableStack;
+import org.apache.xpath.objects.XObject;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
@@ -51,13 +53,9 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.SafePropertyAccessor;
 import org.w3c.dom.Node;
 
-import org.apache.xml.dtm.DTM;
-import org.apache.xpath.XPath;
-import org.apache.xpath.XPathContext;
-import org.apache.xpath.jaxp.JAXPExtensionsProvider;
-import org.apache.xpath.jaxp.JAXPPrefixResolver;
-import org.apache.xpath.jaxp.JAXPVariableStack;
-import org.apache.xpath.objects.XObject;
+import nokogiri.internals.NokogiriNamespaceContext;
+import nokogiri.internals.NokogiriXPathFunctionResolver;
+import nokogiri.internals.NokogiriXPathVariableResolver;
 
 /**
  * Class for Nokogiri::XML::XpathContext
@@ -186,7 +184,7 @@ public class XmlXpathContext extends RubyObject {
             case XObject.CLASS_BOOLEAN : return context.getRuntime().newBoolean(xobj.bool());
             case XObject.CLASS_NUMBER :  return context.getRuntime().newFloat(xobj.num());
             case XObject.CLASS_NODESET :
-                XmlNodeSet xmlNodeSet = XmlNodeSet.create(context.getRuntime());
+                XmlNodeSet xmlNodeSet = XmlNodeSet.newEmptyNodeSet(context);
                 xmlNodeSet.setNodeList(xobj.nodelist());
                 xmlNodeSet.initialize(context.getRuntime(), this.context);
                 return xmlNodeSet;

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -34,7 +34,6 @@ package nokogiri.internals;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -43,6 +42,20 @@ import java.nio.charset.Charset;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyClass;
+import org.jruby.RubyString;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
+import org.w3c.dom.Attr;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import nokogiri.HtmlDocument;
 import nokogiri.NokogiriService;
@@ -58,21 +71,6 @@ import nokogiri.XmlNode;
 import nokogiri.XmlProcessingInstruction;
 import nokogiri.XmlText;
 import nokogiri.XmlXpathContext;
-
-import org.jruby.Ruby;
-import org.jruby.RubyArray;
-import org.jruby.RubyClass;
-import org.jruby.RubyEncoding;
-import org.jruby.RubyString;
-import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.ByteList;
-import org.w3c.dom.Attr;
-import org.w3c.dom.Document;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.DOMException;
 
 /**
  * A class for various utility methods.
@@ -627,16 +625,20 @@ public class NokogiriHelpers {
         return newPrefix + ':' + tagName;
     }
 
-    public static RubyArray nodeListToRubyArray(Ruby ruby, NodeList nodes) {
-        RubyArray array = RubyArray.newArray(ruby, nodes.getLength());
-        return nodeListToRubyArray(ruby, nodes, array);
-    }
-
-    public static RubyArray nodeListToRubyArray(Ruby ruby, NodeList nodes, RubyArray array) {
-        for(int i = 0; i < nodes.getLength(); i++) {
-            array.append(NokogiriHelpers.getCachedNodeOrCreate(ruby, nodes.item(i)));
+    public static IRubyObject[] nodeListToRubyArray(Ruby ruby, NodeList nodes) {
+        IRubyObject[] array = new IRubyObject[nodes.getLength()];
+        for (int i = 0; i < nodes.getLength(); i++) {
+          array[i] = NokogiriHelpers.getCachedNodeOrCreate(ruby, nodes.item(i));
         }
         return array;
+    }
+
+    public static IRubyObject[] nodeArrayToArray(Ruby ruby, Node[] nodes) {
+        IRubyObject[] result = new IRubyObject[nodes.length];
+        for(int i = 0; i < nodes.length; i++) {
+            result[i] = NokogiriHelpers.getCachedNodeOrCreate(ruby, nodes[i]);
+        }
+        return result;
     }
 
     public static RubyArray nodeArrayToRubyArray(Ruby ruby, Node[] nodes) {

--- a/ext/java/nokogiri/internals/NokogiriXPathFunction.java
+++ b/ext/java/nokogiri/internals/NokogiriXPathFunction.java
@@ -37,9 +37,6 @@ import java.util.List;
 import javax.xml.xpath.XPathFunction;
 import javax.xml.xpath.XPathFunctionException;
 
-import nokogiri.XmlNode;
-import nokogiri.XmlNodeSet;
-
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBoolean;
@@ -52,6 +49,9 @@ import org.jruby.javasupport.util.RuntimeHelpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.w3c.dom.NodeList;
+
+import nokogiri.XmlNode;
+import nokogiri.XmlNodeSet;
 
 /**
  * Xpath function handler.
@@ -99,7 +99,7 @@ public class NokogiriXPathFunction implements XPathFunction {
     private static IRubyObject fromObjectToRuby(final Ruby runtime, Object obj) {
         // argument object type is one of NodeList, String, Boolean, or Double.
         if (obj instanceof NodeList) {
-            XmlNodeSet xmlNodeSet = XmlNodeSet.create(runtime);
+            XmlNodeSet xmlNodeSet = XmlNodeSet.newEmptyNodeSet(runtime.getCurrentContext());
             xmlNodeSet.setNodeList((NodeList) obj);
             return xmlNodeSet;
         }
@@ -116,7 +116,7 @@ public class NokogiriXPathFunction implements XPathFunction {
         }
         if (obj instanceof XmlNodeSet) return obj;
         if (obj instanceof RubyArray) {
-            return XmlNodeSet.newXmlNodeSet(runtime, (RubyArray) obj);
+            return XmlNodeSet.newXmlNodeSet(runtime.getCurrentContext(), ((RubyArray) obj).toJavaArray());
         }
         /*if (o instanceof XmlNode)*/ return ((XmlNode) obj).getNode();
     }


### PR DESCRIPTION
The current implementation suffers from having poor performance.  More
specifically, `op_or' is order of magnitude slower than the MRI version slows
down XMLNodeSet::xpath and XMLNodeSet::css significantly.  This
commit rewrites the class to manage its own internal array, similar to what
libxml does.

fixes #1795