### PR TITLE
Fix 1773

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1542,6 +1542,10 @@ public class XmlNode extends RubyObject {
          try {
             Document prev = otherNode.getOwnerDocument();
             Document doc = thisNode.getOwnerDocument();
+            if (doc == null && thisNode instanceof Document) {
+              // we are adding the new node to a new empty document
+              doc = (Document) thisNode;
+            }
             clearXpathContext(prev);
             clearXpathContext(doc);
             if (doc != null && doc != otherNode.getOwnerDocument()) {

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -33,7 +33,16 @@
 package nokogiri;
 
 import static java.lang.Math.max;
-import static nokogiri.internals.NokogiriHelpers.*;
+import static nokogiri.internals.NokogiriHelpers.clearXpathContext;
+import static nokogiri.internals.NokogiriHelpers.convertEncoding;
+import static nokogiri.internals.NokogiriHelpers.convertString;
+import static nokogiri.internals.NokogiriHelpers.getCachedNodeOrCreate;
+import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
+import static nokogiri.internals.NokogiriHelpers.isBlank;
+import static nokogiri.internals.NokogiriHelpers.nodeArrayToRubyArray;
+import static nokogiri.internals.NokogiriHelpers.nonEmptyStringOrNil;
+import static nokogiri.internals.NokogiriHelpers.rubyStringToString;
+import static nokogiri.internals.NokogiriHelpers.stringOrNil;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -43,18 +52,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import nokogiri.internals.HtmlDomParserContext;
-import nokogiri.internals.NokogiriHelpers;
-import nokogiri.internals.NokogiriNamespaceCache;
-import nokogiri.internals.SaveContextVisitor;
-import nokogiri.internals.XmlDomParserContext;
-
 import org.apache.xerces.dom.CoreDocumentImpl;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
-import org.jruby.RubyInteger;
 import org.jruby.RubyFixnum;
+import org.jruby.RubyInteger;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
@@ -75,6 +78,12 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
+
+import nokogiri.internals.HtmlDomParserContext;
+import nokogiri.internals.NokogiriHelpers;
+import nokogiri.internals.NokogiriNamespaceCache;
+import nokogiri.internals.SaveContextVisitor;
+import nokogiri.internals.XmlDomParserContext;
 
 /**
  * Class for Nokogiri::XML::Node

--- a/test/xml/test_node_reparenting.rb
+++ b/test/xml/test_node_reparenting.rb
@@ -197,6 +197,17 @@ module Nokogiri
             end
           end
 
+          describe "given the new document is empty" do
+            it "adds the node to the new document" do
+              doc1 = Nokogiri::XML.parse("<value>3</value>")
+              doc2 = Nokogiri::XML::Document.new
+              node = doc1.at_xpath("//value")
+              node.remove
+              doc2.add_child(node)
+              assert_match /<value>3<\/value>/, doc2.to_xml
+            end
+          end
+
           describe "given a parent node with a default namespace" do
             before do
               @doc = Nokogiri::XML(<<-eoxml)


### PR DESCRIPTION
[I couldn't force push to the original branch which lead to this new PR]

Replaces #1777. I noticed a `&` instead of `&&` in the original PR that I wanted to fix. the latter is the usual short circuit version of and, while the former always evaluate both operands. This is not relevant here but I had to re-read this in the Java spec which I think will be confusing for future maintainers.