### PR TITLE
Ignore test/** into gem for reduce gem size.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -121,7 +121,8 @@ HOE = Hoe.spec 'nokogiri' do
   self.clean_globs += [
     'nokogiri.gemspec',
     'lib/nokogiri/nokogiri.{bundle,jar,rb,so}',
-    'lib/nokogiri/[0-9].[0-9]'
+    'lib/nokogiri/[0-9].[0-9]',
+    'test/*'
   ]
   self.clean_globs += Dir.glob("ports/*").reject { |d| d =~ %r{/archives$} }
 


### PR DESCRIPTION
Remove `test/*` for reduce gem size 2.7Mb.

<img width="441" alt="2018-10-16 18 15 55" src="https://user-images.githubusercontent.com/5518/47009645-9ff4dd80-d16f-11e8-8009-9a59e3782b8c.png">
