### PR TITLE
Remove Version Eye badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ or CSS3 selectors.
 
 [![Concourse CI](https://ci.nokogiri.org/api/v1/teams/nokogiri-core/pipelines/nokogiri/jobs/ruby-2.4-system/badge)](https://ci.nokogiri.org/teams/nokogiri-core/pipelines/nokogiri?groups=master)
 [![Code Climate](https://codeclimate.com/github/sparklemotion/nokogiri.svg)](https://codeclimate.com/github/sparklemotion/nokogiri)
-[![Version Eye](https://www.versioneye.com/ruby/nokogiri/badge.png)](https://www.versioneye.com/ruby/nokogiri)
 [![Join the chat at https://gitter.im/sparklemotion/nokogiri](https://badges.gitter.im/sparklemotion/nokogiri.svg)](https://gitter.im/sparklemotion/nokogiri?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 


### PR DESCRIPTION
Added at https://github.com/sparklemotion/nokogiri/pull/1031

Version Eye was shut down.
https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/