### PR TITLE
On Darwin, ignore anything but system's ranlib. Fixes #1812

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -560,7 +560,8 @@ EOM
       *(libiconv_recipe ? "--with-iconv=#{libiconv_recipe.path}" : iconv_configure_flags),
       "--with-c14n",
       "--with-debug",
-      "--with-threads"
+      "--with-threads",
+      *(darwin? ? ["RANLIB=/usr/bin/ranlib", "AR=/usr/bin/ar"] : "")
     ]
   end
 
@@ -573,7 +574,8 @@ EOM
       "--without-python",
       "--without-crypto",
       "--with-debug",
-      "--with-libxml-prefix=#{sh_export_path(libxml2_recipe.path)}"
+      "--with-libxml-prefix=#{sh_export_path(libxml2_recipe.path)}",
+      *(darwin? ? ["RANLIB=/usr/bin/ranlib", "AR=/usr/bin/ar"] : "")
     ]
   end
 


### PR DESCRIPTION
This PR makes it so the call to `libxml2`'s `configure` script is done with passing `RANLIB=/usr/bin/ranlib` when running on Darwin.

This makes building native extensions more robust to the target system in the following situation:
- the user is using macOS and
- the user has GNU binutils in her `PATH`
- or somewhat, GNU binutils are linked in `/usr/local/bin`

In particular, having `libxml2` build call GNU's `ranlib` instead of Darwin's `ranlib` fails building native extensions with very cryptic error messages. The root cause is far from being obvious and one can waste many hours on it.

As such, I suggest trying to spare users and maintainers' time (less issues opened) by helping `libxml2`'s build system a bit.