### PR TITLE
Free DTD nodes (fixes 1784)

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -9,6 +9,9 @@ static int dealloc_node_i(xmlNodePtr key, xmlNodePtr node, xmlDocPtr doc)
   case XML_NAMESPACE_DECL:
     xmlFreeNs((xmlNsPtr)node);
     break;
+  case XML_DTD_NODE:
+    xmlFreeDtd((xmlDtdPtr)node);
+    break;
   default:
     if(node->parent == NULL) {
       xmlAddChild((xmlNodePtr)doc, node);

--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -707,6 +707,16 @@ eohtml
         assert_equal 'ISO-8859-1', html.encoding.name
       end
 
+      def test_leaking_dtd_nodes_after_internal_subset_removal
+        # see https://github.com/sparklemotion/nokogiri/issues/1784
+        #
+        # just checking that this doesn't raise a valgrind error. we
+        # don't otherwise have any test coverage for removing DTDs.
+        #
+        100.times do |i|
+          Nokogiri::HTML::Document.new.internal_subset.remove
+        end
+      end
     end
   end
 end

--- a/test/test_memory_leak.rb
+++ b/test/test_memory_leak.rb
@@ -190,6 +190,15 @@ EOF
         puts MemInfo.rss
       end
     end
+
+    def test_leaking_dtd_nodes_after_internal_subset_removal
+      # see https://github.com/sparklemotion/nokogiri/issues/1784
+      100_000.times do |i|
+        doc = Nokogiri::HTML::Document.new
+        doc.internal_subset.remove
+        puts MemInfo.rss if (i % 1000 == 0)
+      end
+    end
   end # if NOKOGIRI_GC
 
   module MemInfo


### PR DESCRIPTION
DTD nodes added to a document are not freed when the document is freed.

Fixes #1784 

This supersedes #1791 