### PR TITLE
Add SDK-specific include path for macOS Mojave

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -392,6 +392,10 @@ when arg_config('--clean')
   do_clean
 end
 
+if darwin?
+  ENV['CFLAGS'] = "#{ENV['CFLAGS']} -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libxml2"
+end
+
 if openbsd? && !using_system_libraries?
   if `#{ENV['CC'] || '/usr/bin/cc'} -v 2>&1` !~ /clang/
     ENV['CC'] ||= find_executable('egcc') or


### PR DESCRIPTION
This is an attempt at fixing the issue discussed at length in sparklemotion/nokogiri#1801, which is caused by a of header files provided by the xcode command-line tools in Xcode version 10.

This fix resolves the build issue for me without resorting to the workaround described in the [release notes for Xcode 10](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes#3035624). 