### PR TITLE
CSS selector `:has()` matches against deep descendants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * [MRI] Handle Xcode 10's new library path on macOS. [#1801, #1851] (Thanks, @mlj and @deepj!)
 
 
+### Bug fixes
+
+* CSS selector `:has()` correctly matches against any descendant (previously matched against only direct children). [#350] (Thanks, @Phrogz!)
+
+
 ## 1.10.0 / 2019-01-04
 
 ### Features

--- a/lib/nokogiri/css/xpath_visitor.rb
+++ b/lib/nokogiri/css/xpath_visitor.rb
@@ -51,7 +51,7 @@ module Nokogiri
         when /^comment\(/
           "comment()"
         when /^has\(/
-          node.value[1].accept(self)
+          ".//#{node.value[1].accept(self)}"
         else
           args = ['.'] + node.value[1..-1]
           "#{node.value.first}#{args.join(', ')})"

--- a/test/css/test_parser.rb
+++ b/test/css/test_parser.rb
@@ -63,8 +63,8 @@ module Nokogiri
       end
 
       def test_has
-        assert_xpath  "//a[b]", @parser.parse("a:has(b)")
-        assert_xpath  "//a[b/c]", @parser.parse("a:has(b > c)")
+        assert_xpath  "//a[.//b]", @parser.parse("a:has(b)")
+        assert_xpath  "//a[.//b/c]", @parser.parse("a:has(b > c)")
       end
 
       def test_dashmatch


### PR DESCRIPTION
Fixes #350.