### PR TITLE
[#1482] remove library paths from version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,28 @@
 
 ### Backwards incompatibilities
 
+#### Ruby version support
+
 This release ends support for:
 
 * Ruby 2.3, for which [official support ended on 2019-03-31](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/) [#1886] (Thanks @ashmaroli!)
 * JRuby 9.1, which is the Ruby 2.3-compatible release.
+
+
+#### Self-descriptive version info
+
+This release also changes the information provided in `Nokogiri::VersionInfo`
+
+* Nokogiri::VersionInfo will no longer contain the following keys (previously these were set only when vendored libraries were being used) [#1482]:
+  * `libxml/libxml2_path`
+  * `libxml/libxslt_path`
+* `nokogiri -v` will no longer emit these VersionInfo values [#1482]
+* these C macros will no longer be defined [#1482]:
+  * NOKOGIRI_LIBXML2_PATH
+  * NOKOGIRI_LIBXSLT_PATH
+* these global variables will no longer be defined [#1482]:
+  * NOKOGIRI_LIBXML2_PATH
+  * NOKOGIRI_LIBXSLT_PATH
 
 
 ### Features

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -617,7 +617,6 @@ EOM
       end
 
       # Defining a macro that expands to a C string; double quotes are significant.
-      $CPPFLAGS << ' ' << "-DNOKOGIRI_#{recipe.name.upcase}_PATH=\"#{recipe.path}\"".inspect
       $CPPFLAGS << ' ' << "-DNOKOGIRI_#{recipe.name.upcase}_PATCHES=\"#{recipe.patch_files.map { |path| File.basename(path) }.join(' ')}\"".inspect
 
       case libname

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -86,14 +86,10 @@ void Init_nokogiri()
 
 #ifdef NOKOGIRI_USE_PACKAGED_LIBRARIES
   rb_const_set(mNokogiri, rb_intern("NOKOGIRI_USE_PACKAGED_LIBRARIES"), Qtrue);
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXML2_PATH"), NOKOGIRI_STR_NEW2(NOKOGIRI_LIBXML2_PATH));
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXSLT_PATH"), NOKOGIRI_STR_NEW2(NOKOGIRI_LIBXSLT_PATH));
   rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXML2_PATCHES"), rb_str_split(NOKOGIRI_STR_NEW2(NOKOGIRI_LIBXML2_PATCHES), " "));
   rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXSLT_PATCHES"), rb_str_split(NOKOGIRI_STR_NEW2(NOKOGIRI_LIBXSLT_PATCHES), " "));
 #else
   rb_const_set(mNokogiri, rb_intern("NOKOGIRI_USE_PACKAGED_LIBRARIES"), Qfalse);
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXML2_PATH"), Qnil);
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXSLT_PATH"), Qnil);
   rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXML2_PATCHES"), Qnil);
   rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXSLT_PATCHES"), Qnil);
 #endif

--- a/lib/nokogiri/version.rb
+++ b/lib/nokogiri/version.rb
@@ -62,8 +62,6 @@ module Nokogiri
             libxml["binding"] = "extension"
             if libxml2_using_packaged?
               libxml["source"] = "packaged"
-              libxml["libxml2_path"] = NOKOGIRI_LIBXML2_PATH
-              libxml["libxslt_path"] = NOKOGIRI_LIBXSLT_PATH
               libxml["libxml2_patches"] = NOKOGIRI_LIBXML2_PATCHES
               libxml["libxslt_patches"] = NOKOGIRI_LIBXSLT_PATCHES
             else


### PR DESCRIPTION
some backwards-incompatible changes here that I don't expect actually
break anything for anyone:

* Nokogiri::VersionInfo will no longer contain the following
  keys (previously these were set only when vendored libraries were
  being used):
  * `libxml/libxml2_path`
  * `libxml/libxslt_path`
* `nokogiri -v` will no longer emit these VersionInfo values
* these C macros will no longer be defined:
  * NOKOGIRI_LIBXML2_PATH
  * NOKOGIRI_LIBXSLT_PATH
* these global variables will no longer be defined:
  * NOKOGIRI_LIBXML2_PATH
  * NOKOGIRI_LIBXSLT_PATH

Fixes #1482
