### PR TITLE
[#1802] ensure we trap XML errors while applying XSLT stylesheet

### DIFF
--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -165,7 +165,7 @@ static VALUE transform(int argc, VALUE* argv, VALUE self)
 
     errstr = rb_str_new(0, 0);
     xsltSetGenericErrorFunc((void *)errstr, xslt_generic_error_handler);
-    xmlSetGenericErrorFunc(NULL, (xmlGenericErrorFunc)&swallow_superfluous_xml_errors);
+    xmlSetGenericErrorFunc((void *)errstr, xslt_generic_error_handler);
 
     result = xsltApplyStylesheet(wrapper->ss, xml, params);
     free(params);


### PR DESCRIPTION
otherwise trivial XML errors will silently result in NULL being
returned by xsltApplyStylesheet() and a subsequent segfault

Fixes #1802
