### PR TITLE
Add an attempt to build upstream libxml2-nokogiri with patches

### DIFF
--- a/packages/alpine/APKBUILD
+++ b/packages/alpine/APKBUILD
@@ -1,0 +1,72 @@
+# Contributor: Jonathan Lozinski <jonathan.lozinski@gmail.com>
+# Maintainer: Jonathan Lozinski <jonathan.lozinski@gmail.com>
+pkgname=libxml2-nokogiri
+pkgver=2.9.9
+pkgrel=3
+pkgdesc="XML parsing library, version 2 (Nokogiri Dependent Version)"
+url="http://www.xmlsoft.org/"
+arch="all"
+license="MIT"
+depends=
+depends_dev="zlib-dev"
+makedepends="$depends_dev python-dev"
+subpackages="$pkgname-doc $pkgname-dev py-$pkgname:py $pkgname-utils"
+source="ftp://ftp.xmlsoft.org/libxml2/libxml2-${pkgver}.tar.gz
+  0001-Revert-Do-not-URI-escape-in-server-side-includes.patch
+	"
+
+options="!strip"
+
+builddir="$srcdir/libxml2-$pkgver"
+prepare() {
+	cd "$builddir"
+	for i in $source; do
+		case $i in
+		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
+		esac
+	done
+}
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--disable-static \
+		|| return 1
+	make
+}
+
+package() {
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
+
+	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
+}
+
+dev() {
+	default_dev
+	mv "$pkgdir"/usr/lib/*.sh "$subpkgdir"/usr/lib/
+}
+
+py() {
+	cd "$builddir"
+	pkgdesc="$pkgname python bindings"
+	install -d "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/
+}
+
+utils() {
+	pkgdesc="XML utilities (Nokogiri)"
+	replaces="libxml2-nokogiri"
+	mkdir -p "$subpkgdir"/usr
+	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
+}
+
+
+sha512sums="cb7784ba4e72e942614e12e4f83f4ceb275f3d738b30e3b5c1f25edf8e9fa6789e854685974eed95b362049dbf6c8e7357e0327d64c681ed390534ac154e6810  libxml2-2.9.9.tar.gz
+01197be52a1920fe61be918977d36124c02a80aedd054520445b39d55cac1e13c52f9bdb88a5321c6aa27a8005b55a7a937f6b84fb3cef52f6bd219faa7e1715  0001-Revert-Do-not-URI-escape-in-server-side-includes.patch"

--- a/packages/alpine/Dockerfile
+++ b/packages/alpine/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:latest
+
+RUN apk update && apk upgrade
+RUN apk add build-base
+RUN apk add alpine-sdk shadow
+RUN adduser -D -G abuild -s /bin/sh nokogiri
+RUN echo "nokogiri ALL=(ALL) ALL" >> /etc/sudoers
+
+USER nokogiri
+ADD --chown=nokogiri:abuild . /build/
+ADD --chown=nokogiri:abuild patches/libxml2/*.patch /build/packages/alpine/
+WORKDIR /build/packages/alpine/
+
+RUN abuild-keygen -a
+
+RUN abuild -R

--- a/packages/alpine/README.md
+++ b/packages/alpine/README.md
@@ -1,0 +1,13 @@
+In order to set up this in a build mechanism a Dockerfile has been provided to create this, and would allow for bind-mount of a genuine build key at:
+
+  /home/nokogiri/.abuild/xxxx.rsa /.rsa.pub
+
+Run from root of repository
+
+   docker build -f packages/alpine/Dockerfile -t alpine-nokogiri .
+
+much of this taken from:
+
+https://wiki.alpinelinux.org/wiki/Creating_an_Alpine_package
+
+In order to publish, the APK and patch files here should be sent as a PR to alipe, so to get this into a publised state, the build process should be just update this file and do a PR?


### PR DESCRIPTION
Note this is response to a twitter thread with @tenderlove around trying to build some disti packages to speed up install of the gem, if the disti build could already have a custom build.

1. This doesn't sort the consumption of a disti version in the gem build (yet)
2. This hasn't published, and only currently targets alpine, however there is a docker file which could be used to CI test that a package builds, and that nokogiri can install (when integrated)
3. Is hardcoded in the APKBUILD file which could probably be autogenerated from other artefacts in the repo
4. Needs to be integrated into a CI for publish, and in particular publish a PR to alpine for the build (I think) into a blessed alpine REPO.

**What problem is this PR intended to solve?**

This is a build/APK setup to build a custom alpine package for libxml

**Have you included adequate test coverage?**

No nokogiri changes, just added some APK stuff

**Does this change affect the C or the Java implementations?**

No

If not, that may be OK, just please note it here.