### PR TITLE
Rethrow exceptions caught by Java SAX handler

### DIFF
--- a/ext/java/nokogiri/internals/NokogiriHandler.java
+++ b/ext/java/nokogiri/internals/NokogiriHandler.java
@@ -252,8 +252,9 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
             final String msg = ex.getMessage();
             call("error", runtime.newString(msg == null ? "" : msg));
             addError(new RaiseException(XmlSyntaxError.createError(runtime, ex), true));
-        } catch(RaiseException e) {
-            addError(e);
+        } catch( RaiseException rx ) {
+            addError(rx);
+            throw rx;
         }
     }
 
@@ -263,9 +264,9 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
             final String msg = ex.getMessage();
             call("error", runtime.newString(msg == null ? "" : msg));
             addError(new RaiseException(XmlSyntaxError.createFatalError(runtime, ex), true));
-
-        } catch(RaiseException e) {
-            addError(e);
+        } catch( RaiseException rx ) {
+            addError(rx);
+            throw rx;
         }
     }
 
@@ -275,7 +276,7 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
         call("warning", runtime.newString(msg == null ? "" : msg));
     }
 
-    protected synchronized void addError(RaiseException e) {
+    public synchronized void addError(RaiseException e) {
         errors.add(e);
     }
 

--- a/ext/java/nokogiri/internals/NokogiriHandler.java
+++ b/ext/java/nokogiri/internals/NokogiriHandler.java
@@ -246,12 +246,11 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
         charactersBuilder.setLength(0);
     }
 
-    @Override
-    public void error(SAXParseException ex) {
+    void handleError(SAXParseException spx) {
         try {
-            final String msg = ex.getMessage();
+            final String msg = spx.getMessage();
             call("error", runtime.newString(msg == null ? "" : msg));
-            addError(new RaiseException(XmlSyntaxError.createError(runtime, ex), true));
+            addError(new RaiseException(XmlSyntaxError.createError(runtime, spx), true));
         } catch( RaiseException rx ) {
             addError(rx);
             throw rx;
@@ -259,15 +258,13 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
     }
 
     @Override
+    public void error(SAXParseException ex) {
+        handleError(ex);
+    }
+
+    @Override
     public void fatalError(SAXParseException ex) {
-        try {
-            final String msg = ex.getMessage();
-            call("error", runtime.newString(msg == null ? "" : msg));
-            addError(new RaiseException(XmlSyntaxError.createFatalError(runtime, ex), true));
-        } catch( RaiseException rx ) {
-            addError(rx);
-            throw rx;
-        }
+        handleError(ex);
     }
 
     @Override
@@ -276,7 +273,7 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
         call("warning", runtime.newString(msg == null ? "" : msg));
     }
 
-    public synchronized void addError(RaiseException e) {
+    protected synchronized void addError(RaiseException e) {
         errors.add(e);
     }
 

--- a/ext/java/nokogiri/internals/NokogiriHandler.java
+++ b/ext/java/nokogiri/internals/NokogiriHandler.java
@@ -246,14 +246,14 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
         charactersBuilder.setLength(0);
     }
 
-    void handleError(SAXParseException spx) {
+    void handleError(SAXParseException ex) {
         try {
-            final String msg = spx.getMessage();
+            final String msg = ex.getMessage();
             call("error", runtime.newString(msg == null ? "" : msg));
-            addError(new RaiseException(XmlSyntaxError.createError(runtime, spx), true));
-        } catch( RaiseException rx ) {
-            addError(rx);
-            throw rx;
+            addError(new RaiseException(XmlSyntaxError.createError(runtime, ex), true));
+        } catch( RaiseException e) {
+            addError(e);
+            throw e;
         }
     }
 

--- a/test/xml/sax/test_document_error.rb
+++ b/test/xml/sax/test_document_error.rb
@@ -1,0 +1,55 @@
+require 'helper'
+
+module Nokogiri
+  module XML
+    module SAX
+
+      # raises an exception when underlying parser
+      # encounters an XML parsing error
+      class ThrowingErrorDocument < Document
+        def error(msg)
+          raise(StandardError, "parsing did not complete: #{msg}")
+        end
+      end
+
+      # only warns when underlying parser encounters
+      # an XML parsing error
+      class WarningErrorDocument < Document
+        def error(msg)
+          errors << msg
+         end
+
+        def errors
+          @errors ||= []
+        end
+      end
+
+      class TestErrorHandling < Nokogiri::SAX::TestCase 
+        def setup
+          super
+          @error_parser = Parser.new(ThrowingErrorDocument.new)
+          @warning_parser = Parser.new(WarningErrorDocument.new)
+        end
+
+        def test_error_throwing_document_raises_exception
+          begin
+            @error_parser.parse("<xml>") # no closing element
+            fail '#parse  should not complete successfully when document #error throws exception'
+          rescue StandardError => e
+            assert_match /parsing did not complete/, e.message
+          end
+        end
+
+        def test_warning_document_encounters_error_but_terminates_normally
+          begin
+            @warning_parser.parse("<xml>")
+            assert !@warning_parser.document.errors.empty?, 'error collector did not collect an error'
+          rescue StandardError => e
+            warn(e)
+            fail '#parse should complete successfully unless document #error throws exception (#{e}'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/xml/sax/test_push_parser.rb
+++ b/test/xml/sax/test_push_parser.rb
@@ -73,6 +73,7 @@ module Nokogiri
           rescue => e
             actual = e
           end
+          fail 'PushParser should throw error when fed ill-formed data' if actual.nil?
 
           assert_equal actual.message, "parse error"
         end


### PR DESCRIPTION
Patch for #1847 (JRuby implementation) -- ensures that exceptions raised from `#error` are not swallowed by `nokogiri.internals.NokogiriHandler`.  Includes unit tests to verify the new behavior (as well as avoiding regressions in the SAXPullParser implementation); tests were run under both MRI 2.5.1 and JRuby 9.2.0.0
