### PR TITLE
Update Appveyor-CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,10 @@ test_script:
 environment:
   matrix:
     - ruby_version: head-x64
+    - ruby_version: 26
+    - ruby_version: 25-x64
     - ruby_version: 24
     - ruby_version: 23-x64
-    - ruby_version: 22
-    - ruby_version: 21-x64
-    - ruby_version: 200
 
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
 build: off
 
 test_script:
-  - bundle exec rake -rdevkit
+  - bundle exec rake -rdevkit compile test
 
 environment:
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,18 +9,23 @@ install:
   - gem --version
   - gem install bundler --conservative
   - bundle install
+  - IF DEFINED INSTALL_PACKAGES ( ridk exec pacman --noconfirm --needed --sync %INSTALL_PACKAGES% )
 
 build: off
 
 test_script:
-  - bundle exec rake -rdevkit compile test
+  - bundle exec rake -rdevkit compile test -- %EXTCONF_PARAMS%
 
 environment:
   matrix:
     - ruby_version: head-x64
+      INSTALL_PACKAGES: "mingw-w64-x86_64-libxslt"
+      EXTCONF_PARAMS: "--use-system-libraries"
     - ruby_version: 26
     - ruby_version: 25-x64
     - ruby_version: 24
+      INSTALL_PACKAGES: "mingw-w64-i686-libxslt"
+      EXTCONF_PARAMS: "--use-system-libraries"
     - ruby_version: 23-x64
 
 matrix:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

It updates the Appveyor setup to check the build and the test suite on supported MRI ruby versions.
Since https://ci.nokogiri.org doesn't do any tests on Windows currently, I propose to add Appveyor in the meantime instead to nokogiris github repository.

**Does this change affect the C or the Java implementations?**

Appveyor-CI setup currently runs MRI only and doesn't run JRuby.
