### PR TITLE
Test for handler functions not interfering with CSS id queries

### DIFF
--- a/test/files/tlm.html
+++ b/test/files/tlm.html
@@ -827,6 +827,7 @@ page.<span class="me1">body</span> =~ /&lt;textarea<span class="br0">&#91;</span
 </div>
 
 <div id="abc.123" class='special.character'>Special character div</div>
+<div id="partial_collision_id">Partial collision id</div>
 <div id="footer">
 A design by <a href="http://blog.geminigeek.com/wordpress-theme">GeminiGeek</a> &bull; Powered by <a href="http://wordpress.org">Wordpress</a><!--&bull; <a href="#">CSS</a> &bull; <a href="#">xHTML 1.0</a>-->
 </div>

--- a/test/html/sax/test_parser.rb
+++ b/test/html/sax/test_parser.rb
@@ -29,9 +29,9 @@ module Nokogiri
           # Take a look at the comment in test_parse_document to know
           # a possible reason to this difference.
           if Nokogiri.uses_libxml?
-            assert_equal 1111, @parser.document.end_elements.length
+            assert_equal 1112, @parser.document.end_elements.length
           else
-            assert_equal 1120, @parser.document.end_elements.length
+            assert_equal 1121, @parser.document.end_elements.length
           end
         end
 

--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -496,6 +496,15 @@ eohtml
         }.new)
       end
 
+      def test_find_with_partial_id_collision_function
+        found_by_id = @html.css("#partial_collision_id", Class.new {
+          def collision nodes
+            [nodes.first]
+          end
+        }.new)
+        assert_equal 1, found_by_id.length
+      end
+
       def test_dup_shallow
         found = @html.search('//div/a').first
         dup = found.dup(0)


### PR DESCRIPTION
This PR adds a test for an issue that shows up when using JRuby.  When using JRuby css id queries (at least - maybe others too) where the id partially contains the name of a function in the passed in handler causes the CSS to return no elements.  This does not happen on MRI.  Not really sure where to even start looking for the root cause.