### PR TITLE
Load the extension for JRuby to get the XERCES_VERSION constant.

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -185,6 +185,7 @@ lib/nokogiri/html/entity_lookup.rb
 lib/nokogiri/html/sax/parser.rb
 lib/nokogiri/html/sax/parser_context.rb
 lib/nokogiri/html/sax/push_parser.rb
+lib/nokogiri/jruby/dependencies.rb
 lib/nokogiri/syntax_error.rb
 lib/nokogiri/version.rb
 lib/nokogiri/xml.rb

--- a/lib/nokogiri.rb
+++ b/lib/nokogiri.rb
@@ -4,25 +4,7 @@
 require 'rbconfig'
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
-  # The line below caused a problem on non-GAE rack environment.
-  # unless defined?(JRuby::Rack::VERSION) || defined?(AppEngine::ApiProxy)
-  #
-  # However, simply cutting defined?(JRuby::Rack::VERSION) off resulted in
-  # an unable-to-load-nokogiri problem. Thus, now, Nokogiri checks the presense
-  # of appengine-rack.jar in $LOAD_PATH. If Nokogiri is on GAE, Nokogiri
-  # should skip loading xml jars. This is because those are in WEB-INF/lib and
-  # already set in the classpath.
-  unless $LOAD_PATH.to_s.include?("appengine-rack")
-    require 'stringio'
-    require 'isorelax.jar'
-    require 'jing.jar'
-    require 'nekohtml.jar'
-    require 'nekodtd.jar'
-    require 'xercesImpl.jar'
-    require 'serializer.jar'
-    require 'xalan.jar'
-    require 'xml-apis.jar'
-  end
+  require 'nokogiri/jruby/dependencies'
 end
 
 begin

--- a/lib/nokogiri/jruby/dependencies.rb
+++ b/lib/nokogiri/jruby/dependencies.rb
@@ -1,0 +1,19 @@
+# The line below caused a problem on non-GAE rack environment.
+# unless defined?(JRuby::Rack::VERSION) || defined?(AppEngine::ApiProxy)
+#
+# However, simply cutting defined?(JRuby::Rack::VERSION) off resulted in
+# an unable-to-load-nokogiri problem. Thus, now, Nokogiri checks the presense
+# of appengine-rack.jar in $LOAD_PATH. If Nokogiri is on GAE, Nokogiri
+# should skip loading xml jars. This is because those are in WEB-INF/lib and
+# already set in the classpath.
+unless $LOAD_PATH.to_s.include?("appengine-rack")
+  require 'stringio'
+  require 'isorelax.jar'
+  require 'jing.jar'
+  require 'nekohtml.jar'
+  require 'nekodtd.jar'
+  require 'xercesImpl.jar'
+  require 'serializer.jar'
+  require 'xalan.jar'
+  require 'xml-apis.jar'
+end

--- a/lib/nokogiri/version.rb
+++ b/lib/nokogiri/version.rb
@@ -45,37 +45,38 @@ module Nokogiri
     end
 
     def to_hash
-      hash_info = {}
-      hash_info["warnings"] = []
-      hash_info["nokogiri"] = Nokogiri::VERSION
-      hash_info["ruby"] = {}
-      hash_info["ruby"]["version"] = ::RUBY_VERSION
-      hash_info["ruby"]["platform"] = ::RUBY_PLATFORM
-      hash_info["ruby"]["description"] = ::RUBY_DESCRIPTION
-      hash_info["ruby"]["engine"] = engine
-      hash_info["ruby"]["jruby"] = jruby? if jruby?
-
-      if libxml2?
-        hash_info["libxml"] = {}
-        hash_info["libxml"]["binding"] = "extension"
-        if libxml2_using_packaged?
-          hash_info["libxml"]["source"] = "packaged"
-          hash_info["libxml"]["libxml2_path"] = NOKOGIRI_LIBXML2_PATH
-          hash_info["libxml"]["libxslt_path"] = NOKOGIRI_LIBXSLT_PATH
-          hash_info["libxml"]["libxml2_patches"] = NOKOGIRI_LIBXML2_PATCHES
-          hash_info["libxml"]["libxslt_patches"] = NOKOGIRI_LIBXSLT_PATCHES
-        else
-          hash_info["libxml"]["source"] = "system"
+      {}.tap do |vi|
+        vi["warnings"] = []
+        vi["nokogiri"] = Nokogiri::VERSION
+        vi["ruby"] = {}.tap do |ruby|
+          ruby["version"] = ::RUBY_VERSION
+          ruby["platform"] = ::RUBY_PLATFORM
+          ruby["description"] = ::RUBY_DESCRIPTION
+          ruby["engine"] = engine
+          ruby["jruby"] = jruby? if jruby?
         end
-        hash_info["libxml"]["compiled"] = compiled_parser_version
-        hash_info["libxml"]["loaded"] = loaded_parser_version
-        hash_info["warnings"] = warnings
-      elsif jruby?
-        hash_info["xerces"] = Nokogiri::XERCES_VERSION
-        hash_info["nekohtml"] = Nokogiri::NEKO_VERSION
-      end
 
-      hash_info
+        if libxml2?
+          vi["libxml"] = {}.tap do |libxml|
+            libxml["binding"] = "extension"
+            if libxml2_using_packaged?
+              libxml["source"] = "packaged"
+              libxml["libxml2_path"] = NOKOGIRI_LIBXML2_PATH
+              libxml["libxslt_path"] = NOKOGIRI_LIBXSLT_PATH
+              libxml["libxml2_patches"] = NOKOGIRI_LIBXML2_PATCHES
+              libxml["libxslt_patches"] = NOKOGIRI_LIBXSLT_PATCHES
+            else
+              libxml["source"] = "system"
+            end
+            libxml["compiled"] = compiled_parser_version
+            libxml["loaded"] = loaded_parser_version
+          end
+          vi["warnings"] = warnings
+        elsif jruby?
+          vi["xerces"] = Nokogiri::XERCES_VERSION
+          vi["nekohtml"] = Nokogiri::NEKO_VERSION
+        end
+      end
     end
 
     def to_markdown

--- a/lib/nokogiri/version.rb
+++ b/lib/nokogiri/version.rb
@@ -71,10 +71,6 @@ module Nokogiri
         hash_info["libxml"]["loaded"] = loaded_parser_version
         hash_info["warnings"] = warnings
       elsif jruby?
-        # These constants are defined by the extension, so we need to laod it
-        require 'nokogiri/jruby/dependencies'
-        require 'nokogiri/nokogiri'
-
         hash_info["xerces"] = Nokogiri::XERCES_VERSION
         hash_info["nekohtml"] = Nokogiri::NEKO_VERSION
       end
@@ -100,9 +96,6 @@ module Nokogiri
     def self.instance; @@instance; end
   end
 
-  # More complete version information about libxml
-  VERSION_INFO = VersionInfo.instance.to_hash
-
   def self.uses_libxml? # :nodoc:
     VersionInfo.instance.libxml2?
   end
@@ -110,4 +103,13 @@ module Nokogiri
   def self.jruby? # :nodoc:
     VersionInfo.instance.jruby?
   end
+
+  # Ensure constants used in this file are loaded
+  if Nokogiri.jruby?
+    require "nokogiri/jruby/dependencies"
+  end
+  require "nokogiri/nokogiri"
+
+  # More complete version information about libxml
+  VERSION_INFO = VersionInfo.instance.to_hash
 end

--- a/lib/nokogiri/version.rb
+++ b/lib/nokogiri/version.rb
@@ -71,6 +71,10 @@ module Nokogiri
         hash_info["libxml"]["loaded"] = loaded_parser_version
         hash_info["warnings"] = warnings
       elsif jruby?
+        # These constants are defined by the extension, so we need to laod it
+        require 'nokogiri/jruby/dependencies'
+        require 'nokogiri/nokogiri'
+
         hash_info["xerces"] = Nokogiri::XERCES_VERSION
         hash_info["nekohtml"] = Nokogiri::NEKO_VERSION
       end

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -1,0 +1,58 @@
+require "helper"
+require "rbconfig"
+require "json"
+
+module TestVersionInfoTests
+  #
+  #  This module is mixed into test classes below so that the tests
+  #  are validated when `nokogiri.rb` is required and when
+  #  `nokogiri/version.rb` is required. See #1896 for background.
+  #
+  def test_version_info_for_xerces
+    skip "xerces is only used for JRuby" unless Nokogiri.jruby?
+    assert_equal @version_info["xerces"], Nokogiri::VERSION_INFO["xerces"]
+  end
+
+  def test_version_info_for_nekohtml
+    skip "nekohtml is only used for JRuby" unless Nokogiri.jruby?
+    assert_equal @version_info["nekohtml"], Nokogiri::VERSION_INFO["nekohtml"]
+  end
+
+  def test_version_info_for_libxml
+    skip "libxml2 is only used for CRuby" unless Nokogiri.uses_libxml?
+    assert_equal @version_info["libxml"]["compiled"], Nokogiri::LIBXML_VERSION
+  end
+end
+
+class TestVersionInfo
+  RUBYEXEC = File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["RUBY_INSTALL_NAME"])
+  ROOTDIR = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+
+  class Base < Nokogiri::TestCase
+    def setup
+      super
+      version_info = Dir.chdir(ROOTDIR) do
+        `#{RUBYEXEC} -Ilib -rjson -r#{@require_me} -e 'puts Nokogiri::VERSION_INFO.to_json'`
+      end
+      @version_info = JSON.parse version_info
+    end
+  end
+
+  class RequireNokogiri < TestVersionInfo::Base
+    include TestVersionInfoTests
+
+    def setup
+      @require_me = "nokogiri"
+      super
+    end
+  end
+
+  class RequireVersionFileOnly < TestVersionInfo::Base
+    include TestVersionInfoTests
+
+    def setup
+      @require_me = "nokogiri/version"
+      super
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1896.

Note that this makes `nokogiri/version` load the entire extension and all related jar files, which may not be desirable. This could be turned into an autoload against the XERCES_VERSION constant, but I don't particularly like autoloads.