### PR TITLE
Use private constant to test broken libxml version

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -847,7 +847,7 @@ module Nokogiri
         node_or_tags
       end
 
-      IS_BROKEN_LIBXML_VERSION = LIBXML_VERSION.start_with?('2.6').freeze
+      IS_BROKEN_LIBXML_VERSION = defined?(LIBXML_VERSION) && LIBXML_VERSION.start_with?('2.6').freeze
       private_constant :IS_BROKEN_LIBXML_VERSION
 
       def to_format save_option, options

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -847,9 +847,12 @@ module Nokogiri
         node_or_tags
       end
 
+      IS_BROKEN_LIBXML_VERSION = LIBXML_VERSION.start_with?('2.6').freeze
+      private_constant :IS_BROKEN_LIBXML_VERSION
+
       def to_format save_option, options
         # FIXME: this is a hack around broken libxml versions
-        return dump_html if Nokogiri.uses_libxml? && %w[2 6] === LIBXML_VERSION.split('.')[0..1]
+        return dump_html if Nokogiri.uses_libxml? && IS_BROKEN_LIBXML_VERSION
 
         options[:save_with] = save_option unless options[:save_with]
         serialize(options)
@@ -857,7 +860,7 @@ module Nokogiri
 
       def write_format_to save_option, io, options
         # FIXME: this is a hack around broken libxml versions
-        return (io << dump_html) if Nokogiri.uses_libxml? && %w[2 6] === LIBXML_VERSION.split('.')[0..1]
+        return (io << dump_html) if Nokogiri.uses_libxml? && IS_BROKEN_LIBXML_VERSION
 
         options[:save_with] ||= save_option
         write_to io, options


### PR DESCRIPTION
## What problem is this PR intended to solve?

**Unnecessary memory usage.**

### The issue

While profiling a project for optimizing memory usage, I was pointed to the following line:
```
allocated memory by location
-----------------------------------
  14.61 MB  nokogiri-1.10.3/lib/nokogiri/xml/node.rb:852
```
which is:
https://github.com/sparklemotion/nokogiri/blob/c45658aa86da6cf238216d2cf8bf153dada27f64/lib/nokogiri/xml/node.rb#L852

If the above code is frequently called, then **for every call**:
  - A new array is allocated via `%w[2 6]`
  - An interim array is generated via `LIBXML_VERSION.split('.')`
  - And yet another array is generated via `Array#[]<range>`

### The Solution

The solution is to avoid generating objects and directly check the version string against a substring.
But since its wasteful to repeatedly test a `CONSTANT` string, stash the entire evaluation in a private constant and then read its value as required.

## Have you included adequate test coverage?

This doesn't change behavior nor introduce a new behavior.


## Does this change affect the C or the Java implementations?

No, it doesn't.
