### PR TITLE
Reduce array allocations via ary.each_with_object

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -337,9 +337,9 @@ module Nokogiri
       # If you need to distinguish attributes with the same name, with different namespaces
       # use #attribute_nodes instead.
       def attributes
-        Hash[attribute_nodes.map { |node|
-          [node.node_name, node]
-        }]
+        attribute_nodes.each_with_object({}) do |node, hsh|
+          hsh[node.node_name] = node
+        end
       end
 
       ###
@@ -509,10 +509,13 @@ module Nokogiri
       # default namespaces set on ancestor will NOT be, even if self
       # has no explicit default namespace.
       def namespaces
-        Hash[namespace_scopes.map { |nd|
-          key = ['xmlns', nd.prefix].compact.join(':')
-          [key, nd.href]
-        }]
+        namespace_scopes.each_with_object({}) do |nd, hsh|
+          key = +'xmlns'
+          if (scope_prefix = nd.prefix)
+            key << ":#{scope_prefix}"
+          end
+          hsh[key] = nd.href
+        end
       end
 
       # Returns true if this is a Comment

--- a/lib/nokogiri/xml/reader.rb
+++ b/lib/nokogiri/xml/reader.rb
@@ -87,9 +87,11 @@ module Nokogiri
       ###
       # Get a list of attributes for the current node.
       def attributes
-        Hash[attribute_nodes.map { |node|
-          [node.name, node.to_s]
-        }].merge(namespaces || {})
+        attrs_hash = attribute_nodes.each_with_object({}) do |node, hsh|
+                       hsh[node.name] = node.to_s
+                     end
+        attrs_hash.merge!(namespaces) if namespaces.is_a?(Hash)
+        attrs_hash
       end
 
       ###


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Unnecessary object allocations:
- `array.map` duplicates given Array `array`
- `Array#[]` generates a new Array instance.

Therefore, `Hash[array.map { |e| [e, foo] }]` generates multiple interim arrays on each call and iteration.

**Have you included adequate test coverage?**

Not necessary since this is just refactoring existing implementation.

**Does this change affect the C or the Java implementations?**

Does not affect C or Java code
