### PR TITLE
Add `Nokogiri::XML::Node#line=`

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1334,6 +1334,25 @@ static VALUE line(VALUE self)
 
 /*
  * call-seq:
+ *  line=(num)
+ *
+ * Sets the line for this Node. num must be less than 65535.
+ */
+static VALUE set_line(VALUE self, VALUE num)
+{
+  xmlNodePtr node;
+  Data_Get_Struct(self, xmlNode, node);
+
+  int value = NUM2INT(num);
+  if (value < 65535) {
+    node->line = value;
+  }
+
+  return num;
+}
+
+/*
+ * call-seq:
  *  add_namespace_definition(prefix, href)
  *
  * Adds a namespace definition with +prefix+ using +href+ value. The result is
@@ -1728,6 +1747,7 @@ void init_xml_node()
   rb_define_method(klass, "create_external_subset", create_external_subset, 3);
   rb_define_method(klass, "pointer_id", pointer_id, 0);
   rb_define_method(klass, "line", line, 0);
+  rb_define_method(klass, "line=", set_line, 1);
   rb_define_method(klass, "content", get_native_content, 0);
   rb_define_method(klass, "native_content=", set_native_content, 1);
   rb_define_method(klass, "lang", get_lang, 0);

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -1222,6 +1222,14 @@ EOXML
         assert_equal 2, node.line
       end
 
+      def test_set_line
+        skip "Only supported with libxml2" unless Nokogiri.uses_libxml?
+        document = Nokogiri::XML::Document.new
+        node = document.create_element('a')
+        node.line = 54321
+        assert_equal 54321, node.line
+      end
+
       def test_xpath_results_have_document_and_are_decorated
         x = Module.new do
           def awesome! ; end


### PR DESCRIPTION
Add support for setting the line number on elements from Ruby. This only
works when Nokogiri uses `libxml2`.

Line numbers less than 65535 may be set. Larger line numbers require
`libxml2` to be compiled with a particular option and even then, it is
buggy. See https://bugzilla.gnome.org/show_bug.cgi?id=767138.

---

Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the questions below when you submit this pull request.


**What problem is this PR intended to solve?**

This PR is intended to solve the issues for downstream projects. In particular, https://github.com/gjtorikian/html-proofer/pull/362 in html-proofer which is preventing that from using Nokogumbo for HTML5 parsing.

This implementation is similar to https://github.com/sparklemotion/nokogiri/pull/1658 (which I think was broken because the option, `XML_PARSE_BIG_LINES`, mentioned in https://github.com/sparklemotion/nokogiri/issues/1764 is not used). This version simply limits the number of lines to a maximum of 65534. This limitation could be removed if `XML_PARSE_BIG_LINES` is used, but that could be done later.

Note that the implementation of `set_line()` is slightly different from https://github.com/sparklemotion/nokogiri/pull/1658 which returns `self` rather than the argument. `set_native_content()` and `set_name` return the argument so I followed that approach.

**Have you included adequate test coverage?**

It is tested in the same manner as `Nokogiri::XML::Node#line`. (I think that should be better tested, but JRuby's line number heuristic seems like it would be easy to break and I'm not sure how to use JRuby to test.)

**Does this change affect the C or the Java implementations?**

This effects the C version only. The Java version uses a heuristic to get line numbers but that heuristic [doesn't quite work](https://github.com/sparklemotion/nokogiri/issues/1223).