### PR TITLE
Implement a mark function so we're compaction friendly

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -38,6 +38,15 @@ static void remove_private(xmlNodePtr node)
   node->_private = NULL;
 }
 
+static void mark(xmlDocPtr doc)
+{
+  nokogiriTuplePtr tuple = (nokogiriTuplePtr)doc->_private;
+  if(tuple) {
+      rb_gc_mark(tuple->doc);
+      rb_gc_mark(tuple->node_cache);
+  }
+}
+
 static void dealloc(xmlDocPtr doc)
 {
   st_table *node_hash;
@@ -588,7 +597,7 @@ VALUE Nokogiri_wrap_xml_document(VALUE klass, xmlDocPtr doc)
 
   VALUE rb_doc = Data_Wrap_Struct(
       klass ? klass : cNokogiriXmlDocument,
-      0,
+      mark,
       dealloc,
       doc
   );

--- a/test/test_css_cache.rb
+++ b/test/test_css_cache.rb
@@ -24,6 +24,7 @@ class TestCssCache < Nokogiri::TestCase
   def teardown
     Nokogiri::CSS::Parser.clear_cache
     Nokogiri::CSS::Parser.set_cache true
+    super
   end
 
   [ false, true ].each do |cache_setting|

--- a/test/test_encoding_handler.rb
+++ b/test/test_encoding_handler.rb
@@ -7,6 +7,7 @@ class TestEncodingHandler < Nokogiri::TestCase
     Nokogiri::EncodingHandler.clear_aliases!
     #Replace default aliases removed by clear_aliases!
     Nokogiri.install_default_aliases
+    super
   end
 
   def test_get


### PR DESCRIPTION
If we don't manually mark members of the struct, they can move out from
underneath us.  For now lets just mark them so everything stays stable.