### PR TITLE
[fix] avoid doing (Java) document factory finder lookup

### DIFF
--- a/ext/java/nokogiri/HtmlDocument.java
+++ b/ext/java/nokogiri/HtmlDocument.java
@@ -70,15 +70,15 @@ public class HtmlDocument extends XmlDocument {
     }
 
     @JRubyMethod(name="new", meta = true, rest = true, required=0)
-    public static IRubyObject rbNew(ThreadContext context, IRubyObject klazz,
-                                    IRubyObject[] args) {
+    public static IRubyObject rbNew(ThreadContext context, IRubyObject klazz, IRubyObject[] args) {
+        final Ruby runtime = context.runtime;
         HtmlDocument htmlDocument;
         try {
-            Document docNode = createNewDocument();
-            htmlDocument = (HtmlDocument) NokogiriService.HTML_DOCUMENT_ALLOCATOR.allocate(context.getRuntime(), (RubyClass) klazz);
+            Document docNode = createNewDocument(runtime);
+            htmlDocument = (HtmlDocument) NokogiriService.HTML_DOCUMENT_ALLOCATOR.allocate(runtime, (RubyClass) klazz);
             htmlDocument.setDocumentNode(context, docNode);
         } catch (Exception ex) {
-            throw context.getRuntime().newRuntimeError("couldn't create document: " + ex);
+            throw runtime.newRuntimeError("couldn't create document: " + ex);
         }
 
         Helpers.invoke(context, htmlDocument, "initialize", args);


### PR DESCRIPTION
every time a new XML document is being created, since it causes class-path scanning 
(considerable slow-downs esp. in multi-threaded envs)

samples of captured lock waits (note the stack trace bellow pointing to `XmlDocument.new`) :

![nokogiri1](https://user-images.githubusercontent.com/45967/66398641-71a28a80-e9de-11e9-9a22-8041ee1c4bfb.png)

![nokogiri2](https://user-images.githubusercontent.com/45967/66398650-76673e80-e9de-11e9-84d5-bbc7c3ce177b.png)



**Have you included adequate test coverage?**

hard to test multi-threaded behaviour with internal (JVM) locking


**Does this change affect the C or the Java implementations?**

change is a Java specific fix that improves Nokogiri performance under JRuby
