### PR TITLE
[jruby] cleanup/refactor extension code

### DIFF
--- a/ext/java/nokogiri/HtmlDocument.java
+++ b/ext/java/nokogiri/HtmlDocument.java
@@ -70,15 +70,15 @@ public class HtmlDocument extends XmlDocument {
     }
 
     @JRubyMethod(name="new", meta = true, rest = true, required=0)
-    public static IRubyObject rbNew(ThreadContext context, IRubyObject klazz,
-                                    IRubyObject[] args) {
+    public static IRubyObject rbNew(ThreadContext context, IRubyObject klazz, IRubyObject[] args) {
+        final Ruby runtime = context.runtime;
         HtmlDocument htmlDocument;
         try {
-            Document docNode = createNewDocument();
-            htmlDocument = (HtmlDocument) NokogiriService.HTML_DOCUMENT_ALLOCATOR.allocate(context.getRuntime(), (RubyClass) klazz);
+            Document docNode = createNewDocument(runtime);
+            htmlDocument = (HtmlDocument) NokogiriService.HTML_DOCUMENT_ALLOCATOR.allocate(runtime, (RubyClass) klazz);
             htmlDocument.setDocumentNode(context, docNode);
         } catch (Exception ex) {
-            throw context.getRuntime().newRuntimeError("couldn't create document: " + ex);
+            throw runtime.newRuntimeError("couldn't create document: " + ex);
         }
 
         Helpers.invoke(context, htmlDocument, "initialize", args);

--- a/ext/java/nokogiri/HtmlSaxParserContext.java
+++ b/ext/java/nokogiri/HtmlSaxParserContext.java
@@ -90,7 +90,7 @@ public class HtmlSaxParserContext extends XmlSaxParserContext {
                                            IRubyObject data,
                                            IRubyObject encoding) {
         HtmlSaxParserContext ctx = (HtmlSaxParserContext) NokogiriService.HTML_SAXPARSER_CONTEXT_ALLOCATOR.allocate(context.getRuntime(), (RubyClass)klazz);
-        ctx.initialize(context.getRuntime());
+        ctx.initialize(context.runtime);
         ctx.java_encoding = NokogiriHelpers.getValidEncodingOrNull(context.runtime, encoding);
         ctx.setStringInputSource(context, data, context.nil);
         return ctx;

--- a/ext/java/nokogiri/NokogiriService.java
+++ b/ext/java/nokogiri/NokogiriService.java
@@ -258,7 +258,7 @@ public class NokogiriService implements BasicLibraryService {
         }
     };
 
-    public static final ObjectAllocator HTML_SAXPARSER_CONTEXT_ALLOCATOR = new ObjectAllocator() {
+    private static final ObjectAllocator HTML_SAXPARSER_CONTEXT_ALLOCATOR = new ObjectAllocator() {
         private HtmlSaxParserContext htmlSaxParserContext = null;
         public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
             if (htmlSaxParserContext == null) htmlSaxParserContext = new HtmlSaxParserContext(runtime, klazz);

--- a/ext/java/nokogiri/XmlAttr.java
+++ b/ext/java/nokogiri/XmlAttr.java
@@ -79,22 +79,20 @@ public class XmlAttr extends XmlNode {
     @Override
     protected void init(ThreadContext context, IRubyObject[] args) {
         if (args.length < 2) {
-            throw getRuntime().newArgumentError(args.length, 2);
+            throw context.runtime.newArgumentError(args.length, 2);
         }
 
         IRubyObject doc = args[0];
         IRubyObject content = args[1];
 
-        if(!(doc instanceof XmlDocument)) {
-            final String msg =
-                "document must be an instance of Nokogiri::XML::Document";
-            throw getRuntime().newArgumentError(msg);
+        if (!(doc instanceof XmlDocument)) {
+            throw context.runtime.newArgumentError("document must be an instance of Nokogiri::XML::Document");
         }
 
         XmlDocument xmlDoc = (XmlDocument)doc;
         String str = rubyStringToString(content);
         Node attr = xmlDoc.getDocument().createAttribute(str);
-        setNode(context, attr);
+        setNode(context.runtime, attr);
     }
     
     
@@ -142,10 +140,13 @@ public class XmlAttr extends XmlNode {
         if (name != null) return name;
 
         String attrName = ((Attr) node).getName();
-        if (!(doc instanceof HtmlDocument) && node.getNamespaceURI() != null) {
-            attrName = NokogiriHelpers.getLocalPart(attrName);
-        }
         if (attrName == null) return context.nil;
+
+        if (node.getNamespaceURI() != null && !(document(context.runtime) instanceof HtmlDocument)) {
+            attrName = NokogiriHelpers.getLocalPart(attrName);
+            if (attrName == null) return context.nil;
+        }
+
         return name = RubyString.newString(context.runtime, attrName);
     }
 

--- a/ext/java/nokogiri/XmlAttr.java
+++ b/ext/java/nokogiri/XmlAttr.java
@@ -140,11 +140,13 @@ public class XmlAttr extends XmlNode {
     @Override
     protected IRubyObject getNodeName(ThreadContext context) {
         if (name != null) return name;
-        String attrName = ((Attr)node).getName();
+
+        String attrName = ((Attr) node).getName();
         if (!(doc instanceof HtmlDocument) && node.getNamespaceURI() != null) {
             attrName = NokogiriHelpers.getLocalPart(attrName);
         }
-        return attrName == null ? context.getRuntime().getNil() : RubyString.newString(context.getRuntime(), attrName);
+        if (attrName == null) return context.nil;
+        return name = RubyString.newString(context.runtime, attrName);
     }
 
     @Override

--- a/ext/java/nokogiri/XmlAttr.java
+++ b/ext/java/nokogiri/XmlAttr.java
@@ -103,7 +103,7 @@ public class XmlAttr extends XmlNode {
     // the default namespace should be registered for this attribute
     void setNamespaceIfNecessary(Ruby runtime) {
         if ("xml".equals(node.getPrefix())) {
-           XmlNamespace.createDefaultNamespace(runtime, node); 
+            XmlNamespace.createDefaultNamespace(runtime, node);
         }
     }
 

--- a/ext/java/nokogiri/XmlAttr.java
+++ b/ext/java/nokogiri/XmlAttr.java
@@ -105,16 +105,6 @@ public class XmlAttr extends XmlNode {
         }
     }
 
-    private boolean isHtmlBooleanAttr() {
-        String name = node.getNodeName().toLowerCase();
-
-        for(String s : HTML_BOOLEAN_ATTRS) {
-            if(s.equals(name)) return true;
-        }
-
-        return false;
-    }
-
     @Override
     @JRubyMethod(name = {"content", "value", "to_s"})
     public IRubyObject content(ThreadContext context) {

--- a/ext/java/nokogiri/XmlAttributeDecl.java
+++ b/ext/java/nokogiri/XmlAttributeDecl.java
@@ -67,12 +67,11 @@ public class XmlAttributeDecl extends XmlNode {
         super(ruby, klass, attrDeclNode);
     }
 
-    public static IRubyObject create(ThreadContext context, Node attrDeclNode) {
-        XmlAttributeDecl self =
-            new XmlAttributeDecl(context.getRuntime(),
-                                 getNokogiriClass(context.getRuntime(), "Nokogiri::XML::AttributeDecl"),
-                                 attrDeclNode);
-        return self;
+    static XmlAttributeDecl create(ThreadContext context, Node attrDeclNode) {
+        return new XmlAttributeDecl(context.runtime,
+            getNokogiriClass(context.runtime, "Nokogiri::XML::AttributeDecl"),
+            attrDeclNode
+        );
     }
 
     @Override
@@ -84,8 +83,7 @@ public class XmlAttributeDecl extends XmlNode {
     @Override
     @JRubyMethod(name = "node_name=")
     public IRubyObject node_name_set(ThreadContext context, IRubyObject name) {
-        throw context.getRuntime()
-            .newRuntimeError("cannot change name of DTD decl");
+        throw context.runtime.newRuntimeError("cannot change name of DTD decl");
     }
 
     public IRubyObject element_name(ThreadContext context) {
@@ -112,19 +110,20 @@ public class XmlAttributeDecl extends XmlNode {
      */
     @JRubyMethod
     public IRubyObject enumeration(ThreadContext context) {
-        RubyArray enumVals = RubyArray.newArray(context.getRuntime());
-        String atype = ((Element)node).getAttribute("atype");
+        final String atype = ((Element) node).getAttribute("atype");
 
         if (atype != null && atype.length() != 0 && atype.charAt(0) == '(') {
             // removed enclosing parens
             String valueStr = atype.substring(1, atype.length() - 1);
             String[] values = valueStr.split("\\|");
+            RubyArray enumVals = RubyArray.newArray(context.runtime, values.length);
             for (int i = 0; i < values.length; i++) {
-                enumVals.append(context.getRuntime().newString(values[i]));
+                enumVals.append(context.runtime.newString(values[i]));
             }
+            return enumVals;
         }
 
-        return enumVals;
+        return context.runtime.newEmptyArray();
     }
 
 }

--- a/ext/java/nokogiri/XmlCdata.java
+++ b/ext/java/nokogiri/XmlCdata.java
@@ -69,10 +69,9 @@ public class XmlCdata extends XmlText {
         }
         IRubyObject doc = args[0];
         content = args[1];
-        XmlDocument xmlDoc =(XmlDocument) ((XmlNode) doc).document(context);
-        Document document = xmlDoc.getDocument();
+        Document document = ((XmlNode) doc).getOwnerDocument();
         Node node = document.createCDATASection(rubyStringToString(content));
-        setNode(context, node);
+        setNode(context.runtime, node);
     }
 
     @Override

--- a/ext/java/nokogiri/XmlCdata.java
+++ b/ext/java/nokogiri/XmlCdata.java
@@ -71,7 +71,7 @@ public class XmlCdata extends XmlText {
         content = args[1];
         XmlDocument xmlDoc =(XmlDocument) ((XmlNode) doc).document(context);
         Document document = xmlDoc.getDocument();
-        Node node = document.createCDATASection((content.isNil()) ? null : rubyStringToString(content));
+        Node node = document.createCDATASection(rubyStringToString(content));
         setNode(context, node);
     }
 

--- a/ext/java/nokogiri/XmlComment.java
+++ b/ext/java/nokogiri/XmlComment.java
@@ -82,7 +82,7 @@ public class XmlComment extends XmlNode {
         if (xmlDoc != null) {
             Document document = xmlDoc.getDocument();
             Node node = document.createComment(rubyStringToString(text));
-            setNode(context, node);
+            setNode(context.runtime, node);
         }
     }
 

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -85,7 +85,7 @@ import nokogiri.internals.c14n.Canonicalizer;
 
 @JRubyClass(name="Nokogiri::XML::Document", parent="Nokogiri::XML::Node")
 public class XmlDocument extends XmlNode {
-    private transient NokogiriNamespaceCache nsCache;
+    private NokogiriNamespaceCache nsCache;
 
     /* UserData keys for storing extra info in the document node. */
     public final static String DTD_RAW_DOCUMENT = "DTD_RAW_DOCUMENT";
@@ -188,7 +188,7 @@ public class XmlDocument extends XmlNode {
         if (nodePrefix == null) { // default namespace
             NokogiriHelpers.renameNode(node, default_href, node.getNodeName());
         } else {
-            String href = nsCache.get(node, nodePrefix).getHref();
+            String href = getNamespaceCache().get(node, nodePrefix).getHref();
             NokogiriHelpers.renameNode(node, href, node.getNodeName());
         }
         resolveNamespaceIfNecessary(node.getNextSibling(), default_href);
@@ -347,7 +347,7 @@ public class XmlDocument extends XmlNode {
     @JRubyMethod(name="remove_namespaces!")
     public IRubyObject remove_namespaces(ThreadContext context) {
         removeNamespceRecursively(context, this);
-        nsCache.clear();
+        if (nsCache != null) nsCache.clear();
         clearXpathContext(getNode());
         return this;
     }

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -54,6 +54,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
@@ -104,15 +105,15 @@ public class XmlDocument extends XmlNode {
     private static boolean loadExternalSubset = false; // TODO: Verify this.
 
     /** cache variables */
-    protected IRubyObject encoding = null;
-    protected IRubyObject url = null;
+    protected IRubyObject encoding;
+    protected IRubyObject url;
 
-    public XmlDocument(Ruby ruby, RubyClass klazz) {
-        super(ruby, klazz, createNewDocument());
+    public XmlDocument(Ruby runtime, RubyClass klazz) {
+        super(runtime, klazz, createNewDocument(runtime));
     }
 
-    public XmlDocument(Ruby ruby, Document document) {
-        this(ruby, getNokogiriClass(ruby, "Nokogiri::XML::Document"), document);
+    public XmlDocument(Ruby runtime, Document document) {
+        this(runtime, getNokogiriClass(runtime, "Nokogiri::XML::Document"), document);
     }
 
     public XmlDocument(Ruby ruby, RubyClass klass, Document document) {
@@ -227,13 +228,29 @@ public class XmlDocument extends XmlNode {
         return getUrl();
     }
 
-    public static Document createNewDocument() {
+    public static Document createNewDocument(final Ruby runtime) {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance(DOCUMENTBUILDERFACTORY_IMPLE_NAME, NokogiriService.class.getClassLoader());
-            return factory.newDocumentBuilder().newDocument();
+            return DocumentBuilderFactoryHolder.INSTANCE.newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException e) {
-            return null;        // this will end is disaster...
+            throw asRuntimeError(runtime, null, e);
         }
+    }
+
+    private static class DocumentBuilderFactoryHolder {
+        static final DocumentBuilderFactory INSTANCE;
+        static {
+            INSTANCE = DocumentBuilderFactory.newInstance(DOCUMENTBUILDERFACTORY_IMPLE_NAME, NokogiriService.class.getClassLoader());
+        }
+    }
+
+    private static RaiseException asRuntimeError(Ruby runtime, String message, Exception cause) {
+        if (cause instanceof RaiseException) return (RaiseException) cause;
+
+        if (message == null) message = cause.toString();
+        else message = message + '(' + cause.toString() + ')';
+        RaiseException ex = runtime.newRuntimeError(message);
+        ex.initCause(cause);
+        return ex;
     }
 
     /*
@@ -244,19 +261,20 @@ public class XmlDocument extends XmlNode {
      */
     @JRubyMethod(name="new", meta = true, rest = true, required=0)
     public static IRubyObject rbNew(ThreadContext context, IRubyObject klazz, IRubyObject[] args) {
+        final Ruby runtime = context.runtime;
         XmlDocument xmlDocument;
         try {
-            Document docNode = createNewDocument();
+            Document docNode = createNewDocument(runtime);
             if ("Nokogiri::HTML::Document".equals(((RubyClass)klazz).getName())) {
-                xmlDocument = (XmlDocument) NokogiriService.HTML_DOCUMENT_ALLOCATOR.allocate(context.getRuntime(), (RubyClass) klazz);
+                xmlDocument = (XmlDocument) NokogiriService.HTML_DOCUMENT_ALLOCATOR.allocate(runtime, (RubyClass) klazz);
                 xmlDocument.setDocumentNode(context, docNode);
             } else {
                 // XML::Document and sublass
-                xmlDocument = (XmlDocument) NokogiriService.XML_DOCUMENT_ALLOCATOR.allocate(context.getRuntime(), (RubyClass) klazz);
+                xmlDocument = (XmlDocument) NokogiriService.XML_DOCUMENT_ALLOCATOR.allocate(runtime, (RubyClass) klazz);
                 xmlDocument.setDocumentNode(context, docNode);
             }
         } catch (Exception ex) {
-            throw context.getRuntime().newRuntimeError("couldn't create document: "+ex.toString());
+            throw asRuntimeError(runtime, "couldn't create document: ", ex);
         }
 
         Helpers.invoke(context, xmlDocument, "initialize", args);

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -45,11 +45,12 @@ import java.util.List;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.jcodings.specific.UTF8Encoding;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
-import org.jruby.RubyNil;
+import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaUtil;
@@ -57,6 +58,7 @@ import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentType;
@@ -174,8 +176,7 @@ public class XmlDocument extends XmlNode {
     public XmlDocument(Ruby ruby, RubyClass klass, Document document, XmlDocument contextDoc) {
         super(ruby, klass, document);
         nsCache = contextDoc.getNamespaceCache();
-        XmlNamespace default_ns = nsCache.getDefault();
-        String default_href = rubyStringToString(default_ns.href);
+        String default_href = nsCache.getDefault().getHref();
         resolveNamespaceIfNecessary(document.getDocumentElement(), default_href);
     }
 
@@ -185,8 +186,7 @@ public class XmlDocument extends XmlNode {
         if (nodePrefix == null) { // default namespace
             NokogiriHelpers.renameNode(node, default_href, node.getNodeName());
         } else {
-            XmlNamespace xmlNamespace = nsCache.get(node, nodePrefix);
-            String href = rubyStringToString(xmlNamespace.href);
+            String href = nsCache.get(node, nodePrefix).getHref();
             NokogiriHelpers.renameNode(node, href, node.getNodeName());
         }
         resolveNamespaceIfNecessary(node.getNextSibling(), default_href);
@@ -214,7 +214,7 @@ public class XmlDocument extends XmlNode {
 
     @Override
     protected IRubyObject getNodeName(ThreadContext context) {
-        if (name == null) name = context.getRuntime().newString("document");
+        if (name == null) name = context.runtime.newString("document");
         return name;
     }
 
@@ -273,10 +273,10 @@ public class XmlDocument extends XmlNode {
         // FIXME: Entity node should be create by some right way.
         // this impl passes tests, but entity doesn't exists in DTD, which
         // would cause validation failure.
-        if (argv.length == 0) throw context.getRuntime().newRuntimeError("Could not create entity");
+        if (argv.length == 0) throw context.runtime.newRuntimeError("Could not create entity");
         String tagName = rubyStringToString(argv[0]);
-        Node n = this.getOwnerDocument().createElement(tagName);
-        return XmlEntityDecl.create(context, n, argv);
+        Node node = getOwnerDocument().createElement(tagName);
+        return XmlEntityDecl.create(context, node, argv);
     }
 
     @Override
@@ -307,7 +307,7 @@ public class XmlDocument extends XmlNode {
     @JRubyMethod(meta = true)
     public static IRubyObject load_external_subsets_set(ThreadContext context, IRubyObject cls, IRubyObject value) {
         XmlDocument.loadExternalSubset = value.isTrue();
-        return context.getRuntime().getNil();
+        return context.nil;
     }
 
     @JRubyMethod(meta = true, required = 4)
@@ -358,7 +358,7 @@ public class XmlDocument extends XmlNode {
         }
         XmlNodeSet nodeSet = (XmlNodeSet) xmlNode.children(context);
         for (long i=0; i < nodeSet.length(); i++) {
-            XmlNode childNode = (XmlNode)nodeSet.slice(context, RubyFixnum.newFixnum(context.getRuntime(), i));
+            XmlNode childNode = (XmlNode)nodeSet.slice(context, RubyFixnum.newFixnum(context.runtime, i));
             removeNamespceRecursively(context, childNode);
         }
     }
@@ -393,17 +393,17 @@ public class XmlDocument extends XmlNode {
     }
 
     @JRubyMethod(name="root=")
-    public IRubyObject root_set(ThreadContext context, IRubyObject newRoot_) {
+    public IRubyObject root_set(ThreadContext context, IRubyObject new_root) {
         // in case of document fragment, temporary root node should be deleted.
 
         // Java can't have a root whose value is null. Instead of setting null,
         // the method sets user data so that other methods are able to know the root
         // should be nil.
-        if (newRoot_ instanceof RubyNil) {
+        if (new_root == context.nil) {
             getDocument().getDocumentElement().setUserData(NokogiriHelpers.VALID_ROOT_NODE, false, null);
-            return newRoot_;
+            return new_root;
         }
-        XmlNode newRoot = asXmlNode(context, newRoot_);
+        XmlNode newRoot = asXmlNode(context, new_root);
 
         IRubyObject root = root(context);
         if (root.isNil()) {
@@ -415,10 +415,10 @@ public class XmlDocument extends XmlNode {
                 // with different owner document.
                 newRootNode = getDocument().importNode(newRoot.node, true);
             }
-            add_child_node(context, getCachedNodeOrCreate(context.getRuntime(), newRootNode));
+            add_child_node(context, getCachedNodeOrCreate(context.runtime, newRootNode));
         } else {
             Node rootNode = asXmlNode(context, root).node;
-            ((XmlNode)getCachedNodeOrCreate(context.getRuntime(), rootNode)).replace_node(context, newRoot);
+            ((XmlNode)getCachedNodeOrCreate(context.runtime, rootNode)).replace_node(context, newRoot);
         }
 
         return newRoot;
@@ -426,13 +426,13 @@ public class XmlDocument extends XmlNode {
 
     @JRubyMethod
     public IRubyObject version(ThreadContext context) {
-        return stringOrNil(context.getRuntime(), getDocument().getXmlVersion());
+        return stringOrNil(context.runtime, getDocument().getXmlVersion());
     }
 
     @JRubyMethod(meta = true)
     public static IRubyObject substitute_entities_set(ThreadContext context, IRubyObject cls, IRubyObject value) {
         XmlDocument.substituteEntities = value.isTrue();
-        return context.getRuntime().getNil();
+        return context.nil;
     }
 
     public IRubyObject getInternalSubset(ThreadContext context) {
@@ -441,27 +441,23 @@ public class XmlDocument extends XmlNode {
         if (dtd == null) {
             Document document = getDocument();
             if (document.getUserData(XmlDocument.DTD_RAW_DOCUMENT) != null) {
-                dtd = XmlDtd.newFromInternalSubset(context.getRuntime(), document);
+                dtd = XmlDtd.newFromInternalSubset(context.runtime, document);
             } else if (document.getDoctype() != null) {
                 DocumentType docType = document.getDoctype();
                 IRubyObject name, publicId, systemId;
-                name = publicId = systemId = context.getRuntime().getNil();
+                name = publicId = systemId = context.nil;
                 if (docType.getName() != null) {
-                    name = context.getRuntime().newString(docType.getName());
+                    name = context.runtime.newString(docType.getName());
                 }
                 if (docType.getPublicId() != null) {
-                    publicId = context.getRuntime().newString(docType.getPublicId());
+                    publicId = context.runtime.newString(docType.getPublicId());
                 }
                 if (docType.getSystemId() != null) {
-                    systemId = context.getRuntime().newString(docType.getSystemId());
+                    systemId = context.runtime.newString(docType.getSystemId());
                 }
-                dtd = XmlDtd.newEmpty(context.getRuntime(),
-                                      document,
-                                      name,
-                                      publicId,
-                                      systemId);
+                dtd = XmlDtd.newEmpty(context.runtime, document, name, publicId, systemId);
             } else {
-                dtd = context.getRuntime().getNil();
+                dtd = context.nil;
             }
 
             setInternalSubset(dtd);
@@ -478,9 +474,7 @@ public class XmlDocument extends XmlNode {
                                             IRubyObject name,
                                             IRubyObject external_id,
                                             IRubyObject system_id) {
-        XmlDtd dtd = XmlDtd.newEmpty(context.getRuntime(),
-                                     this.getDocument(),
-                                     name, external_id, system_id);
+        XmlDtd dtd = XmlDtd.newEmpty(context.runtime, getDocument(), name, external_id, system_id);
         setInternalSubset(dtd);
         return dtd;
     }
@@ -492,7 +486,7 @@ public class XmlDocument extends XmlNode {
     public IRubyObject getExternalSubset(ThreadContext context) {
         IRubyObject dtd = (IRubyObject) node.getUserData(DTD_EXTERNAL_SUBSET);
 
-        if (dtd == null) return context.getRuntime().getNil();
+        if (dtd == null) return context.nil;
         return dtd;
     }
 
@@ -504,9 +498,7 @@ public class XmlDocument extends XmlNode {
                                             IRubyObject name,
                                             IRubyObject external_id,
                                             IRubyObject system_id) {
-        XmlDtd dtd = XmlDtd.newEmpty(context.getRuntime(),
-                                     this.getDocument(),
-                                     name, external_id, system_id);
+        XmlDtd dtd = XmlDtd.newEmpty(context.runtime, getDocument(), name, external_id, system_id);
         setExternalSubset(dtd);
         return dtd;
     }
@@ -524,19 +516,19 @@ public class XmlDocument extends XmlNode {
             Node child = children.item(i);
             short type = child.getNodeType();
             if (type == Node.COMMENT_NODE) {
-                XmlComment xmlComment = (XmlComment) getCachedNodeOrCreate(context.getRuntime(), child);
+                XmlComment xmlComment = (XmlComment) getCachedNodeOrCreate(context.runtime, child);
                 xmlComment.accept(context, visitor);
             } else if (type == Node.DOCUMENT_TYPE_NODE) {
-                XmlDtd xmlDtd = (XmlDtd) getCachedNodeOrCreate(context.getRuntime(), child);
+                XmlDtd xmlDtd = (XmlDtd) getCachedNodeOrCreate(context.runtime, child);
                 xmlDtd.accept(context, visitor);
             } else if (type == Node.PROCESSING_INSTRUCTION_NODE) {
-                XmlProcessingInstruction xmlProcessingInstruction = (XmlProcessingInstruction) getCachedNodeOrCreate(context.getRuntime(), child);
+                XmlProcessingInstruction xmlProcessingInstruction = (XmlProcessingInstruction) getCachedNodeOrCreate(context.runtime, child);
                 xmlProcessingInstruction.accept(context, visitor);
             } else if (type == Node.TEXT_NODE) {
-                XmlText xmlText = (XmlText) getCachedNodeOrCreate(context.getRuntime(), child);
+                XmlText xmlText = (XmlText) getCachedNodeOrCreate(context.runtime, child);
                 xmlText.accept(context, visitor);
             } else if (type == Node.ELEMENT_NODE) {
-                XmlElement xmlElement = (XmlElement) getCachedNodeOrCreate(context.getRuntime(), child);
+                XmlElement xmlElement = (XmlElement) getCachedNodeOrCreate(context.runtime, child);
                 xmlElement.accept(context, visitor);
             }
         }
@@ -577,11 +569,11 @@ public class XmlDocument extends XmlNode {
         }
         if (args.length > 1 ) {
             if (!args[1].isNil() && !(args[1] instanceof List)) {
-                throw context.getRuntime().newTypeError("Expected array");
+                throw context.runtime.newTypeError("Expected array");
             }
             if (!args[1].isNil()) {
               inclusive_namespace = ((RubyArray)args[1])
-                .join(context, context.getRuntime().newString(" "))
+                .join(context, context.runtime.newString(" "))
                 .asString()
                 .asJavaString(); // OMG I wish I knew JRuby better, this is ugly
             }
@@ -613,16 +605,12 @@ public class XmlDocument extends XmlNode {
             } else {
                 result = canonicalizer.canonicalizeSubtree(startingNode.getNode(), inclusive_namespace, filter);
             }
-            String resultString = new String(result, "UTF-8");
-            return stringOrNil(context.getRuntime(), resultString);
+            return RubyString.newString(context.runtime, new ByteList(result, UTF8Encoding.INSTANCE));
         } catch (CanonicalizationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (UnsupportedEncodingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
         }
-        return context.getRuntime().getNil();
+        return context.nil;
     }
 
     private XmlNode getStartingNode(Block block) {
@@ -636,6 +624,6 @@ public class XmlDocument extends XmlNode {
 
     public void resetNamespaceCache(ThreadContext context) {
         nsCache = new NokogiriNamespaceCache();
-        createAndCacheNamespaces(context.getRuntime(), node);
+        createAndCacheNamespaces(context.runtime, node);
     }
 }

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -45,6 +45,7 @@ import java.util.List;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.jcodings.specific.USASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -95,6 +96,9 @@ public class XmlDocument extends XmlNode {
      * Setting an appropriate classloader resolves issue 380.
      */
     private static final String DOCUMENTBUILDERFACTORY_IMPLE_NAME = "org.apache.xerces.jaxp.DocumentBuilderFactoryImpl";
+
+    private static final ByteList DOCUMENT = ByteList.create("document");
+    static { DOCUMENT.setEncoding(USASCIIEncoding.INSTANCE); }
 
     private static boolean substituteEntities = false;
     private static boolean loadExternalSubset = false; // TODO: Verify this.
@@ -206,7 +210,7 @@ public class XmlDocument extends XmlNode {
 
     @Override
     protected IRubyObject getNodeName(ThreadContext context) {
-        if (name == null) name = context.runtime.newString("document");
+        if (name == null) name = RubyString.newStringShared(context.runtime, DOCUMENT);
         return name;
     }
 

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -58,6 +58,7 @@ import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.w3c.dom.Attr;
@@ -539,14 +540,21 @@ public class XmlDocument extends XmlNode {
         visitor.leave(document);
     }
 
-    @JRubyMethod(meta=true)
-    public static IRubyObject wrapJavaDocument(ThreadContext context, IRubyObject klass, IRubyObject arg) {
+    @JRubyMethod(meta = true)
+    public static IRubyObject wrap(ThreadContext context, IRubyObject klass, IRubyObject arg) {
         XmlDocument xmlDocument = new XmlDocument(context.runtime, (RubyClass) klass, (Document) arg.toJava(Document.class));
         Helpers.invoke(context, xmlDocument, "initialize");
         return xmlDocument;
     }
 
-    @JRubyMethod
+    @Deprecated
+    @JRubyMethod(meta = true, visibility = Visibility.PRIVATE)
+    public static IRubyObject wrapJavaDocument(ThreadContext context, IRubyObject klass, IRubyObject arg) {
+        return wrap(context, klass, arg);
+    }
+
+    @Deprecated // default to_java works (due inherited from XmlNode#toJava)
+    @JRubyMethod(visibility = Visibility.PRIVATE)
     public IRubyObject toJavaDocument(ThreadContext context) {
         return JavaUtil.convertJavaToUsableRubyObject(context.getRuntime(), node);
     }
@@ -617,9 +625,8 @@ public class XmlDocument extends XmlNode {
 
     private XmlNode getStartingNode(Block block) {
         if (block.isGiven()) {
-            if (block.getBinding().getSelf() instanceof XmlNode) {
-                return (XmlNode)block.getBinding().getSelf();
-            }
+            IRubyObject boundSelf = block.getBinding().getSelf();
+            if (boundSelf instanceof XmlNode) return (XmlNode) boundSelf;
         }
         return this;
     }

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -338,13 +338,13 @@ public class XmlDocument extends XmlNode {
 
     @JRubyMethod(name="remove_namespaces!")
     public IRubyObject remove_namespaces(ThreadContext context) {
-        removeNamespceRecursively(context, this);
+        removeNamespaceRecursively(this);
         if (nsCache != null) nsCache.clear();
         clearXpathContext(getNode());
         return this;
     }
 
-    private void removeNamespceRecursively(ThreadContext context, XmlNode xmlNode) {
+    private void removeNamespaceRecursively(XmlNode xmlNode) {
         Node node = xmlNode.node;
         if (node.getNodeType() == Node.ELEMENT_NODE) {
             node.setPrefix(null);
@@ -353,17 +353,17 @@ public class XmlDocument extends XmlNode {
             for (int i=0; i<attrs.getLength(); i++) {
                 Attr attr = (Attr) attrs.item(i);
                 if (isNamespace(attr.getNodeName())) {
-                    ((org.w3c.dom.Element)node).removeAttributeNode(attr);
+                    ((org.w3c.dom.Element) node).removeAttributeNode(attr);
                 } else {
                     attr.setPrefix(null);
                     NokogiriHelpers.renameNode(attr, null, attr.getLocalName());
                 }
             }
         }
-        XmlNodeSet nodeSet = (XmlNodeSet) xmlNode.children(context);
-        for (long i=0; i < nodeSet.length(); i++) {
-            XmlNode childNode = (XmlNode)nodeSet.slice(context, RubyFixnum.newFixnum(context.runtime, i));
-            removeNamespceRecursively(context, childNode);
+        IRubyObject[] nodes = xmlNode.getChildren();
+        for (int i=0; i < nodes.length; i++) {
+            XmlNode childNode = (XmlNode) nodes[i];
+            removeNamespaceRecursively(childNode);
         }
     }
 

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -39,7 +39,6 @@ import static nokogiri.internals.NokogiriHelpers.isNamespace;
 import static nokogiri.internals.NokogiriHelpers.rubyStringToString;
 import static nokogiri.internals.NokogiriHelpers.stringOrNil;
 
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -116,23 +115,22 @@ public class XmlDocument extends XmlNode {
         this(runtime, getNokogiriClass(runtime, "Nokogiri::XML::Document"), document);
     }
 
-    public XmlDocument(Ruby ruby, RubyClass klass, Document document) {
-        super(ruby, klass, document);
-        createAndCacheNamespaces(ruby, document.getDocumentElement());
+    XmlDocument(Ruby runtime, RubyClass klass, Document document) {
+        super(runtime, klass, document);
+        init(runtime, document);
+    }
+
+    private void init(Ruby runtime, Document document) {
         stabilizeTextContent(document);
-        setInstanceVariable("@decorators", ruby.getNil());
+        createAndCacheNamespaces(runtime, document.getDocumentElement());
+        setInstanceVariable("@decorators", runtime.getNil());
     }
 
     public void setDocumentNode(ThreadContext context, Node node) {
-        super.setNode(context, node);
+        setNode(context, node);
         getNamespaceCache(); // initialize
-        Ruby runtime = context.runtime;
-        if (node != null) {
-            Document document = (Document)node;
-            stabilizeTextContent(document);
-            createAndCacheNamespaces(runtime, document.getDocumentElement());
-        }
-        setInstanceVariable("@decorators", runtime.getNil());
+        if (node != null) init(context.runtime, (Document) node);
+        else setInstanceVariable("@decorators", context.nil);
     }
 
     public void setEncoding(IRubyObject encoding) {

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -175,24 +175,24 @@ public class XmlDocument extends XmlNode {
         super(ruby, klass, document);
         nsCache = contextDoc.getNamespaceCache();
         XmlNamespace default_ns = nsCache.getDefault();
-        String default_href = rubyStringToString(default_ns.href(ruby.getCurrentContext()));
-        resolveNamespaceIfNecessary(ruby.getCurrentContext(), document.getDocumentElement(), default_href);
+        String default_href = rubyStringToString(default_ns.href);
+        resolveNamespaceIfNecessary(document.getDocumentElement(), default_href);
     }
 
-    private void resolveNamespaceIfNecessary(ThreadContext context, Node node, String default_href) {
+    private void resolveNamespaceIfNecessary(Node node, String default_href) {
         if (node == null) return;
         String nodePrefix = node.getPrefix();
         if (nodePrefix == null) { // default namespace
             NokogiriHelpers.renameNode(node, default_href, node.getNodeName());
         } else {
             XmlNamespace xmlNamespace = nsCache.get(node, nodePrefix);
-            String href = rubyStringToString(xmlNamespace.href(context));
+            String href = rubyStringToString(xmlNamespace.href);
             NokogiriHelpers.renameNode(node, href, node.getNodeName());
         }
-        resolveNamespaceIfNecessary(context, node.getNextSibling(), default_href);
+        resolveNamespaceIfNecessary(node.getNextSibling(), default_href);
         NodeList children = node.getChildNodes();
         for (int i=0; i<children.getLength(); i++) {
-            resolveNamespaceIfNecessary(context, children.item(i), default_href);
+            resolveNamespaceIfNecessary(children.item(i), default_href);
         }
     }
 
@@ -293,10 +293,11 @@ public class XmlDocument extends XmlNode {
     @JRubyMethod
     public IRubyObject encoding(ThreadContext context) {
         if (this.encoding == null || this.encoding.isNil()) {
-            if (getDocument().getXmlEncoding() == null) {
-                this.encoding = context.getRuntime().getNil();
+            final String enc = getDocument().getXmlEncoding();
+            if (enc == null) {
+                this.encoding = context.nil;
             } else {
-                this.encoding = context.getRuntime().newString(getDocument().getXmlEncoding());
+                this.encoding = context.runtime.newString(enc);
             }
         }
 

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -358,16 +358,12 @@ public class XmlDocument extends XmlNode {
     @JRubyMethod
     public IRubyObject root(ThreadContext context) {
         Node rootNode = getDocument().getDocumentElement();
-        try {
-            Boolean isValid = (Boolean)rootNode.getUserData(NokogiriHelpers.VALID_ROOT_NODE);
-            if (!isValid) return context.getRuntime().getNil();
-        } catch (NullPointerException e) {
-            // does nothing since nil wasn't set to the root node before.
-        }
-        if (rootNode == null)
-            return context.getRuntime().getNil();
-        else
-            return getCachedNodeOrCreate(context.getRuntime(), rootNode);
+        if (rootNode == null) return context.nil;
+
+        Object invalid = rootNode.getUserData(NokogiriHelpers.ROOT_NODE_INVALID);
+        if (invalid != null && ((Boolean) invalid)) return context.nil;
+
+        return getCachedNodeOrCreate(context.runtime, rootNode);
     }
 
     protected IRubyObject dup_implementation(Ruby runtime, boolean deep) {
@@ -392,7 +388,7 @@ public class XmlDocument extends XmlNode {
         // the method sets user data so that other methods are able to know the root
         // should be nil.
         if (new_root == context.nil) {
-            getDocument().getDocumentElement().setUserData(NokogiriHelpers.VALID_ROOT_NODE, false, null);
+            getDocument().getDocumentElement().setUserData(NokogiriHelpers.ROOT_NODE_INVALID, Boolean.TRUE, null);
             return new_root;
         }
         XmlNode newRoot = asXmlNode(context, new_root);
@@ -410,7 +406,7 @@ public class XmlDocument extends XmlNode {
             add_child_node(context, getCachedNodeOrCreate(context.runtime, newRootNode));
         } else {
             Node rootNode = asXmlNode(context, root).node;
-            ((XmlNode)getCachedNodeOrCreate(context.runtime, rootNode)).replace_node(context, newRoot);
+            ((XmlNode) getCachedNodeOrCreate(context.runtime, rootNode)).replace_node(context, newRoot);
         }
 
         return newRoot;

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -84,7 +84,7 @@ import nokogiri.internals.c14n.Canonicalizer;
 
 @JRubyClass(name="Nokogiri::XML::Document", parent="Nokogiri::XML::Node")
 public class XmlDocument extends XmlNode {
-    private NokogiriNamespaceCache nsCache;
+    private transient NokogiriNamespaceCache nsCache;
 
     /* UserData keys for storing extra info in the document node. */
     public final static String DTD_RAW_DOCUMENT = "DTD_RAW_DOCUMENT";
@@ -113,7 +113,6 @@ public class XmlDocument extends XmlNode {
 
     public XmlDocument(Ruby ruby, RubyClass klass, Document document) {
         super(ruby, klass, document);
-        initializeNamespaceCacheIfNecessary();
         createAndCacheNamespaces(ruby, document.getDocumentElement());
         stabilizeTextContent(document);
         setInstanceVariable("@decorators", ruby.getNil());
@@ -121,8 +120,8 @@ public class XmlDocument extends XmlNode {
 
     public void setDocumentNode(ThreadContext context, Node node) {
         super.setNode(context, node);
-        initializeNamespaceCacheIfNecessary();
-        Ruby runtime = context.getRuntime();
+        getNamespaceCache(); // initialize
+        Ruby runtime = context.runtime;
         if (node != null) {
             Document document = (Document)node;
             stabilizeTextContent(document);
@@ -197,15 +196,8 @@ public class XmlDocument extends XmlNode {
     }
 
     public NokogiriNamespaceCache getNamespaceCache() {
-        return nsCache;
-    }
-
-    public void initializeNamespaceCacheIfNecessary() {
         if (nsCache == null) nsCache = new NokogiriNamespaceCache();
-    }
-
-    public void setNamespaceCache(NokogiriNamespaceCache nsCache) {
-        this.nsCache = nsCache;
+        return nsCache;
     }
 
     public Document getDocument() {

--- a/ext/java/nokogiri/XmlDocumentFragment.java
+++ b/ext/java/nokogiri/XmlDocumentFragment.java
@@ -180,6 +180,6 @@ public class XmlDocumentFragment extends XmlNode {
 
     @Override
     public void relink_namespace(ThreadContext context) {
-        ((XmlNodeSet) children(context)).relink_namespace(context);
+        relink_namespace(context, getChildren());
     }
 }

--- a/ext/java/nokogiri/XmlDocumentFragment.java
+++ b/ext/java/nokogiri/XmlDocumentFragment.java
@@ -76,13 +76,12 @@ public class XmlDocumentFragment extends XmlNode {
 
     @JRubyMethod(name="new", meta = true, required=1, optional=2)
     public static IRubyObject rbNew(ThreadContext context, IRubyObject cls, IRubyObject[] args) {
-        
-        if(args.length < 1) {
-            throw context.getRuntime().newArgumentError(args.length, 1);
+        if (args.length < 1) {
+            throw context.runtime.newArgumentError(args.length, 1);
         }
 
-        if(!(args[0] instanceof XmlDocument)){
-            throw context.getRuntime().newArgumentError("first parameter must be a Nokogiri::XML::Document instance");
+        if (!(args[0] instanceof XmlDocument)){
+            throw context.runtime.newArgumentError("first parameter must be a Nokogiri::XML::Document instance");
         }
 
         XmlDocument doc = (XmlDocument) args[0];
@@ -97,7 +96,7 @@ public class XmlDocumentFragment extends XmlNode {
 
         XmlDocumentFragment fragment = (XmlDocumentFragment) NokogiriService.XML_DOCUMENT_FRAGMENT_ALLOCATOR.allocate(context.runtime, (RubyClass)cls);
         fragment.setDocument(context, doc);
-        fragment.setNode(context, doc.getDocument().createDocumentFragment());
+        fragment.setNode(context.runtime, doc.getDocument().createDocumentFragment());
 
         //TODO: Get namespace definitions from doc.
         if (args.length == 3 && args[2] != null && args[2] instanceof XmlElement) {

--- a/ext/java/nokogiri/XmlDocumentFragment.java
+++ b/ext/java/nokogiri/XmlDocumentFragment.java
@@ -119,7 +119,7 @@ public class XmlDocumentFragment extends XmlNode {
         for (int i=0; i < nodeMap.getLength(); i++) {
             Attr attr = (Attr)nodeMap.item(i);
             if (isNamespace(attr.getNodeName())) {
-                String localPart = getLocalNameForNamespace(attr.getNodeName());
+                String localPart = getLocalNameForNamespace(attr.getNodeName(), null);
                 if (getPrefix(qName).equals(localPart)) {
                     return true;
                 }

--- a/ext/java/nokogiri/XmlDocumentFragment.java
+++ b/ext/java/nokogiri/XmlDocumentFragment.java
@@ -64,7 +64,8 @@ import org.w3c.dom.NamedNodeMap;
  */
 @JRubyClass(name="Nokogiri::XML::DocumentFragment", parent="Nokogiri::XML::Node")
 public class XmlDocumentFragment extends XmlNode {
-    private XmlElement fragmentContext = null;
+
+    private XmlElement fragmentContext;
 
     public XmlDocumentFragment(Ruby ruby) {
         this(ruby, getNokogiriClass(ruby, "Nokogiri::XML::DocumentFragment"));
@@ -177,20 +178,15 @@ public class XmlDocumentFragment extends XmlNode {
         return fragmentContext;
     }
 
-    //@Override
     public void add_child(ThreadContext context, XmlNode child) {
         // Some magic for DocumentFragment
 
-        Ruby ruby = context.getRuntime();
         XmlNodeSet children = (XmlNodeSet) child.children(context);
 
-        long length = children.length();
-
-        RubyArray childrenArray = children.convertToArray();
-
-        if(length != 0) {
-            for(int i = 0; i < length; i++) {
-                XmlNode item = (XmlNode) ((XmlNode) childrenArray.aref(ruby.newFixnum(i))).dup_implementation(context, true);
+        int length = children.length();
+        if (length != 0) {
+            for (int i = 0; i < length; i++) {
+                XmlNode item = ((XmlNode) children.nodes[i]).cloneImpl(true);
                 add_child(context, item);
             }
         }

--- a/ext/java/nokogiri/XmlDocumentFragment.java
+++ b/ext/java/nokogiri/XmlDocumentFragment.java
@@ -89,12 +89,13 @@ public class XmlDocumentFragment extends XmlNode {
         
         // make wellformed fragment, ignore invalid namespace, or add appropriate namespace to parse
         if (args.length > 1 && args[1] instanceof RubyString) {
-            if (XmlDocumentFragment.isTag((RubyString)args[1])) {
-                args[1] = RubyString.newString(context.getRuntime(), addNamespaceDeclIfNeeded(doc, rubyStringToString(args[1])));
+            final RubyString arg1 = (RubyString) args[1];
+            if (XmlDocumentFragment.isTag(arg1)) {
+                args[1] = RubyString.newString(context.runtime, addNamespaceDeclIfNeeded(doc, rubyStringToString(arg1)));
             }
         }
 
-        XmlDocumentFragment fragment = (XmlDocumentFragment) NokogiriService.XML_DOCUMENT_FRAGMENT_ALLOCATOR.allocate(context.getRuntime(), (RubyClass)cls);
+        XmlDocumentFragment fragment = (XmlDocumentFragment) NokogiriService.XML_DOCUMENT_FRAGMENT_ALLOCATOR.allocate(context.runtime, (RubyClass)cls);
         fragment.setDocument(context, doc);
         fragment.setNode(context, doc.getDocument().createDocumentFragment());
 

--- a/ext/java/nokogiri/XmlDocumentFragment.java
+++ b/ext/java/nokogiri/XmlDocumentFragment.java
@@ -178,20 +178,6 @@ public class XmlDocumentFragment extends XmlNode {
         return fragmentContext;
     }
 
-    public void add_child(ThreadContext context, XmlNode child) {
-        // Some magic for DocumentFragment
-
-        XmlNodeSet children = (XmlNodeSet) child.children(context);
-
-        int length = children.length();
-        if (length != 0) {
-            for (int i = 0; i < length; i++) {
-                XmlNode item = ((XmlNode) children.nodes[i]).cloneImpl(true);
-                add_child(context, item);
-            }
-        }
-    }
-
     @Override
     public void relink_namespace(ThreadContext context) {
         ((XmlNodeSet) children(context)).relink_namespace(context);

--- a/ext/java/nokogiri/XmlDtd.java
+++ b/ext/java/nokogiri/XmlDtd.java
@@ -369,7 +369,7 @@ public class XmlDtd extends XmlNode {
      * the various collections.
      */
     protected void extractDecls(ThreadContext context) {
-        Ruby runtime = context.getRuntime();
+        Ruby runtime = context.runtime;
 
         // initialize data structures
         attributes = RubyHash.newHash(runtime);
@@ -383,7 +383,7 @@ public class XmlDtd extends XmlNode {
         if (node == null) return; // leave all the decl hash's empty
 
         // convert allDecls to a NodeSet
-        children = XmlNodeSet.newXmlNodeSet(context, extractDecls(context, node.getFirstChild()));
+        children = XmlNodeSet.newNodeSet(runtime, extractDecls(context, node.getFirstChild()));
 
         // add attribute decls as attributes to the matching element decl
         RubyArray keys = attributes.keys();

--- a/ext/java/nokogiri/XmlDtd.java
+++ b/ext/java/nokogiri/XmlDtd.java
@@ -432,18 +432,15 @@ public class XmlDtd extends XmlNode {
             if (isExternalSubset(node)) {
                 break;
             } else if (isAttributeDecl(node)) {
-                XmlAttributeDecl decl = (XmlAttributeDecl)
-                    XmlAttributeDecl.create(context, node);
+                XmlAttributeDecl decl = XmlAttributeDecl.create(context, node);
                 attributes.op_aset(context, decl.attribute_name(context), decl);
                 decls.add(decl);
             } else if (isElementDecl(node)) {
-                XmlElementDecl decl = (XmlElementDecl)
-                    XmlElementDecl.create(context, node);
+                XmlElementDecl decl = XmlElementDecl.create(context, node);
                 elements.op_aset(context, decl.element_name(context), decl);
                 decls.add(decl);
             } else if (isEntityDecl(node)) {
-                XmlEntityDecl decl = (XmlEntityDecl)
-                    XmlEntityDecl.create(context, node);
+                XmlEntityDecl decl = XmlEntityDecl.create(context, node);
                 entities.op_aset(context, decl.node_name(context), decl);
                 decls.add(decl);
             } else if (isNotationDecl(node)) {

--- a/ext/java/nokogiri/XmlElement.java
+++ b/ext/java/nokogiri/XmlElement.java
@@ -62,19 +62,7 @@ public class XmlElement extends XmlNode {
     @Override
     public void accept(ThreadContext context, SaveContextVisitor visitor) {
         visitor.enter((Element) node);
-        XmlNodeSet xmlNodeSet = (XmlNodeSet) children(context);
-        if (xmlNodeSet.length() > 0) {
-            IRubyObject[] nodes = XmlNodeSet.getNodes(context, xmlNodeSet);
-            for( int i = 0; i < nodes.length; i++ ) {
-                Object item = nodes[i];
-                if (item instanceof XmlNode) {
-                    ((XmlNode) item).accept(context, visitor);
-                }
-                else if (item instanceof XmlNamespace) {
-                    ((XmlNamespace) item).accept(context, visitor);
-                }
-            }
-        }
+        acceptChildren(context, getChildren(), visitor);
         visitor.leave((Element) node);
     }
 }

--- a/ext/java/nokogiri/XmlElement.java
+++ b/ext/java/nokogiri/XmlElement.java
@@ -60,13 +60,6 @@ public class XmlElement extends XmlNode {
     }
     
     @Override
-    public void setNode(ThreadContext context, Node node) {
-      super.setNode(context, node);
-      if (doc != null)
-        setInstanceVariable("@document", doc);
-    }
-    
-    @Override
     public void accept(ThreadContext context, SaveContextVisitor visitor) {
         visitor.enter((Element) node);
         XmlNodeSet xmlNodeSet = (XmlNodeSet) children(context);

--- a/ext/java/nokogiri/XmlElementDecl.java
+++ b/ext/java/nokogiri/XmlElementDecl.java
@@ -56,32 +56,31 @@ public class XmlElementDecl extends XmlNode {
     RubyArray attrDecls;
     IRubyObject contentModel;
     
-    public XmlElementDecl(Ruby ruby, RubyClass klazz) {
-        super(ruby, klazz);
-    }
-    
-    public void setNode(ThreadContext context, Node node) {
-        super.setNode(context, node);
-        attrDecls = RubyArray.newArray(context.getRuntime());
-        contentModel = context.getRuntime().getNil();
+    public XmlElementDecl(Ruby runtime, RubyClass klazz) {
+        super(runtime, klazz);
+        attrDecls = RubyArray.newArray(runtime);
+        contentModel = runtime.getNil();
     }
 
     /**
-     * Initialize based on an elementDecl node from a NekoDTD parsed
-     * DTD.
+     * Initialize based on an elementDecl node from a NekoDTD parsed DTD.
      */
     public XmlElementDecl(Ruby ruby, RubyClass klass, Node elemDeclNode) {
         super(ruby, klass, elemDeclNode);
-        attrDecls = RubyArray.newArray(ruby);
-        contentModel = ruby.getNil();
     }
 
-    public static IRubyObject create(ThreadContext context, Node elemDeclNode) {
-        XmlElementDecl self =
-            new XmlElementDecl(context.getRuntime(),
-                               getNokogiriClass(context.getRuntime(), "Nokogiri::XML::ElementDecl"),
-                               elemDeclNode);
-        return self;
+    @Override // gets called from constructor ^^^
+    public void setNode(ThreadContext context, Node node) {
+        super.setNode(context, node);
+        attrDecls = RubyArray.newArray(context.runtime);
+        contentModel = context.nil;
+    }
+
+    static XmlElementDecl create(ThreadContext context, Node elemDeclNode) {
+        return new XmlElementDecl(context.runtime,
+            getNokogiriClass(context.runtime, "Nokogiri::XML::ElementDecl"),
+            elemDeclNode
+        );
     }
 
     public IRubyObject element_name(ThreadContext context) {
@@ -105,10 +104,8 @@ public class XmlElementDecl extends XmlNode {
     @JRubyMethod
     public IRubyObject prefix(ThreadContext context) {
         String enamePrefix = getPrefix(getAttribute("ename"));
-        if (enamePrefix == null)
-            return context.getRuntime().getNil();
-        else
-            return context.getRuntime().newString(enamePrefix);
+        if (enamePrefix == null) return context.nil;
+        return context.runtime.newString(enamePrefix);
     }
 
     /**
@@ -118,14 +115,13 @@ public class XmlElementDecl extends XmlNode {
     @JRubyMethod
     public IRubyObject node_name(ThreadContext context) {
         String ename = getLocalPart(getAttribute("ename"));
-        return context.getRuntime().newString(ename);
+        return context.runtime.newString(ename);
     }
 
     @Override
     @JRubyMethod(name = "node_name=")
     public IRubyObject node_name_set(ThreadContext context, IRubyObject name) {
-        throw context.getRuntime()
-            .newRuntimeError("cannot change name of DTD decl");
+        throw context.runtime.newRuntimeError("cannot change name of DTD decl");
     }
 
     @Override
@@ -137,8 +133,7 @@ public class XmlElementDecl extends XmlNode {
     @Override
     @JRubyMethod
     public IRubyObject attribute(ThreadContext context, IRubyObject name) {
-        throw context.getRuntime()
-            .newRuntimeError("attribute by name not implemented");
+        throw context.runtime.newRuntimeError("attribute by name not implemented");
     }
 
     public void appendAttrDecl(XmlAttributeDecl decl) {
@@ -147,6 +142,6 @@ public class XmlElementDecl extends XmlNode {
 
     @JRubyMethod
     public IRubyObject element_type(ThreadContext context) {
-        return context.getRuntime().newFixnum(node.getNodeType());
+        return context.runtime.newFixnum(node.getNodeType());
     }
 }

--- a/ext/java/nokogiri/XmlElementDecl.java
+++ b/ext/java/nokogiri/XmlElementDecl.java
@@ -70,10 +70,10 @@ public class XmlElementDecl extends XmlNode {
     }
 
     @Override // gets called from constructor ^^^
-    public void setNode(ThreadContext context, Node node) {
-        super.setNode(context, node);
-        attrDecls = RubyArray.newArray(context.runtime);
-        contentModel = context.nil;
+    public void setNode(Ruby runtime, Node node) {
+        super.setNode(runtime, node);
+        attrDecls = RubyArray.newArray(runtime);
+        contentModel = runtime.getNil();
     }
 
     static XmlElementDecl create(ThreadContext context, Node elemDeclNode) {

--- a/ext/java/nokogiri/XmlEntityDecl.java
+++ b/ext/java/nokogiri/XmlEntityDecl.java
@@ -64,26 +64,25 @@ public class XmlEntityDecl extends XmlNode {
     private IRubyObject system_id;
     private IRubyObject content;
 
-    public XmlEntityDecl(Ruby ruby, RubyClass klass) {
-        super(ruby, klass);
-        throw ruby.newRuntimeError("node required");
+    XmlEntityDecl(Ruby runtime, RubyClass klass) {
+        super(runtime, klass);
     }
 
     /**
-     * Initialize based on an entityDecl node from a NekoDTD parsed
-     * DTD.
+     * Initialize based on an entityDecl node from a NekoDTD parsed DTD.
      */
-    public XmlEntityDecl(Ruby ruby, RubyClass klass, Node entDeclNode) {
-        super(ruby, klass, entDeclNode);
-        entityType = RubyFixnum.newFixnum(ruby, XmlEntityDecl.INTERNAL_GENERAL);
-        name = external_id = system_id = content = ruby.getNil();       
+    public XmlEntityDecl(Ruby runtime, RubyClass klass, Node entDeclNode) {
+        super(runtime, klass, entDeclNode);
+        entityType = RubyFixnum.newFixnum(runtime, XmlEntityDecl.INTERNAL_GENERAL);
+        name = external_id = system_id = content = runtime.getNil();
     }
     
-    public XmlEntityDecl(Ruby ruby, RubyClass klass, Node entDeclNode, IRubyObject[] argv) {
-        super(ruby, klass, entDeclNode);
+    public XmlEntityDecl(Ruby runtime, RubyClass klass, Node entDeclNode, IRubyObject[] argv) {
+        super(runtime, klass, entDeclNode);
         name = argv[0];
-        entityType = RubyFixnum.newFixnum(ruby, XmlEntityDecl.INTERNAL_GENERAL);
-        external_id = system_id = content = ruby.getNil(); 
+        entityType = RubyFixnum.newFixnum(runtime, XmlEntityDecl.INTERNAL_GENERAL);
+        external_id = system_id = content = runtime.getNil();
+
         if (argv.length > 1) entityType = argv[1];
         if (argv.length > 4) {
             external_id = argv[2];
@@ -92,21 +91,19 @@ public class XmlEntityDecl extends XmlNode {
         }
     }
 
-    public static IRubyObject create(ThreadContext context, Node entDeclNode) {
-        XmlEntityDecl self =
-            new XmlEntityDecl(context.getRuntime(),
-                              getNokogiriClass(context.getRuntime(), "Nokogiri::XML::EntityDecl"),
-                              entDeclNode);
-        return self;
+    static XmlEntityDecl create(ThreadContext context, Node entDeclNode) {
+        return new XmlEntityDecl(context.runtime,
+            getNokogiriClass(context.runtime, "Nokogiri::XML::EntityDecl"),
+            entDeclNode
+        );
     }
     
     // when entity is created by create_entity method
-    public static IRubyObject create(ThreadContext context, Node entDeclNode, IRubyObject[] argv) {
-        XmlEntityDecl self =
-            new XmlEntityDecl(context.getRuntime(),
-                              getNokogiriClass(context.getRuntime(), "Nokogiri::XML::EntityDecl"),
-                              entDeclNode, argv);
-        return self;
+    static XmlEntityDecl create(ThreadContext context, Node entDeclNode, IRubyObject... argv) {
+        return new XmlEntityDecl(context.runtime,
+            getNokogiriClass(context.runtime, "Nokogiri::XML::EntityDecl"),
+            entDeclNode, argv
+        );
     }
 
     /**
@@ -123,8 +120,7 @@ public class XmlEntityDecl extends XmlNode {
     @Override
     @JRubyMethod(name = "node_name=")
     public IRubyObject node_name_set(ThreadContext context, IRubyObject name) {
-        throw context.getRuntime()
-            .newRuntimeError("cannot change name of DTD decl");
+        throw context.runtime.newRuntimeError("cannot change name of DTD decl");
     }
 
     @JRubyMethod

--- a/ext/java/nokogiri/XmlEntityReference.java
+++ b/ext/java/nokogiri/XmlEntityReference.java
@@ -65,7 +65,7 @@ public class XmlEntityReference extends XmlNode {
 
     protected void init(ThreadContext context, IRubyObject[] args) {
         if (args.length < 2) {
-            throw getRuntime().newArgumentError(args.length, 2);
+            throw context.runtime.newArgumentError(args.length, 2);
         }
 
         IRubyObject doc = args[0];
@@ -78,7 +78,7 @@ public class XmlEntityReference extends XmlNode {
         internalDocument.setErrorChecking(false);
         Node node = document.createEntityReference(rubyStringToString(name));
         internalDocument.setErrorChecking(oldErrorChecking);
-        setNode(context, node);
+        setNode(context.runtime, node);
     }
     
     @Override

--- a/ext/java/nokogiri/XmlNamespace.java
+++ b/ext/java/nokogiri/XmlNamespace.java
@@ -32,7 +32,6 @@
 
 package nokogiri;
 
-import static nokogiri.internals.NokogiriHelpers.CACHED_NODE;
 import static nokogiri.internals.NokogiriHelpers.getCachedNodeOrCreate;
 import static nokogiri.internals.NokogiriHelpers.getLocalNameForNamespace;
 import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
@@ -61,8 +60,8 @@ import org.w3c.dom.Node;
 @JRubyClass(name="Nokogiri::XML::Namespace")
 public class XmlNamespace extends RubyObject {
     private Attr attr;
-    private IRubyObject prefix;
-    private IRubyObject href;
+    IRubyObject prefix;
+    IRubyObject href;
     private String prefixString;
     private String hrefString;
 

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -661,10 +661,8 @@ public class XmlNode extends RubyObject {
     public IRubyObject attribute(ThreadContext context, IRubyObject name){
         NamedNodeMap attrs = this.node.getAttributes();
         Node attr = attrs.getNamedItem(rubyStringToString(name));
-        if(attr == null) {
-            return  context.getRuntime().getNil();
-        }
-        return getCachedNodeOrCreate(context.getRuntime(), attr);
+        if (attr == null) return context.nil;
+        return getCachedNodeOrCreate(context.runtime, attr);
     }
 
     @JRubyMethod
@@ -691,10 +689,9 @@ public class XmlNode extends RubyObject {
 
         Node el = this.node.getAttributes().getNamedItemNS(nsj, namej);
 
-        if(el == null) {
-            return context.getRuntime().getNil();
-        }
-        return NokogiriHelpers.getCachedNodeOrCreate(context.getRuntime(), el);
+        if (el == null) return context.nil;
+
+        return NokogiriHelpers.getCachedNodeOrCreate(context.runtime, el);
     }
 
     @JRubyMethod(name = "blank?")

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1143,16 +1143,11 @@ public class XmlNode extends RubyObject {
         // namespaces might be deleted. Reflecting the result of
         // namespace removals is complicated, so the cache might not be
         // updated.
-        Ruby ruby = context.runtime;
-        RubyArray namespace_definitions = ruby.newArray();
-        if (doc == null) return namespace_definitions;
-        if (doc instanceof HtmlDocument) return namespace_definitions;
-        List<XmlNamespace> namespaces = ((XmlDocument) doc).getNamespaceCache().get(node);
-        for (XmlNamespace namespace : namespaces) {
-            namespace_definitions.append(namespace);
-        }
+        if (doc == null) return context.runtime.newEmptyArray();
+        if (doc instanceof HtmlDocument) return context.runtime.newEmptyArray();
 
-        return namespace_definitions;
+        List<XmlNamespace> namespaces = ((XmlDocument) doc).getNamespaceCache().get(node);
+        return context.runtime.newArray((List) namespaces);
     }
 
     /**

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -350,53 +350,6 @@ public class XmlNode extends RubyObject {
         return node;
     }
 
-    public static Node getNodeFromXmlNode(ThreadContext context, IRubyObject xmlNode) {
-        return asXmlNode(context, xmlNode).node;
-    }
-
-    protected String indentString(IRubyObject indentStringObject, String xml) {
-        String[] lines = xml.split("\n");
-
-        if(lines.length <= 1) return xml;
-
-        String[] resultLines  = new String[lines.length];
-
-        String curLine;
-        boolean closingTag = false;
-        String indentString = rubyStringToString(indentStringObject);
-        int lengthInd = indentString.length();
-        StringBuilder curInd = new StringBuilder();
-
-        resultLines[0] = lines[0];
-
-        for(int i = 1; i < lines.length; i++) {
-
-            curLine = lines[i].trim();
-
-            if(curLine.length() == 0) continue;
-
-            if(curLine.startsWith("</")) {
-                closingTag = true;
-                curInd.setLength(max(0,curInd.length() - lengthInd));
-            }
-
-            resultLines[i] = curInd.toString() + curLine;
-
-            if(!curLine.endsWith("/>") && !closingTag) {
-                curInd.append(indentString);
-            }
-
-            closingTag = false;
-        }
-
-        StringBuilder result = new StringBuilder();
-        for(int i = 0; i < resultLines.length; i++) {
-            result.append(resultLines[i]).append('\n');
-        }
-
-        return result.toString();
-    }
-
     public boolean isComment() { return false; }
 
     public boolean isElement() {

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -994,8 +994,7 @@ public class XmlNode extends RubyObject {
      * Instance method version of the above static method.
      */
     @JRubyMethod(name="encode_special_chars")
-    public IRubyObject i_encode_special_chars(ThreadContext context,
-                                              IRubyObject string) {
+    public IRubyObject i_encode_special_chars(ThreadContext context, IRubyObject string) {
         return encode_special_chars(context, string);
     }
 
@@ -1007,14 +1006,14 @@ public class XmlNode extends RubyObject {
     @JRubyMethod(visibility = Visibility.PRIVATE)
     public IRubyObject get(ThreadContext context, IRubyObject rbkey) {
         if (node instanceof Element) {
-            if (rbkey == null || rbkey.isNil()) context.getRuntime().getNil();
+            if (rbkey == null || rbkey.isNil()) return context.nil;
             String key = rubyStringToString(rbkey);
             Element element = (Element) node;
-            if (!element.hasAttribute(key)) return context.getRuntime().getNil();
+            if (!element.hasAttribute(key)) return context.nil;
             String value = element.getAttribute(key);
-            return stringOrNil(context.getRuntime(), value);
+            return stringOrNil(context.runtime, value);
         }
-        return context.getRuntime().getNil();
+        return context.nil;
     }
 
     /**
@@ -1277,7 +1276,7 @@ public class XmlNode extends RubyObject {
         IRubyObject indentString = args[2];
         IRubyObject options = args[3];
 
-        String encString = encoding.isNil() ? null : rubyStringToString(encoding);
+        String encString = rubyStringToString(encoding);
 
         SaveContextVisitor visitor =
             new SaveContextVisitor(RubyFixnum.fix2int(options), rubyStringToString(indentString), encString, isHtmlDoc(context), isFragment(), 0);
@@ -1419,8 +1418,8 @@ public class XmlNode extends RubyObject {
             }
         } else {
             XmlNamespace ns = (XmlNamespace) namespace;
-            String prefix = rubyStringToString(ns.prefix(context));
-            String href = rubyStringToString(ns.href(context));
+            String prefix = rubyStringToString(ns.prefix);
+            String href = rubyStringToString(ns.href);
 
             // Assigning node = ...renameNode() or not seems to make no
             // difference.  Why not? -pmahoney

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1348,23 +1348,17 @@ public class XmlNode extends RubyObject {
     }
 
     private String findNamespaceHref(ThreadContext context, String prefix) {
-      XmlNode currentNode = this;
-      while(currentNode != document(context)) {
-        RubyArray namespaces = (RubyArray) currentNode.namespace_scopes(context);
-        Iterator iterator = namespaces.iterator();
-        while(iterator.hasNext()) {
-          XmlNamespace namespace = (XmlNamespace) iterator.next();
-          if (namespace.getPrefix().equals(prefix)) {
-            return namespace.getHref();
-          }
-        }
-        if (currentNode.parent(context).isNil()) {
-            break;
-        } else {
+        XmlNode currentNode = this;
+        while (currentNode != document(context)) {
+            RubyArray namespaces = currentNode.namespace_scopes(context);
+            for (int i = 0; i<namespaces.size(); i++) {
+                XmlNamespace namespace = (XmlNamespace) namespaces.eltInternal(i);
+                if (namespace.getPrefix().equals(prefix)) return namespace.getHref();
+            }
+            if (currentNode.parent(context) == context.nil) break;
             currentNode = (XmlNode) currentNode.parent(context);
         }
-      }
-      return null;
+        return null;
     }
 
     @JRubyMethod

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -666,39 +666,41 @@ public class XmlNode extends RubyObject {
 
     @JRubyMethod
     public IRubyObject first_element_child(ThreadContext context) {
-        List<Node> elementNodes = new ArrayList<Node>();
-        addElements(node, elementNodes, true);
-        if (elementNodes.size() == 0) return context.getRuntime().getNil();
-        return getCachedNodeOrCreate(context.getRuntime(), elementNodes.get(0));
+        List<Node> elementNodes = getElements(node, true);
+        if (elementNodes.size() == 0) return context.nil;
+        return getCachedNodeOrCreate(context.runtime, elementNodes.get(0));
     }
 
     @JRubyMethod
     public IRubyObject last_element_child(ThreadContext context) {
-        List<Node> elementNodes = new ArrayList<Node>();
-        addElements(node, elementNodes, false);
-        if (elementNodes.size() == 0) return context.getRuntime().getNil();
-        return getCachedNodeOrCreate(context.getRuntime(), elementNodes.get(elementNodes.size()-1));
+        List<Node> elementNodes = getElements(node, false);
+        if (elementNodes.size() == 0) return context.nil;
+        return getCachedNodeOrCreate(context.runtime, elementNodes.get(elementNodes.size() - 1));
     }
 
     @JRubyMethod(name = {"element_children", "elements"})
     public IRubyObject element_children(ThreadContext context) {
-        List<Node> elementNodes = new ArrayList<Node>();
-        addElements(node, elementNodes, false);
-        IRubyObject[] array = NokogiriHelpers.nodeArrayToArray(context.runtime,
-                                                               elementNodes.toArray(new Node[0]));
+        List<Node> elementNodes = getElements(node, false);
+        IRubyObject[] array = NokogiriHelpers.nodeListToArray(context.runtime, elementNodes);
         return XmlNodeSet.newNodeSet(context.runtime, array, this);
     }
 
-    private void addElements(Node n, List<Node> nodes, boolean isFirstOnly) {
-        NodeList children = n.getChildNodes();
-        if (children.getLength() == 0) return;
+    private static List<Node> getElements(Node node, final boolean firstOnly) {
+        NodeList children = node.getChildNodes();
+        if (children.getLength() == 0) {
+            return Collections.emptyList();
+        }
+        ArrayList<Node> elements = firstOnly ? null : new ArrayList<Node>(children.getLength());
         for (int i=0; i< children.getLength(); i++) {
             Node child = children.item(i);
             if (child.getNodeType() == Node.ELEMENT_NODE) {
-                nodes.add(child);
-                if (isFirstOnly) return;
+                if (firstOnly) {
+                    return Collections.singletonList(child);
+                }
+                elements.add(child);
             }
         }
+        return elements;
     }
 
     /**

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -616,15 +616,13 @@ public class XmlNode extends RubyObject {
      * <code>xmlns:prefix="uri"</code>.
      */
     @JRubyMethod(name = {"add_namespace_definition", "add_namespace"})
-    public IRubyObject add_namespace_definition(ThreadContext context,
-                                                IRubyObject prefix,
-                                                IRubyObject href) {
+    public IRubyObject add_namespace_definition(ThreadContext context, IRubyObject prefix, IRubyObject href) {
         String prefixString = rubyStringToString(prefix);
         String hrefString ;
 
         // try to search the namespace first
         if (href.isNil()) {
-            hrefString = this.findNamespaceHref(context, rubyStringToString(prefix));
+            hrefString = this.findNamespaceHref(context, prefixString);
             if (hrefString == null) return context.nil;
             href = context.runtime.newString(hrefString);
         } else {
@@ -673,16 +671,13 @@ public class XmlNode extends RubyObject {
     public IRubyObject attribute_nodes(ThreadContext context) {
         NamedNodeMap nodeMap = this.node.getAttributes();
 
-        Ruby ruby = context.getRuntime();
-        if(nodeMap == null){
-            return ruby.newEmptyArray();
-        }
+        if (nodeMap == null) return context.runtime.newEmptyArray();
 
-        RubyArray attr = ruby.newArray();
+        RubyArray attr = context.runtime.newArray();
 
-        for(int i = 0; i < nodeMap.getLength(); i++) {
+        for (int i = 0; i < nodeMap.getLength(); i++) {
             if ((doc instanceof HtmlDocument) || !NokogiriHelpers.isNamespace(nodeMap.item(i))) {
-                attr.append(getCachedNodeOrCreate(context.getRuntime(), nodeMap.item(i)));
+                attr.append(getCachedNodeOrCreate(context.runtime, nodeMap.item(i)));
             }
         }
 

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1681,4 +1681,14 @@ public class XmlNode extends RubyObject {
         clearXpathContext(getNode());
         return context.nil ;
     }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object toJava(final Class target) {
+        if (target == Object.class || Node.class.isAssignableFrom(target)) {
+            return getNode();
+        }
+        return super.toJava(target);
+    }
+
 }

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -101,7 +101,7 @@ public class XmlNode extends RubyObject {
     /* Cached objects */
     protected IRubyObject content = null;
     protected IRubyObject doc = null;
-    protected IRubyObject name = null;
+    protected transient RubyString name;
 
     /*
      * Taken from http://ejohn.org/blog/comparing-document-position/
@@ -554,8 +554,9 @@ public class XmlNode extends RubyObject {
         visitor.leave(node);
     }
 
-    public void setName(IRubyObject name) {
-        this.name = name;
+    RubyString doSetName(IRubyObject name) {
+        if (name.isNil()) return this.name = null;
+        return this.name = name.convertToString();
     }
 
     public void setDocument(ThreadContext context, IRubyObject doc) {
@@ -1304,9 +1305,9 @@ public class XmlNode extends RubyObject {
 
     @JRubyMethod(name = {"node_name=", "name="})
     public IRubyObject node_name_set(ThreadContext context, IRubyObject nodeName) {
-        String newName = rubyStringToString(nodeName);
+        nodeName = doSetName(nodeName);
+        String newName = nodeName == null ? null : rubyStringToString((RubyString) nodeName);
         this.node = NokogiriHelpers.renameNode(node, null, newName);
-        setName(nodeName);
         return this;
     }
 

--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -126,7 +126,7 @@ public class XmlNodeSet extends RubyObject implements NodeList {
     }
 
     public int length() {
-      return nodes == null ? 0 : nodes.length;
+        return nodes == null ? 0 : nodes.length;
     }
 
     public void relink_namespace(ThreadContext context) {
@@ -221,7 +221,7 @@ outer:
           }
         }
 
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = {"length", "size"})
@@ -405,13 +405,6 @@ outer:
         return this;
     }
 
-    private static XmlNodeSet newXmlNodeSet(ThreadContext context, XmlNodeSet reference) {
-        XmlNodeSet xmlNodeSet = create(context.getRuntime());
-        xmlNodeSet.setReference(reference);
-        xmlNodeSet.nodes = new IRubyObject[0];
-        return xmlNodeSet;
-    }
-
     private static IRubyObject asXmlNodeOrNamespace(ThreadContext context, IRubyObject possibleNode) {
         if (possibleNode instanceof XmlNode || possibleNode instanceof XmlNamespace) {
             return possibleNode;
@@ -432,8 +425,8 @@ outer:
 
     public Node item(int index) {
         Object n = nodes[index];
-        if (n instanceof XmlNode) return ((XmlNode)n).node;
-        if (n instanceof XmlNamespace) return ((XmlNamespace)n).getNode();
+        if (n instanceof XmlNode) return ((XmlNode) n).node;
+        if (n instanceof XmlNamespace) return ((XmlNamespace) n).getNode();
         return null;
     }
 }

--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -120,7 +120,7 @@ public class XmlNodeSet extends RubyObject implements NodeList {
 
     final void initialize(Ruby runtime, IRubyObject refNode) {
         if (refNode instanceof XmlNode) {
-            IRubyObject doc = ((XmlNode) refNode).document(runtime);
+            XmlDocument doc = ((XmlNode) refNode).document(runtime);
             setDocumentAndDecorate(runtime.getCurrentContext(), this, doc);
         }
     }

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -168,11 +168,11 @@ public class XmlSchema extends RubyObject {
 
     @JRubyMethod(visibility=Visibility.PRIVATE)
     public IRubyObject validate_file(ThreadContext context, IRubyObject file) {
-        Ruby ruby = context.getRuntime();
+        Ruby runtime = context.runtime;
 
-        XmlDomParserContext ctx = new XmlDomParserContext(ruby, RubyFixnum.newFixnum(ruby, 1L));
+        XmlDomParserContext ctx = new XmlDomParserContext(runtime, RubyFixnum.newFixnum(runtime, 1L));
         ctx.setInputSourceFile(context, file);
-        XmlDocument xmlDocument = ctx.parse(context, getNokogiriClass(ruby, "Nokogiri::XML::Document"), ruby.getNil());
+        XmlDocument xmlDocument = ctx.parse(context, getNokogiriClass(runtime, "Nokogiri::XML::Document"), context.nil);
         return validate_document_or_file(context, xmlDocument);
     }
 

--- a/ext/java/nokogiri/XmlText.java
+++ b/ext/java/nokogiri/XmlText.java
@@ -36,11 +36,14 @@ import static nokogiri.internals.NokogiriHelpers.getCachedNodeOrCreate;
 import static nokogiri.internals.NokogiriHelpers.rubyStringToString;
 import nokogiri.internals.SaveContextVisitor;
 
+import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.Text;
@@ -53,6 +56,9 @@ import org.w3c.dom.Text;
  */
 @JRubyClass(name="Nokogiri::XML::Text", parent="Nokogiri::XML::CharacterData")
 public class XmlText extends XmlNode {
+
+    private static final ByteList TEXT = ByteList.create("text");
+    static { TEXT.setEncoding(USASCIIEncoding.INSTANCE); }
 
     public XmlText(Ruby runtime, RubyClass rubyClass, Node node) {
         super(runtime, rubyClass, node);
@@ -83,7 +89,7 @@ public class XmlText extends XmlNode {
     
     @Override
     protected IRubyObject getNodeName(ThreadContext context) {
-        if (name == null) name = context.getRuntime().newString("text");
+        if (name == null) name = RubyString.newStringShared(context.runtime, TEXT);
         return name;
     }
 

--- a/ext/java/nokogiri/XmlText.java
+++ b/ext/java/nokogiri/XmlText.java
@@ -71,20 +71,17 @@ public class XmlText extends XmlNode {
     @Override
     protected void init(ThreadContext context, IRubyObject[] args) {
         if (args.length < 2) {
-            throw getRuntime().newArgumentError(args.length, 2);
+            throw context.runtime.newArgumentError(args.length, 2);
         }
 
         content = args[0];
         IRubyObject xNode = args[1];
 
-        XmlNode xmlNode = asXmlNode(context, xNode);
-        XmlDocument xmlDoc = (XmlDocument)xmlNode.document(context);
-        doc = xmlDoc;
-        Document document = xmlDoc.getDocument();
+        Document document = asXmlNode(context, xNode).getOwnerDocument();
         // text node content should not be encoded when it is created by Text node.
         // while content should be encoded when it is created by Element node.
         Node node = document.createTextNode(rubyStringToString(content));
-        setNode(context, node);
+        setNode(context.runtime, node);
     }
     
     @Override

--- a/ext/java/nokogiri/XmlText.java
+++ b/ext/java/nokogiri/XmlText.java
@@ -89,10 +89,10 @@ public class XmlText extends XmlNode {
 
     @Override
     public void accept(ThreadContext context, SaveContextVisitor visitor) {
-        visitor.enter((Text)node);
+        visitor.enter((Text) node);
         Node child = node.getFirstChild();
         while (child != null) {
-            IRubyObject nokoNode = getCachedNodeOrCreate(context.getRuntime(), child);
+            IRubyObject nokoNode = getCachedNodeOrCreate(context.runtime, child);
             if (nokoNode instanceof XmlNode) {
                 XmlNode cur = (XmlNode) nokoNode;
                 cur.accept(context, visitor);

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -57,6 +57,8 @@ import nokogiri.internals.NokogiriNamespaceContext;
 import nokogiri.internals.NokogiriXPathFunctionResolver;
 import nokogiri.internals.NokogiriXPathVariableResolver;
 
+import static nokogiri.internals.NokogiriHelpers.nodeListToRubyArray;
+
 /**
  * Class for Nokogiri::XML::XpathContext
  *
@@ -181,14 +183,12 @@ public class XmlXpathContext extends RubyObject {
             xobj = xpathInternal.execute(getXPathContext(fnResolver), contextNode, prefixResolver);
 
         switch (xobj.getType()) {
-            case XObject.CLASS_BOOLEAN : return context.getRuntime().newBoolean(xobj.bool());
-            case XObject.CLASS_NUMBER :  return context.getRuntime().newFloat(xobj.num());
+            case XObject.CLASS_BOOLEAN : return context.runtime.newBoolean(xobj.bool());
+            case XObject.CLASS_NUMBER :  return context.runtime.newFloat(xobj.num());
             case XObject.CLASS_NODESET :
-                XmlNodeSet xmlNodeSet = XmlNodeSet.newEmptyNodeSet(context);
-                xmlNodeSet.setNodeList(xobj.nodelist());
-                xmlNodeSet.initialize(context.getRuntime(), this.context);
-                return xmlNodeSet;
-            default : return context.getRuntime().newString(xobj.str());
+                IRubyObject[] nodes = nodeListToRubyArray(context.runtime, xobj.nodelist());
+                return XmlNodeSet.newNodeSet(context.runtime, nodes, this.context);
+            default : return context.runtime.newString(xobj.str());
         }
     }
 

--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -130,12 +130,11 @@ public class XsltStylesheet extends RubyObject {
         }
     }
     
-    private Pattern p = Pattern.compile("'.{1,}'");
+    private static final Pattern QUOTED = Pattern.compile("'.{1,}'");
 
     private String unparseValue(String orig) {
-        Matcher m = p.matcher(orig);
-        if ((orig.startsWith("\"") && orig.endsWith("\"")) || m.matches()) {
-            orig = orig.substring(1, orig.length()-1);
+        if ((orig.startsWith("\"") && orig.endsWith("\"")) || QUOTED.matcher(orig).matches()) {
+            orig = orig.substring(1, orig.length() - 1);
         }
 
         return orig;

--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -173,11 +173,8 @@ public class XsltStylesheet extends RubyObject {
     }
     
     private static void ensureFirstArgIsDocument(Ruby runtime, IRubyObject arg) {
-        if (arg instanceof XmlDocument) {
-            return;
-        } else {
-            throw runtime.newArgumentError("doc must be a Nokogiri::XML::Document instance");
-        }
+        if (arg instanceof XmlDocument) return;
+        throw runtime.newArgumentError("doc must be a Nokogiri::XML::Document instance");
     }
     
     private static void ensureDocumentHasNoError(ThreadContext context, XmlDocument xmlDoc) {

--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -289,13 +289,9 @@ public class XsltStylesheet extends RubyObject {
     
     private IRubyObject createDocumentFromDomResult(ThreadContext context, Ruby runtime, DOMResult domResult) {
         if ("html".equals(domResult.getNode().getFirstChild().getNodeName())) {
-            HtmlDocument htmlDocument = (HtmlDocument) getNokogiriClass(runtime, "Nokogiri::HTML::Document").allocate();
-            htmlDocument.setDocumentNode(context, (Document) domResult.getNode());
-            return htmlDocument;
+            return new HtmlDocument(context.runtime, (Document) domResult.getNode());
         } else {
-            XmlDocument xmlDocument = (XmlDocument) NokogiriService.XML_DOCUMENT_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::Document"));
-            xmlDocument.setDocumentNode(context, (Document) domResult.getNode());
-            return xmlDocument;
+            return new XmlDocument(context.runtime, (Document) domResult.getNode());
         }
     }
     

--- a/ext/java/nokogiri/internals/HtmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/HtmlDomParserContext.java
@@ -118,15 +118,9 @@ public class HtmlDomParserContext extends XmlDomParserContext {
     }
 
     @Override
-    protected XmlDocument getNewEmptyDocument(ThreadContext context) {
-        IRubyObject[] args = IRubyObject.NULL_ARRAY;
-        return (XmlDocument) XmlDocument.rbNew(context, getNokogiriClass(context.getRuntime(), "Nokogiri::HTML::Document"), args);
-    }
-
-    @Override
-    protected XmlDocument wrapDocument(ThreadContext context, RubyClass klazz, Document document) {
-        HtmlDocument htmlDocument = (HtmlDocument) NokogiriService.HTML_DOCUMENT_ALLOCATOR.allocate(context.getRuntime(), klazz);
-        htmlDocument.setDocumentNode(context, document);
+    protected XmlDocument wrapDocument(ThreadContext context, RubyClass klass, Document document) {
+        HtmlDocument htmlDocument = new HtmlDocument(context.runtime, klass, document);
+        htmlDocument.setDocumentNode(context.runtime, document);
         if (ruby_encoding.isNil()) {
             // ruby_encoding might have detected by HtmlDocument::EncodingReader
             if (detected_encoding != null && !detected_encoding.isNil()) {

--- a/ext/java/nokogiri/internals/HtmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/HtmlDomParserContext.java
@@ -128,7 +128,7 @@ public class HtmlDomParserContext extends XmlDomParserContext {
             } else {
                 // no encoding given & no encoding detected, then try to get it
                 String charset = tryGetCharsetFromHtml5MetaTag(document);
-                ruby_encoding = stringOrNil(context.getRuntime(), charset);
+                ruby_encoding = stringOrNil(context.runtime, charset);
             }
         }
         htmlDocument.setEncoding(ruby_encoding);

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -111,9 +111,9 @@ public class NokogiriHelpers {
     public static IRubyObject getCachedNodeOrCreate(Ruby runtime, Node node) {
         if (node == null) return runtime.getNil();
         if (node.getNodeType() == Node.ATTRIBUTE_NODE && isNamespace(node.getNodeName())) {
-            XmlDocument xmlDocument = (XmlDocument)node.getOwnerDocument().getUserData(CACHED_NODE);
+            XmlDocument xmlDocument = (XmlDocument) node.getOwnerDocument().getUserData(CACHED_NODE);
             if (!(xmlDocument instanceof HtmlDocument)) {
-                String prefix = getLocalNameForNamespace(((Attr) node).getName(), "");
+                String prefix = getLocalNameForNamespace(((Attr) node).getName(), null);
                 String href = ((Attr) node).getValue();
                 XmlNamespace xmlNamespace = xmlDocument.getNamespaceCache().get(prefix, href);
                 if (xmlNamespace != null) return xmlNamespace;
@@ -121,7 +121,7 @@ public class NokogiriHelpers {
             }
         }
         XmlNode xmlNode = getCachedNode(node);
-        if(xmlNode == null) {
+        if (xmlNode == null) {
             xmlNode = (XmlNode) constructNode(runtime, node);
             node.setUserData(CACHED_NODE, xmlNode, null);
         }

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -108,22 +108,21 @@ public class NokogiriHelpers {
      * or XmlNamespace wrapping <code>node</code> if there is no cached
      * value.
      */
-    public static IRubyObject getCachedNodeOrCreate(Ruby ruby, Node node) {
-        if(node == null) return ruby.getNil();
+    public static IRubyObject getCachedNodeOrCreate(Ruby runtime, Node node) {
+        if (node == null) return runtime.getNil();
         if (node.getNodeType() == Node.ATTRIBUTE_NODE && isNamespace(node.getNodeName())) {
             XmlDocument xmlDocument = (XmlDocument)node.getOwnerDocument().getUserData(CACHED_NODE);
             if (!(xmlDocument instanceof HtmlDocument)) {
-                String prefix = getLocalNameForNamespace(((Attr)node).getName());
-                prefix = prefix != null ? prefix : "";
-                String href = ((Attr)node).getValue();
+                String prefix = getLocalNameForNamespace(((Attr) node).getName(), "");
+                String href = ((Attr) node).getValue();
                 XmlNamespace xmlNamespace = xmlDocument.getNamespaceCache().get(prefix, href);
                 if (xmlNamespace != null) return xmlNamespace;
-                else return XmlNamespace.createFromAttr(ruby, (Attr)node);
+                return XmlNamespace.createFromAttr(runtime, (Attr) node);
             }
         }
         XmlNode xmlNode = getCachedNode(node);
         if(xmlNode == null) {
-            xmlNode = (XmlNode)constructNode(ruby, node);
+            xmlNode = (XmlNode) constructNode(runtime, node);
             node.setUserData(CACHED_NODE, xmlNode, null);
         }
         return xmlNode;
@@ -242,9 +241,9 @@ public class NokogiriHelpers {
         return pos > 0 ? qName.substring(pos + 1) : qName;
     }
 
-    public static String getLocalNameForNamespace(String name) {
+    public static String getLocalNameForNamespace(String name, String defValue) {
         String localName = getLocalPart(name);
-        return ("xmlns".equals(localName)) ? null : localName;
+        return ("xmlns".equals(localName)) ? defValue : localName;
     }
 
     public static String rubyStringToString(IRubyObject str) {

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -708,8 +708,9 @@ public class NokogiriHelpers {
 
         Class nkfClass;
         try {
-            nkfClass = runtime.getClassLoader().loadClass("org.jruby.RubyNKF");
-        } catch (ClassNotFoundException e2) {
+            // JRuby 1.7 and later
+            nkfClass = runtime.getClassLoader().loadClass("org.jruby.ext.nkf.RubyNKF");
+        } catch (ClassNotFoundException e1) {
             return str;
         }
         Method nkf_method;

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -267,7 +267,6 @@ public class NokogiriHelpers {
 
         Node cur, tmp, next;
 
-        // TODO: Rename buffer to path.
         String buffer = "";
 
         cur = node;
@@ -509,20 +508,6 @@ public class NokogiriHelpers {
 
     public static CharSequence decodeJavaString(CharSequence str) {
         return convert(encoded_pattern, str, encoded, decoded);
-    }
-
-    public static String getNodeName(Node node) {
-        if(node == null) { System.out.println("node is null"); return ""; }
-        String name = node.getNodeName();
-        if(name == null) { System.out.println("name is null"); return ""; }
-        if(name.equals("#document")) {
-            return "document";
-        } else if(name.equals("#text")) {
-            return "text";
-        } else {
-            name = getLocalPart(name);
-            return (name == null) ? "" : name;
-        }
     }
 
     public static final String XMLNS_URI = "http://www.w3.org/2000/xmlns/";

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -139,37 +139,37 @@ public class NokogiriHelpers {
         switch (node.getNodeType()) {
             case Node.ELEMENT_NODE:
                 XmlElement xmlElement = (XmlElement) NokogiriService.XML_ELEMENT_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::Element"));
-                xmlElement.setNode(runtime.getCurrentContext(), node);
+                xmlElement.setNode(runtime, node);
                 return xmlElement;
             case Node.ATTRIBUTE_NODE:
                 XmlAttr xmlAttr = (XmlAttr) NokogiriService.XML_ATTR_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::Attr"));
-                xmlAttr.setNode(runtime.getCurrentContext(), node);
+                xmlAttr.setNode(runtime, node);
                 return xmlAttr;
             case Node.TEXT_NODE:
                 XmlText xmlText = (XmlText) NokogiriService.XML_TEXT_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::Text"));
-                xmlText.setNode(runtime.getCurrentContext(), node);
+                xmlText.setNode(runtime, node);
                 return xmlText;
             case Node.COMMENT_NODE:
                 XmlComment xmlComment = (XmlComment) NokogiriService.XML_COMMENT_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::Comment"));
-                xmlComment.setNode(runtime.getCurrentContext(), node);
+                xmlComment.setNode(runtime, node);
                 return xmlComment;
             case Node.ENTITY_NODE:
                 return new XmlNode(runtime, getNokogiriClass(runtime, "Nokogiri::XML::EntityDecl"), node);
             case Node.ENTITY_REFERENCE_NODE:
                 XmlEntityReference xmlEntityRef = (XmlEntityReference) NokogiriService.XML_ENTITY_REFERENCE_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::EntityReference"));
-                xmlEntityRef.setNode(runtime.getCurrentContext(), node);
+                xmlEntityRef.setNode(runtime, node);
                 return xmlEntityRef;
             case Node.PROCESSING_INSTRUCTION_NODE:
                 XmlProcessingInstruction xmlProcessingInstruction = (XmlProcessingInstruction) NokogiriService.XML_PROCESSING_INSTRUCTION_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::ProcessingInstruction"));
-                xmlProcessingInstruction.setNode(runtime.getCurrentContext(), node);
+                xmlProcessingInstruction.setNode(runtime, node);
                 return xmlProcessingInstruction;
             case Node.CDATA_SECTION_NODE:
                 XmlCdata xmlCdata = (XmlCdata) NokogiriService.XML_CDATA_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::CDATA"));
-                xmlCdata.setNode(runtime.getCurrentContext(), node);
+                xmlCdata.setNode(runtime, node);
                 return xmlCdata;
             case Node.DOCUMENT_NODE:
                 XmlDocument xmlDocument = (XmlDocument) NokogiriService.XML_DOCUMENT_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::Document"));
-                xmlDocument.setDocumentNode(runtime.getCurrentContext(), node);
+                xmlDocument.setDocumentNode(runtime, (Document) node);
                 return xmlDocument;
             case Node.DOCUMENT_TYPE_NODE:
                 XmlDtd xmlDtd = (XmlDtd) NokogiriService.XML_DTD_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::DTD"));
@@ -177,7 +177,7 @@ public class NokogiriHelpers {
                 return xmlDtd;
             default:
                 XmlNode xmlNode = (XmlNode) NokogiriService.XML_NODE_ALLOCATOR.allocate(runtime, getNokogiriClass(runtime, "Nokogiri::XML::Node"));
-                xmlNode.setNode(runtime.getCurrentContext(), node);
+                xmlNode.setNode(runtime, node);
                 return xmlNode;
         }
     }

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -586,14 +586,14 @@ public class NokogiriHelpers {
     public static IRubyObject[] nodeListToRubyArray(Ruby ruby, NodeList nodes) {
         IRubyObject[] array = new IRubyObject[nodes.getLength()];
         for (int i = 0; i < nodes.getLength(); i++) {
-          array[i] = NokogiriHelpers.getCachedNodeOrCreate(ruby, nodes.item(i));
+            array[i] = NokogiriHelpers.getCachedNodeOrCreate(ruby, nodes.item(i));
         }
         return array;
     }
 
     public static IRubyObject[] nodeArrayToArray(Ruby ruby, Node[] nodes) {
         IRubyObject[] result = new IRubyObject[nodes.length];
-        for(int i = 0; i < nodes.length; i++) {
+        for (int i = 0; i < nodes.length; i++) {
             result[i] = NokogiriHelpers.getCachedNodeOrCreate(ruby, nodes[i]);
         }
         return result;
@@ -601,7 +601,7 @@ public class NokogiriHelpers {
 
     public static RubyArray nodeArrayToRubyArray(Ruby ruby, Node[] nodes) {
         RubyArray n = RubyArray.newArray(ruby, nodes.length);
-        for(int i = 0; i < nodes.length; i++) {
+        for (int i = 0; i < nodes.length; i++) {
             n.append(NokogiriHelpers.getCachedNodeOrCreate(ruby, nodes[i]));
         }
         return n;
@@ -609,7 +609,7 @@ public class NokogiriHelpers {
 
     public static RubyArray namedNodeMapToRubyArray(Ruby ruby, NamedNodeMap map) {
         RubyArray n = RubyArray.newArray(ruby, map.getLength());
-        for(int i = 0; i < map.getLength(); i++) {
+        for (int i = 0; i < map.getLength(); i++) {
             n.append(NokogiriHelpers.getCachedNodeOrCreate(ruby, map.item(i)));
         }
         return n;
@@ -745,17 +745,17 @@ public class NokogiriHelpers {
       return !shouldEncode(text);
     }
 
-    public static NokogiriNamespaceCache getNamespaceCacheFormNode(Node n) {
-        XmlDocument xmlDoc = (XmlDocument)getCachedNode(n.getOwnerDocument());
+    public static NokogiriNamespaceCache getNamespaceCache(Node node) {
+        XmlDocument xmlDoc = (XmlDocument) getCachedNode(node.getOwnerDocument());
         return xmlDoc.getNamespaceCache();
     }
 
-    public static Node renameNode(Node n, String namespaceURI, String qualifiedName) throws DOMException {
-        Document doc = n.getOwnerDocument();
-        NokogiriNamespaceCache nsCache = getNamespaceCacheFormNode(n);
-        Node result = doc.renameNode(n, namespaceURI, qualifiedName);
-        if (result != n) {
-            nsCache.replaceNode(n, result);
+    public static Node renameNode(Node node, String namespaceURI, String qualifiedName) throws DOMException {
+        Document doc = node.getOwnerDocument();
+        NokogiriNamespaceCache nsCache = getNamespaceCache(node);
+        Node result = doc.renameNode(node, namespaceURI, qualifiedName);
+        if (result != node) {
+            nsCache.replaceNode(node, result);
         }
         return result;
     }

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -81,7 +81,7 @@ import nokogiri.XmlXpathContext;
  */
 public class NokogiriHelpers {
     public static final String CACHED_NODE = "NOKOGIRI_CACHED_NODE";
-    public static final String VALID_ROOT_NODE = "NOKOGIRI_VALIDE_ROOT_NODE";
+    public static final String ROOT_NODE_INVALID = "NOKOGIRI_ROOT_NODE_INVALID";
     public static final String ENCODED_STRING = "NOKOGIRI_ENCODED_STRING";
 
     public static XmlNode getCachedNode(Node node) {

--- a/ext/java/nokogiri/internals/NokogiriNamespaceCache.java
+++ b/ext/java/nokogiri/internals/NokogiriNamespaceCache.java
@@ -129,7 +129,7 @@ public class NokogiriNamespaceCache {
         keys.add(key);
         CacheEntry entry = new CacheEntry(namespace, ownerNode);
         cache.put(key, entry);
-        if ("".equals(prefixString)) defaultNamespace = namespace;
+        if (prefixString.isEmpty()) defaultNamespace = namespace;
     }
 
     public void remove(String prefix, String href) {
@@ -145,7 +145,7 @@ public class NokogiriNamespaceCache {
             CacheEntry entry = cache.get(key);
             NamedNodeMap attributes = entry.ownerNode.getAttributes();
             for (int j=0; j<attributes.getLength(); j++) {
-                String name = ((Attr)attributes.item(j)).getName();
+                String name = ((Attr) attributes.item(j)).getName();
                 if (isNamespace(name)) {
                     attributes.removeNamedItem(name);
                 }

--- a/ext/java/nokogiri/internals/NokogiriXPathFunction.java
+++ b/ext/java/nokogiri/internals/NokogiriXPathFunction.java
@@ -53,6 +53,8 @@ import org.w3c.dom.NodeList;
 import nokogiri.XmlNode;
 import nokogiri.XmlNodeSet;
 
+import static nokogiri.internals.NokogiriHelpers.nodeListToRubyArray;
+
 /**
  * Xpath function handler.
  * 
@@ -99,9 +101,8 @@ public class NokogiriXPathFunction implements XPathFunction {
     private static IRubyObject fromObjectToRuby(final Ruby runtime, Object obj) {
         // argument object type is one of NodeList, String, Boolean, or Double.
         if (obj instanceof NodeList) {
-            XmlNodeSet xmlNodeSet = XmlNodeSet.newEmptyNodeSet(runtime.getCurrentContext());
-            xmlNodeSet.setNodeList((NodeList) obj);
-            return xmlNodeSet;
+            IRubyObject[] nodes = nodeListToRubyArray(runtime, (NodeList) obj);
+            return XmlNodeSet.newNodeSet(runtime, nodes);
         }
         return JavaUtil.convertJavaToUsableRubyObject(runtime, obj);
     }
@@ -116,7 +117,7 @@ public class NokogiriXPathFunction implements XPathFunction {
         }
         if (obj instanceof XmlNodeSet) return obj;
         if (obj instanceof RubyArray) {
-            return XmlNodeSet.newXmlNodeSet(runtime.getCurrentContext(), ((RubyArray) obj).toJavaArray());
+            return XmlNodeSet.newNodeSet(runtime, ((RubyArray) obj).toJavaArray());
         }
         /*if (o instanceof XmlNode)*/ return ((XmlNode) obj).getNode();
     }

--- a/ext/java/nokogiri/internals/ParserContext.java
+++ b/ext/java/nokogiri/internals/ParserContext.java
@@ -101,7 +101,7 @@ public abstract class ParserContext extends RubyObject {
 
         if (stringData.encoding(context) != null) {
             RubyString stringEncoding = stringData.encoding(context).asString();
-            String encName = NokogiriHelpers.getValidEncodingOrNull(context.runtime, stringEncoding);
+            String encName = NokogiriHelpers.getValidEncodingOrNull(stringEncoding);
             if (encName != null) {
                 java_encoding = encName;
             }

--- a/ext/java/nokogiri/internals/ReaderNode.java
+++ b/ext/java/nokogiri/internals/ReaderNode.java
@@ -112,17 +112,14 @@ public abstract class ReaderNode {
     public IRubyObject getAttributesNodes() {
         RubyArray array = RubyArray.newArray(ruby);
         if (attributeList != null && attributeList.length > 0) {
-            final ThreadContext context = ruby.getCurrentContext();
             if (document == null) {
-                XmlDocument doc = (XmlDocument) XmlDocument.rbNew(context, getNokogiriClass(ruby, "Nokogiri::XML::Document"), new IRubyObject[0]);
-                document = doc.getDocument();
+                document = XmlDocument.createNewDocument(ruby);
             }
             for (int i=0; i<attributeList.length; i++) {
                 if (!isNamespace(attributeList.names.get(i))) {
                     Attr attr = document.createAttributeNS(attributeList.namespaces.get(i), attributeList.names.get(i));
                     attr.setValue(attributeList.values.get(i));
-                    XmlAttr xmlAttr = (XmlAttr) NokogiriService.XML_ATTR_ALLOCATOR.allocate(ruby, getNokogiriClass(ruby, "Nokogiri::XML::Attr"));
-                    xmlAttr.setNode(context, attr);
+                    XmlAttr xmlAttr = new XmlAttr(ruby, attr);
                     array.append(xmlAttr);
                 }
             }

--- a/ext/java/nokogiri/internals/ReaderNode.java
+++ b/ext/java/nokogiri/internals/ReaderNode.java
@@ -112,8 +112,9 @@ public abstract class ReaderNode {
     public IRubyObject getAttributesNodes() {
         RubyArray array = RubyArray.newArray(ruby);
         if (attributeList != null && attributeList.length > 0) {
+            final ThreadContext context = ruby.getCurrentContext();
             if (document == null) {
-                XmlDocument doc = (XmlDocument) XmlDocument.rbNew(ruby.getCurrentContext(), getNokogiriClass(ruby, "Nokogiri::XML::Document"), new IRubyObject[0]);
+                XmlDocument doc = (XmlDocument) XmlDocument.rbNew(context, getNokogiriClass(ruby, "Nokogiri::XML::Document"), new IRubyObject[0]);
                 document = doc.getDocument();
             }
             for (int i=0; i<attributeList.length; i++) {
@@ -121,7 +122,7 @@ public abstract class ReaderNode {
                     Attr attr = document.createAttributeNS(attributeList.namespaces.get(i), attributeList.names.get(i));
                     attr.setValue(attributeList.values.get(i));
                     XmlAttr xmlAttr = (XmlAttr) NokogiriService.XML_ATTR_ALLOCATOR.allocate(ruby, getNokogiriClass(ruby, "Nokogiri::XML::Attr"));
-                    xmlAttr.setNode(ruby.getCurrentContext(), attr);
+                    xmlAttr.setNode(context, attr);
                     array.append(xmlAttr);
                 }
             }

--- a/ext/java/nokogiri/internals/XmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/XmlDomParserContext.java
@@ -216,10 +216,9 @@ public class XmlDomParserContext extends ParserContext {
         xmlDocument.setEncoding(ruby_encoding);
 
         if (options.dtdLoad) {
-            IRubyObject xmlDtdOrNil = XmlDtd.newFromExternalSubset(context.getRuntime(), doc);
-            if (!xmlDtdOrNil.isNil()) {
-                XmlDtd xmlDtd = (XmlDtd) xmlDtdOrNil;
-                doc.setUserData(XmlDocument.DTD_EXTERNAL_SUBSET, xmlDtd, null);
+            IRubyObject dtd = XmlDtd.newFromExternalSubset(context.runtime, doc);
+            if (!dtd.isNil()) {
+                doc.setUserData(XmlDocument.DTD_EXTERNAL_SUBSET, (XmlDtd) dtd, null);
             }
         }
         return xmlDocument;
@@ -228,20 +227,18 @@ public class XmlDomParserContext extends ParserContext {
     /**
      * Must call setInputSource() before this method.
      */
-    public XmlDocument parse(ThreadContext context,
-                             IRubyObject klazz,
-                             IRubyObject url) {
+    public XmlDocument parse(ThreadContext context, RubyClass klass, IRubyObject url) {
         XmlDocument xmlDoc;
         try {
             Document doc = do_parse();
-            xmlDoc = wrapDocument(context, (RubyClass)klazz, doc);
+            xmlDoc = wrapDocument(context, klass, doc);
             xmlDoc.setUrl(url);
             addErrorsIfNecessary(context, xmlDoc);
             return xmlDoc;
         } catch (SAXException e) {
-            return getDocumentWithErrorsOrRaiseException(context, (RubyClass)klazz, e);
+            return getDocumentWithErrorsOrRaiseException(context, klass, e);
         } catch (IOException e) {
-            return getDocumentWithErrorsOrRaiseException(context, (RubyClass)klazz, e);
+            return getDocumentWithErrorsOrRaiseException(context, klass, e);
         }
     }
 

--- a/ext/java/nokogiri/internals/XmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/XmlDomParserContext.java
@@ -93,7 +93,7 @@ public class XmlDomParserContext extends ParserContext {
     public XmlDomParserContext(Ruby runtime, IRubyObject encoding, IRubyObject options) {
         super(runtime);
         this.options = new ParserContext.Options(RubyFixnum.fix2long(options));
-        java_encoding = NokogiriHelpers.getValidEncoding(runtime, encoding);
+        java_encoding = NokogiriHelpers.getValidEncoding(encoding);
         ruby_encoding = encoding;
         initErrorHandler();
         initParser(runtime);

--- a/ext/java/nokogiri/internals/XmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/XmlDomParserContext.java
@@ -200,30 +200,19 @@ public class XmlDomParserContext extends ParserContext {
         }
     }
     
-    private XmlDocument getInterruptedOrNewXmlDocument(ThreadContext context, RubyClass klazz) {
+    private XmlDocument getInterruptedOrNewXmlDocument(ThreadContext context, RubyClass klass) {
         Document document = parser.getDocument();
-        XmlDocument xmlDocument = (XmlDocument) NokogiriService.XML_DOCUMENT_ALLOCATOR.allocate(context.getRuntime(), klazz);
-        if (document != null) {
-            xmlDocument.setDocumentNode(context, document);
-        }
+        XmlDocument xmlDocument = new XmlDocument(context.runtime, klass, document);
         xmlDocument.setEncoding(ruby_encoding);
         return xmlDocument;
-    }
-
-    protected XmlDocument getNewEmptyDocument(ThreadContext context) {
-        IRubyObject[] args = new IRubyObject[0];
-        return (XmlDocument) XmlDocument.rbNew(context, getNokogiriClass(context.getRuntime(), "Nokogiri::XML::Document"), args);
     }
 
     /**
      * This method is broken out so that HtmlDomParserContext can
      * override it.
      */
-    protected XmlDocument wrapDocument(ThreadContext context,
-                                       RubyClass klazz,
-                                       Document doc) {
-        XmlDocument xmlDocument = (XmlDocument) NokogiriService.XML_DOCUMENT_ALLOCATOR.allocate(context.getRuntime(), klazz);
-        xmlDocument.setDocumentNode(context, doc);
+    protected XmlDocument wrapDocument(ThreadContext context, RubyClass klass, Document doc) {
+        XmlDocument xmlDocument = new XmlDocument(context.runtime, klass, doc);
         xmlDocument.setEncoding(ruby_encoding);
 
         if (options.dtdLoad) {

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -254,18 +254,12 @@ module Nokogiri
       ##
       # +JRuby+
       # Wraps Java's org.w3c.dom.document and returns Nokogiri::XML::Document
-      def self.wrap document
-        raise "JRuby only method" unless Nokogiri.jruby?
-        return wrapJavaDocument(document)
-      end
+      def self.wrap(document) end if false # native-ext provides Document.wrap
 
       ##
       # +JRuby+
       # Returns Java's org.w3c.dom.document of this Document.
-      def to_java
-        raise "JRuby only method" unless Nokogiri.jruby?
-        return toJavaDocument()
-      end
+      def to_java; end if false # JRuby provides #to_java
 
       private
       def self.empty_doc? string_or_io


### PR DESCRIPTION
There's some anti-patterns regarding JRuby ext / Java to revisit (still an ongoing effort).
The Java ext part is confusing at times - initializing parts twice (e.g. XmlDocument's node).

Relevant changes : 

- avoid ns-cache being double backed by a map + another key list (use just map backing)
  also introduce a cache-key as using arrays was weird - potentially leaky on some scenarios
- do not construct ext wrapper objects went internally XML API objects are sufficient
- cleaner and more explicit way of initializing (document) internals of XmlNodeSets
- align with JRuby's toJava convention (will also now work for any Node not just Document)
- review some of the internals and remove dead-code
- do not silently swallow potentially fatal exception from backend

Nokogiri is a bit heavy on memory on times - there's a few attempts to reduce allocations here.


**NOTE:** includes https://github.com/sparklemotion/nokogiri/pull/1930 (to avoid potential conflict resolution) should be without conflicts after its merged.

This also could use some raw performance numbers.