### PR TITLE
Do not override encoding set during initialisation

### DIFF
--- a/lib/nokogiri/xml/sax/parser.rb
+++ b/lib/nokogiri/xml/sax/parser.rb
@@ -88,9 +88,8 @@ module Nokogiri
 
         ###
         # Parse given +io+
-        def parse_io(io, encoding = "ASCII")
-          @encoding = check_encoding(encoding)
-          ctx = ParserContext.io(io, ENCODINGS[@encoding])
+        def parse_io(io, encoding = @encoding)
+          ctx = ParserContext.io(io, ENCODINGS[check_encoding(encoding)])
           yield ctx if block_given?
           ctx.parse_with(self)
         end

--- a/test/xml/sax/test_parser.rb
+++ b/test/xml/sax/test_parser.rb
@@ -190,6 +190,12 @@ module Nokogiri
           end
         end
 
+        it :test_parse_io_does_not_override_encoding do
+          parser = XML::SAX::Parser.new(Doc.new, "UTF-8")
+          parser.parse_io(StringIO.new("<root/>"), "ASCII")
+          assert_equal "UTF-8", parser.encoding
+        end
+
         it :test_parse_with_memory_argument do
           parser.parse(File.read(XML_FILE))
           refute_empty(parser.document.cdata_blocks)


### PR DESCRIPTION
encoding set during initialisation of sax parser gets replaced to ASCII when parsing.
Fix: check if encoding has already been set.

