### PR TITLE
Rakefile: fix "code" gemspec URL metadata typo

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -120,7 +120,7 @@ HOE = Hoe.spec 'nokogiri' do
     "bugs" => "https://github.com/sparklemotion/nokogiri/issues",
     "doco" => "https://nokogiri.org/rdoc/index.html",
     "clog" => "https://nokogiri.org/CHANGELOG.html",
-    "code" => "https://github.com/sparklemotion/nokogiri}",
+    "code" => "https://github.com/sparklemotion/nokogiri",
   }
 
   self.extra_rdoc_files = FileList['ext/nokogiri/*.c']


### PR DESCRIPTION
Fix a URL typo.

**What problem is this PR intended to solve?**

The gemspec metadata provided via hoe seemed to have an extraneous `}` character.

That would lead to an erroneous URL presented in the RubyGems.org website for the next release.

**Have you included adequate test coverage?**

No.

I have left this up to manual inspection.

**Does this change affect the C or the Java implementations?**

No.