### PR TITLE
Fix loading of nokogiri binary gems

### DIFF
--- a/lib/nokogiri/version.rb
+++ b/lib/nokogiri/version.rb
@@ -110,7 +110,12 @@ module Nokogiri
   if Nokogiri.jruby?
     require "nokogiri/jruby/dependencies"
   end
-  require "nokogiri/nokogiri"
+  begin
+    RUBY_VERSION =~ /(\d+\.\d+)/
+    require "nokogiri/#{$1}/nokogiri"
+  rescue LoadError
+    require "nokogiri/nokogiri"
+  end
 
   # More complete version information about libxml
   VERSION_INFO = VersionInfo.instance.to_hash


### PR DESCRIPTION
The loading mechanism must include the ruby-version specific path.

This is a fixup to commit 252acd99aa7d9749d820b5b6ce3848e319ad282d .

---

**What problem is this PR intended to solve?**

Loading of fat binary gems fails on master branch on Windows with 
```
        12: from C:/Ruby27-x64/bin/nokogiri:23:in `<main>'
        11: from C:/Ruby27-x64/bin/nokogiri:23:in `load'
        10: from C:/Ruby27-x64/lib/ruby/gems/2.7.0/gems/nokogiri-1.10.4-x64-mingw32/bin/nokogiri:6:in `<top (required)>'
         9: from C:/Ruby27-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:156:in `require'
         8: from C:/Ruby27-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `rescue in require'
         7: from C:/Ruby27-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `require'
         6: from C:/Ruby27-x64/lib/ruby/gems/2.7.0/gems/nokogiri-1.10.4-x64-mingw32/lib/nokogiri.rb:17:in `<top (required)>'
         5: from C:/Ruby27-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
         4: from C:/Ruby27-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
         3: from C:/Ruby27-x64/lib/ruby/gems/2.7.0/gems/nokogiri-1.10.4-x64-mingw32/lib/nokogiri/version.rb:2:in `<top (required)>'
         2: from C:/Ruby27-x64/lib/ruby/gems/2.7.0/gems/nokogiri-1.10.4-x64-mingw32/lib/nokogiri/version.rb:113:in `<module:Nokogiri>'
         1: from C:/Ruby27-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
C:/Ruby27-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- nokogiri/nokogiri (LoadError)
```

**Have you included adequate test coverage?**

Possibly we could implement a test queue for binary builds, but so far there is none.

**Does this change affect the C or the Java implementations?**

Only the C implementation. And only the master branch, not the released gems.
