### PR TITLE
Use the same empty string literal

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -763,10 +763,15 @@ module Nokogiri
         end
         indent_text   = options[:indent_text] || ' '
 
+        # Any string times 0 returns an empty string. Therefore, use the same
+        # string instead of generating a new empty string for every node with
+        # zero indentation.
+        indentation = indent_times.zero? ? '' : (indent_text * indent_times)
+
         config = SaveOptions.new(save_options.to_i)
         yield config if block_given?
 
-        native_write_to(io, encoding, indent_text * indent_times, config.options)
+        native_write_to(io, encoding, indentation, config.options)
       end
 
       ###


### PR DESCRIPTION
## What problem is this PR intended to solve?

**Avoidable extra memory allocation**

While profiling a project to optimize memory usage, the following came to my notice:
```
Allocated String Report
-----------------------------------
    154375  ""
     88132  nokogiri-1.10.7/lib/nokogiri/xml/node.rb:767
```
which is:
https://github.com/sparklemotion/nokogiri/blob/e6b3229ec53ddf70f1d198bba0d3fc13fde842a8/lib/nokogiri/xml/node.rb#L767

The explanation is that **`'a string of any length' * 0 == ""`**.

`String#*` generates a *new string* even if string literals are frozen via the pragma.
Therefore, if the above line was executed (with `indent_times == 0`) a 100 times, there would be an allocation of 100 empty strings (irrespective of `indent_text`) .

This PR replaces this deterministic allocation with a single frozen string literal.
(*Hope the native method doesn't mutate it*).

**Have you included adequate test coverage?**

No change in behavior.


**Does this change affect the C or the Java implementations?**

N/A
