### PR TITLE
don't export libxml2 symbols

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -415,6 +415,9 @@ $LIBS << " #{ENV["LIBS"]}"
 # Read CFLAGS from ENV and make sure compiling works.
 add_cflags(ENV["CFLAGS"])
 
+# Ensure libxml2/libxslt symbols aren't exported. See #1959 for details.
+$LDFLAGS << " -Wl,--exclude-libs,ALL"
+
 if windows?
   $CFLAGS << " -DXP_WIN -DXP_WIN32 -DUSE_INCLUDED_VASPRINTF"
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See #1959 


**Have you included adequate test coverage?**

I'm concerned that without exported symbols, nokogumbo will break. We don't have tests for that. Otherwise, existing test coverage suffices.

Pinging @stevecheckoway for awareness and to ask for validation and input from the nokogumbo project maintainers.

**Does this change affect the C or the Java implementations?**

Will only affect CRuby.
