### PR TITLE
Remove dependency to "mini_portile2" from binary gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -275,6 +275,7 @@ else
 Nokogiri is built with the packaged libraries: #{libs}.
       EOS
       spec.files.reject! { |path| File.fnmatch?('ports/*', path) }
+      spec.dependencies.reject! { |dep| dep.name=='mini_portile2' }
     end
   end
 end


### PR DESCRIPTION
It is only necessary at build in extconf.rb.


**What problem is this PR intended to solve?**

As noted in [this issue](https://github.com/sparklemotion/nokogiri/issues/1983#issuecomment-581850547) binary gems depend on "mini_portile2" gems, although it isn't necessary.


**Have you included adequate test coverage?**

There are no automated tests for binary gems, so far.

**Does this change affect the C or the Java implementations?**

Only the C implementation.
