### PR TITLE
Update mini_portile2 gem to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Either way, we'd appreciate some feedback at [#1983](https://github.com/sparklem
 
 ### Dependencies
 
+#### Ruby
+
 This release introduces support for:
 
 * Ruby 2.7, including the precompiled native binary gems for Windows.
@@ -52,6 +54,11 @@ This release ends support for:
 
 * Ruby 2.3, for which [official support ended on 2019-03-31](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/) [[#1886](https://github.com/sparklemotion/nokogiri/issues/1886)] (Thanks [@ashmaroli](https://github.com/ashmaroli)!)
 * JRuby 9.1, which is the Ruby 2.3-compatible release.
+
+
+#### Gems
+
+* [MRI] Upgrade mini_portile2 dependency from `~> 2.4.0` to `~> 2.5.0` [[#2005](https://github.com/sparklemotion/nokogiri/issues/2005)] (Thanks, [@alejandroperea](https://github.com/alejandroperea)!)
 
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 
 source "https://rubygems.org/"
 
-gem "mini_portile2", "~>2.4.0"
+gem "mini_portile2", "~>2.5.0"
 
 gem "concourse", "~>0.30", :group => [:development, :test]
 gem "hoe", "~>3.22", ">=3.22.1", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -171,7 +171,7 @@ HOE = Hoe.spec 'nokogiri' do
 
   unless java?
     self.extra_deps += [
-      ["mini_portile2", "~> 2.4.0"], # keep version in sync with extconf.rb
+      ["mini_portile2", "~> 2.5.0"], # keep version in sync with extconf.rb
     ]
   end
 

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -470,7 +470,7 @@ else
   # The gem version constraint in the Rakefile is not respected at install time.
   # Keep this version in sync with the one in the Rakefile !
   require 'rubygems'
-  gem 'mini_portile2', '~> 2.4.0'
+  gem 'mini_portile2', '~> 2.5.0'
   require 'mini_portile2'
   message "Using mini_portile version #{MiniPortile::VERSION}\n"
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Keeping the dependencies updated.


**Have you included adequate test coverage?**

It is not needed, all of the current ones should pass.


**Does this change affect the C or the Java implementations?**

It shouldn't.
