### PR TITLE
Add a workaround for missing call to cross_compile block

### DIFF
--- a/tasks/cross-ruby.rb
+++ b/tasks/cross-ruby.rb
@@ -166,6 +166,7 @@ namespace "gem" do
       RakeCompilerDock.sh <<-EOT, platform: plat
         gem install bundler --no-document &&
         bundle &&
+        find /usr/local/rvm/gems -name extensiontask.rb | while read f ; do sudo sed -i 's/callback.call(spec) if callback/@cross_compiling.call(spec) if @cross_compiling/' $f ; done &&
         rake native:#{plat} pkg/#{HOE.spec.full_name}-#{plat}.gem MAKE='nice make -j`nproc`' RUBY_CC_VERSION=#{ENV["RUBY_CC_VERSION"]}
       EOT
     end


### PR DESCRIPTION
The cross_compiling block wasn't called for the x86_64-linux platform, leading to an additional dependency to mini_portile2 and missing post install message.

Related patch to rake-compiler is here: https://github.com/rake-compiler/rake-compiler/pull/171

Fixes #1991
