### PR TITLE
Support MSVC

### DIFF
--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -1,6 +1,18 @@
 #ifndef NOKOGIRI_NATIVE
 #define NOKOGIRI_NATIVE
 
+#if _MSC_VER
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif /* WIN32_LEAN_AND_MEAN */
+#ifndef WIN32
+#define WIN32
+#endif /* WIN32 */
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>


### PR DESCRIPTION
---

**What problem is this PR intended to solve?**

Aims to partially fix the issue #2015 to allow compilation on MSVC. 
**This fixes the redefinition issues, but ideally the packaged dependencies (zlib, libxml, lixslt) would work out of the box (I am using `conan` to get the dependencies and passing some arguments such as `with-xxx-dir` to make it work right now), and the .cross-rubies and task/cross-ruby.rb would be modified to allow MSVC gems to be packaged.**


**Have you included adequate test coverage?**

We have a thorough test suite that allows us to create releases confidently and prevent accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.

If possible, please try to write the tests so that they communicate intent.


**Does this change affect the C or the Java implementations?**

I'm adding a macro to the C nokogiri.h header which shouldn't have much effect since it's wrapped in a `#if _MSC_VER` block. 

I currently added jaro_winkler to a patched version of mine (https://github.com/tonytonyjan/jaro_winkler/pull/43)
