### PR TITLE
Clean up deprecated calls into JRuby

### DIFF
--- a/ext/java/nokogiri/HtmlSaxParserContext.java
+++ b/ext/java/nokogiri/HtmlSaxParserContext.java
@@ -194,7 +194,7 @@ public class HtmlSaxParserContext extends XmlSaxParserContext {
             throw context.getRuntime().newEncodingCompatibilityError(rubyEncoding + "is not supported");
         }
         catch (IllegalCharsetNameException e) {
-            throw context.getRuntime().newInvalidEncoding(e.getMessage());
+            throw context.getRuntime().newEncodingError(e.getMessage());
         }
     }
 

--- a/ext/java/nokogiri/HtmlSaxPushParser.java
+++ b/ext/java/nokogiri/HtmlSaxPushParser.java
@@ -129,7 +129,7 @@ public class HtmlSaxPushParser extends RubyObject {
         final ByteArrayInputStream data = NokogiriHelpers.stringBytesToStream(chunk);
         if (data == null) {
             terminateTask(context.runtime);
-            throw new RaiseException(XmlSyntaxError.createHTMLSyntaxError(context.runtime)); // Nokogiri::HTML::SyntaxError
+            throw XmlSyntaxError.createHTMLSyntaxError(context.runtime).toThrowable(); // Nokogiri::HTML::SyntaxError
         }
 
         int errorCount0 = parserTask.getErrorCount();

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -1662,7 +1662,7 @@ public class XmlNode extends RubyObject {
         while(errors.getLength() > 0) {
             XmlSyntaxError error = (XmlSyntaxError)errors.shift(context);
             if (error.toString().contains("Include operation failed")) {
-                throw new RaiseException(error);
+                throw error.toThrowable();
             }
         }
         return this;

--- a/ext/java/nokogiri/XmlReader.java
+++ b/ext/java/nokogiri/XmlReader.java
@@ -328,7 +328,7 @@ public class XmlReader extends RubyObject {
             continueParsing = config.parse(false);
         }
         catch (XNIException e) {
-            throw new RaiseException(XmlSyntaxError.createXMLSyntaxError(context.runtime, e)); // Nokogiri::XML::SyntaxError
+            throw XmlSyntaxError.createXMLSyntaxError(context.runtime, e).toThrowable(); // Nokogiri::XML::SyntaxError
         }
         catch (IOException e) {
             throw context.runtime.newRuntimeError(e.toString());
@@ -364,7 +364,7 @@ public class XmlReader extends RubyObject {
             errors.append(error);
             setInstanceVariable("@errors", errors);
 
-            throw ex != null ? ex : new RaiseException((XmlSyntaxError) error);
+            throw ex != null ? ex : ((XmlSyntaxError) error).toThrowable();
         }
         if ( ex != null ) throw ex;
         return this;

--- a/ext/java/nokogiri/XmlSaxParserContext.java
+++ b/ext/java/nokogiri/XmlSaxParserContext.java
@@ -94,7 +94,8 @@ public class XmlSaxParserContext extends ParserContext {
             parser = createParser();
         }
         catch (SAXException se) {
-            throw RaiseException.createNativeRaiseException(runtime, se);
+            // Unexpected failure in XML subsystem
+            throw runtime.newRuntimeError(se.getMessage());
         }
     }
 
@@ -208,7 +209,8 @@ public class XmlSaxParserContext extends ParserContext {
                 parser.setFeature(FEATURE_CONTINUE_AFTER_FATAL_ERROR, true);
             }
             catch (Exception e) {
-                throw RaiseException.createNativeRaiseException(runtime, e);
+                // Unexpected failure in XML subsystem
+                throw runtime.newRuntimeError(e.getMessage());
             }
         }
     }
@@ -261,7 +263,8 @@ public class XmlSaxParserContext extends ParserContext {
             }
         }
         catch (SAXException ex) {
-            throw RaiseException.createNativeRaiseException(runtime, ex);
+            // Unexpected failure in XML subsystem
+            throw runtime.newRuntimeError(ex.getMessage());
         }
         catch (IOException ex) {
             throw runtime.newIOErrorFromException(ex);

--- a/ext/java/nokogiri/XmlSaxParserContext.java
+++ b/ext/java/nokogiri/XmlSaxParserContext.java
@@ -95,7 +95,9 @@ public class XmlSaxParserContext extends ParserContext {
         }
         catch (SAXException se) {
             // Unexpected failure in XML subsystem
-            throw runtime.newRuntimeError(se.getMessage());
+            RaiseException ex = runtime.newRuntimeError(se.toString());
+            ex.initCause(se);
+            throw ex;
         }
     }
 

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -131,7 +131,7 @@ public class XmlSchema extends RubyObject {
 
         RubyArray errors = (RubyArray) doc.getInstanceVariable("@errors");
         if (!errors.isEmpty()) {
-            throw new RaiseException((XmlSyntaxError) errors.first());
+            throw ((XmlSyntaxError) errors.first()).toThrowable();
         }
 
         DOMSource source = new DOMSource(doc.getDocument());

--- a/ext/java/nokogiri/XmlSyntaxError.java
+++ b/ext/java/nokogiri/XmlSyntaxError.java
@@ -120,13 +120,9 @@ public class XmlSyntaxError extends RubyException {
         setInstanceVariable("@file", stringOrNil(runtime, exception.getSystemId()));
     }
 
-    // NOTE: special care - due JRuby 1.7.x
-    
-    @Override
-    public IRubyObject to_s(ThreadContext context) { return to_s19(context); }
-
     @JRubyMethod(name = "to_s")
-    public RubyString to_s19(ThreadContext context) {
+    @Override
+    public IRubyObject to_s(ThreadContext context) {
         RubyString msg = msg(context.runtime);
         return msg != null ? msg : super.to_s(context).asString();
     }

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -163,7 +163,7 @@ public class XmlXpathContext extends RubyObject {
             return tryGetNodeSet(context, expr, fnResolver);
         }
         catch (TransformerException ex) {
-            throw new RaiseException(XmlSyntaxError.createXMLXPathSyntaxError(context.runtime, expr, ex)); // Nokogiri::XML::XPath::SyntaxError
+            throw XmlSyntaxError.createXMLXPathSyntaxError(context.runtime, expr, ex).toThrowable(); // Nokogiri::XML::XPath::SyntaxError
         }
     }
 

--- a/ext/java/nokogiri/internals/NokogiriHandler.java
+++ b/ext/java/nokogiri/internals/NokogiriHandler.java
@@ -249,7 +249,7 @@ public class NokogiriHandler extends DefaultHandler2 implements XmlDeclHandler {
         try {
             final String msg = ex.getMessage();
             call("error", runtime.newString(msg == null ? "" : msg));
-            addError(new RaiseException(XmlSyntaxError.createError(runtime, ex), true));
+            addError(XmlSyntaxError.createError(runtime, ex).toThrowable());
         } catch( RaiseException e) {
             addError(e);
             throw e;

--- a/ext/java/nokogiri/internals/XmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/XmlDomParserContext.java
@@ -196,7 +196,7 @@ public class XmlDomParserContext extends ParserContext {
         } else {
             XmlSyntaxError xmlSyntaxError = XmlSyntaxError.createXMLSyntaxError(context.runtime);
             xmlSyntaxError.setException(ex);
-            throw new RaiseException(xmlSyntaxError);
+            throw xmlSyntaxError.toThrowable();
         }
     }
     


### PR DESCRIPTION
This PR removes all deprecation warnings from the Java extension by using newer preferred APIs in JRuby.

The bulk of changes are to use `RubyException.toThrowable()` to construct a Java throwable for a Ruby exception, rather than the deprecated `RaiseException` constructor. This change is the likely the most controversial since it breaks compatibility with JRuby versions older than 9.2.

The other changes are to use RuntimeError instead of NativeException for raising unexpected Java XML errors, and to move away from overriding the old `to_s19` form from JRuby 1.7.