### PR TITLE
Kernel#open -> URI#open

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ require 'nokogiri'
 require 'open-uri'
 
 # Fetch and parse HTML document
-doc = Nokogiri::HTML(open('https://nokogiri.org/tutorials/installing_nokogiri.html'))
+doc = Nokogiri::HTML(URI.open('https://nokogiri.org/tutorials/installing_nokogiri.html'))
 
 puts "### Search for nodes by css"
 doc.css('nav ul.menu li a', 'article h2').each do |link|

--- a/lib/nokogiri.rb
+++ b/lib/nokogiri.rb
@@ -37,7 +37,7 @@ require 'nokogiri/html/builder'
 #
 #   # Get a Nokogiri::HTML:Document for the page we’re interested in...
 #
-#   doc = Nokogiri::HTML(open('http://www.google.com/search?q=tenderlove'))
+#   doc = Nokogiri::HTML(URI.open('http://www.google.com/search?q=tenderlove'))
 #
 #   # Do funky things with it using Nokogiri::XML::Node methods...
 #


### PR DESCRIPTION
I made this PR to update sample code.

**What problem is this PR intended to solve?**

Run sample codes with Ruby 2.7.0 and later and get decricated warning like below.

```
> Nokogiri::HTML(open('https://nokogiri.org/tutorials/installing_nokogiri.html'))
(irb):33: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly
```

So, I edited the codes not to use `Kernel#open` but `URI#open`.

**Have you included adequate test coverage?**

Tests has no changes because I only changed sample codes.
