### PR TITLE
Fix openSUSE/SUSE spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ help you directly and improve the documentation.
 Binary packages are available for some distributions.
 
 * Debian: https://packages.debian.org/sid/ruby-nokogiri
-* SuSE: https://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/
+* openSUSE/SLE: https://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/
 * Fedora: http://s390.koji.fedoraproject.org/koji/packageinfo?packageID=6756
 
 

--- a/concourse/TODO.md
+++ b/concourse/TODO.md
@@ -23,7 +23,7 @@
   * [ ] linux (system)
   * [ ] linux (vendored)
   * [ ] linux (vendored, --disable-static)
-  * [ ] OpenSuse with site_config (lib64, #1562)
+  * [ ] openSUSE with site_config (lib64, #1562)
   * [ ] windows (fat binary)
   * [ ] windows (devkit)
 * notifications on failure / success


### PR DESCRIPTION
**What problem is this PR intended to solve?**

I did not specifically create an issue for this because it is just a **minor spelling fix** of openSUSE/SUSE in [README.md](https://github.com/sparklemotion/nokogiri/blob/master/README.md) and [TODO.md](https://github.com/sparklemotion/nokogiri/blob/master/concourse/TODO.md)

**Have you included adequate test coverage?**

No.

**Does this change affect the C or the Java implementations?**

No