### PR TITLE
ensure libxml2/libxslt symbols aren't exported

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -415,6 +415,9 @@ $LIBS << " #{ENV["LIBS"]}"
 # Read CFLAGS from ENV and make sure compiling works.
 add_cflags(ENV["CFLAGS"])
 
+# Ensure libxml2/libxslt symbols aren't exported. See #1959 for details.
+$LDFLAGS << " -Wl,--exclude-libs,ALL"
+
 if windows?
   $CFLAGS << " -DXP_WIN -DXP_WIN32 -DUSE_INCLUDED_VASPRINTF"
 end


### PR DESCRIPTION
see #1959 for details

---

Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the questions below when you submit this pull request.

The Nokogiri core team work off of `master`, so please submit all PRs based on the `master` branch. We generally will cherry-pick relevant bug fixes onto the current release branch.


**What problem is this PR intended to solve?**

If there is an existing issue that describes this, feel free to simply link to that issue.

Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.


**Have you included adequate test coverage?**

We have a thorough test suite that allows us to create releases confidently and prevent accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.

If possible, please try to write the tests so that they communicate intent.


**Does this change affect the C or the Java implementations?**

If you're proposing a change to the C implementation, has the behavior change been made to the Java code as well? And vice versa?

If not, that may be OK, just please note it here.
