### PR TITLE
Follow WHATWG guidance for incorrectly-closed HTML comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ We bump `Major.Minor.Patch` versions following this guidance:
 `Minor`:
 
 - Features and bugfixes.
-- Dropping support for EOLed Ruby versions, updating vendored libraries.
-- Updating vendored libraries for non-security-related reasons.
+- Dropping support for EOLed Ruby versions, updating packaged libraries.
+- Updating packaged libraries for non-security-related reasons.
 
 `Patch`:
 
-- Security updates, including updating vendored libraries for security-related reasons.
+- Security updates, including updating packaged libraries for security-related reasons.
 - Bugfixes.
 
 ---
@@ -91,6 +91,7 @@ This release ends support for:
 * Avoid creation of unnecessary zero-length String objects. [[#1970](https://github.com/sparklemotion/nokogiri/issues/1970)] (Thanks, [@ashmaroli](https://github.com/ashmaroli)!)
 * Always compile libxml2 and libxslt with '-O2' [[#2022](https://github.com/sparklemotion/nokogiri/issues/2022), [#2100](https://github.com/sparklemotion/nokogiri/issues/2100)] (Thanks, [@ilyazub](https://github.com/ilyazub)!)
 * {HTML,XML}::Document#parse now accept `Pathname` objects. Previously this worked only if the referenced file was less than 4096 bytes long; longer files resulted in undefined behavior because the `read` method would be repeatedly invoked. [[#1821](https://github.com/sparklemotion/nokogiri/issues/1821), [#2110](https://github.com/sparklemotion/nokogiri/issues/2110)] (Thanks, [@doriantaylor](https://github.com/doriantaylor) and [@phokz](https://github.com/phokz)!)
+* [CRuby] Packaged libxml2 follows WHATWG guidance for incorrectly-closed HTML comments. [[#2058](https://github.com/sparklemotion/nokogiri/issues/2058)] (Thanks to HackerOne user [mayflower](https://hackerone.com/mayflower?type=user) for reporting this!)
 * [JRuby] Lots of code cleanup and performance improvements. [[#1934](https://github.com/sparklemotion/nokogiri/issues/1934)] (Thanks, [@kares](https://github.com/kares)!)
 * [JRuby] Clean up deprecated calls into JRuby. [[#2027](https://github.com/sparklemotion/nokogiri/issues/2027)] (Thanks, [@headius](https://github.com/headius)!)
 
@@ -119,7 +120,7 @@ This release changes the information provided in
 `Nokogiri::VersionInfo`, see [#1482](https://github.com/sparklemotion/nokogiri/issues/1482) and [#1974](https://github.com/sparklemotion/nokogiri/issues/1974) for background. Note that
 the output of `nokogiri -v` will also reflect these changes.
 
-`Nokogiri::VersionInfo` will no longer contain the following keys (previously these were set only when vendored libraries were being used)
+`Nokogiri::VersionInfo` will no longer contain the following keys (previously these were set only when packaged libraries were being used)
 * `libxml/libxml2_path`
 * `libxml/libxslt_path`
 
@@ -149,7 +150,7 @@ These methods have been renamed and the return type changed from `String` to `Ge
 
 `Nokogiri.uses_libxml?` now accepts an optional requirement string which is interpreted as a `Gem::Requirement` and tested against the loaded libxml2 version (the value in `VersionInfo` key `libxml/loaded`). This greatly simplifies much of the version-dependent branching logic in both the implementation and the tests.
 
-To sum these changes up, the output from CRuby when using vendored libraries was something like:
+To sum these changes up, the output from CRuby when using packaged libraries was something like:
 
 ```
 # Nokogiri (1.10.7)

--- a/patches/libxml2/0006-htmlParseComment-treat-as-if-it-closed-the-comment.patch
+++ b/patches/libxml2/0006-htmlParseComment-treat-as-if-it-closed-the-comment.patch
@@ -1,0 +1,55 @@
+From 15b28d8a99224e16ae8a7e7774ee3b6b6769dca3 Mon Sep 17 00:00:00 2001
+From: Mike Dalessio <mike.dalessio@gmail.com>
+Date: Mon, 3 Aug 2020 17:36:05 -0400
+Subject: [PATCH] htmlParseComment: treat `--!>` as if it closed the comment
+
+See guidance provided on incorrectly-closed comments here:
+
+https://html.spec.whatwg.org/multipage/parsing.html#parse-error-incorrectly-closed-comment
+
+This is a minimal patch to try to avoid merge conflicts.
+---
+ HTMLparser.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/HTMLparser.c b/HTMLparser.c
+index 7b6d689..0046642 100644
+--- a/HTMLparser.c
++++ b/HTMLparser.c
+@@ -3301,6 +3301,7 @@ htmlParseComment(htmlParserCtxtPtr ctxt) {
+     int r, rl;
+     int cur, l;
+     xmlParserInputState state;
++    int possiblyIncorrectlyClosed = 0;
+ 
+     /*
+      * Check that there is a comment right here.
+@@ -3346,6 +3347,16 @@ htmlParseComment(htmlParserCtxtPtr ctxt) {
+ 	    buf = tmp;
+ 	}
+ 	COPY_BUF(ql,buf,len,q);
++
++	if (possiblyIncorrectlyClosed && cur == '>') {
++	  htmlParseErr(ctxt, XML_ERR_COMMENT_NOT_FINISHED,
++		       "Comment incorrectly closed by '--!>'", NULL, NULL);
++	  buf[len-2] = 0;
++	  goto recover ;
++	}
++
++	possiblyIncorrectlyClosed = (q == '-' && r == '-' && cur == '!') ? 1 : 0 ;
++
+ 	q = r;
+ 	ql = rl;
+ 	r = cur;
+@@ -3359,6 +3370,8 @@ htmlParseComment(htmlParserCtxtPtr ctxt) {
+ 	}
+     }
+     buf[len] = 0;
++
++recover:
+     if (IS_CHAR(cur)) {
+         NEXT;
+ 	if ((ctxt->sax != NULL) && (ctxt->sax->comment != NULL) &&
+-- 
+2.25.1
+

--- a/patches/libxml2/0007-rewrite-htmlParseLookupSequence-to-accept-an-arbitra.patch
+++ b/patches/libxml2/0007-rewrite-htmlParseLookupSequence-to-accept-an-arbitra.patch
@@ -1,0 +1,265 @@
+From 73fb87d057c22abf7e2b417f559ad62ef7ed67c8 Mon Sep 17 00:00:00 2001
+From: Mike Dalessio <mike.dalessio@gmail.com>
+Date: Sun, 11 Oct 2020 13:50:56 -0400
+Subject: [PATCH 1/2] rewrite htmlParseLookupSequence to accept an arbitrary
+ string
+
+This simplifies the logic in the method and allows us to pass in
+longer sequences.
+---
+ HTMLparser.c | 95 +++++++++++++++++++---------------------------------
+ 1 file changed, 34 insertions(+), 61 deletions(-)
+
+diff --git a/HTMLparser.c b/HTMLparser.c
+index 26b4c5d..123dff5 100644
+--- a/HTMLparser.c
++++ b/HTMLparser.c
+@@ -5128,25 +5128,19 @@ htmlCreateDocParserCtxt(const xmlChar *cur, const char *encoding) {
+ /**
+  * htmlParseLookupSequence:
+  * @ctxt:  an HTML parser context
+- * @first:  the first char to lookup
+- * @next:  the next char to lookup or zero
+- * @third:  the next char to lookup or zero
++ * @sequence:  a null-terminated array of bytes to lookup
+  * @comment: flag to force checking inside comments
+  *
+- * Try to find if a sequence (first, next, third) or  just (first next) or
+- * (first) is available in the input stream.
++ * Try to find if a sequence of bytes is available in the input stream.
+  * This function has a side effect of (possibly) incrementing ctxt->checkIndex
+  * to avoid rescanning sequences of bytes, it DOES change the state of the
+  * parser, do not use liberally.
+  * This is basically similar to xmlParseLookupSequence()
+  *
+- * Returns the index to the current parsing point if the full sequence
+- *      is available, -1 otherwise.
++ * Returns the index to the current parsing point if the full sequence is available, -1 otherwise.
+  */
+ static int
+-htmlParseLookupSequence(htmlParserCtxtPtr ctxt, xmlChar first,
+-                        xmlChar next, xmlChar third, int iscomment,
+-                        int ignoreattrval)
++htmlParseLookupSequence(htmlParserCtxtPtr ctxt, const char* sequence, int iscomment, int ignoreattrval)
+ {
+     int base, len;
+     htmlParserInputPtr in;
+@@ -5154,14 +5148,18 @@ htmlParseLookupSequence(htmlParserCtxtPtr ctxt, xmlChar first,
+     int incomment = 0;
+     int invalue = 0;
+     char valdellim = 0x0;
++    int sequence_len = xmlStrlen((const xmlChar*)sequence);
++    int matched;
+ 
+     in = ctxt->input;
+-    if (in == NULL)
++    if (in == NULL) {
+         return (-1);
++    }
+ 
+     base = in->cur - in->base;
+-    if (base < 0)
++    if (base < 0) {
+         return (-1);
++    }
+ 
+     if (ctxt->checkIndex > base)
+         base = ctxt->checkIndex;
+@@ -5174,11 +5172,7 @@ htmlParseLookupSequence(htmlParserCtxtPtr ctxt, xmlChar first,
+         len = xmlBufUse(in->buf->buffer);
+     }
+ 
+-    /* take into account the sequence length */
+-    if (third)
+-        len -= 2;
+-    else if (next)
+-        len--;
++    len = len + 1 - sequence_len;
+     for (; base < len; base++) {
+         if ((!incomment) && (base + 4 < len) && (!iscomment)) {
+             if ((buf[base] == '<') && (buf[base + 1] == '!') &&
+@@ -5214,28 +5208,17 @@ htmlParseLookupSequence(htmlParserCtxtPtr ctxt, xmlChar first,
+             }
+             continue;
+         }
+-        if (buf[base] == first) {
+-            if (third != 0) {
+-                if ((buf[base + 1] != next) || (buf[base + 2] != third))
+-                    continue;
+-            } else if (next != 0) {
+-                if (buf[base + 1] != next)
+-                    continue;
++        for (matched = 0 ; matched < sequence_len ; matched++) {
++            if (buf[base+matched] != sequence[matched]) {
++                break;
+             }
++        }
++        if (matched == sequence_len) {
+             ctxt->checkIndex = 0;
+ #ifdef DEBUG_PUSH
+-            if (next == 0)
+-                xmlGenericError(xmlGenericErrorContext,
+-                                "HPP: lookup '%c' found at %d\n",
+-                                first, base);
+-            else if (third == 0)
+-                xmlGenericError(xmlGenericErrorContext,
+-                                "HPP: lookup '%c%c' found at %d\n",
+-                                first, next, base);
+-            else
+-                xmlGenericError(xmlGenericErrorContext,
+-                                "HPP: lookup '%c%c%c' found at %d\n",
+-                                first, next, third, base);
++            xmlGenericError(xmlGenericErrorContext,
++                            "HPP: lookup '%s' found at %d\n",
++                            sequence, base);
+ #endif
+             return (base - (in->cur - in->base));
+         }
+@@ -5243,16 +5226,7 @@ htmlParseLookupSequence(htmlParserCtxtPtr ctxt, xmlChar first,
+     if ((!incomment) && (!invalue))
+         ctxt->checkIndex = base;
+ #ifdef DEBUG_PUSH
+-    if (next == 0)
+-        xmlGenericError(xmlGenericErrorContext,
+-                        "HPP: lookup '%c' failed\n", first);
+-    else if (third == 0)
+-        xmlGenericError(xmlGenericErrorContext,
+-                        "HPP: lookup '%c%c' failed\n", first, next);
+-    else
+-        xmlGenericError(xmlGenericErrorContext,
+-                        "HPP: lookup '%c%c%c' failed\n", first, next,
+-                        third);
++    xmlGenericError(xmlGenericErrorContext, "HPP: lookup '%s' failed\n", sequence);
+ #endif
+     return (-1);
+ }
+@@ -5462,7 +5436,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		    (UPP(6) == 'Y') && (UPP(7) == 'P') &&
+ 		    (UPP(8) == 'E')) {
+ 		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, '>', 0, 0, 0, 1) < 0))
++		        (htmlParseLookupSequence(ctxt, ">", 0, 1) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5508,7 +5482,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 	        if ((cur == '<') && (next == '!') &&
+ 		    (in->cur[2] == '-') && (in->cur[3] == '-')) {
+ 		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, '-', '-', '>', 1, 1) < 0))
++		        (htmlParseLookupSequence(ctxt, "-->", 1, 1) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5518,7 +5492,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		    ctxt->instate = XML_PARSER_MISC;
+ 	        } else if ((cur == '<') && (next == '?')) {
+ 		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, '>', 0, 0, 0, 1) < 0))
++		        (htmlParseLookupSequence(ctxt, ">", 0, 1) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5532,7 +5506,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		    (UPP(6) == 'Y') && (UPP(7) == 'P') &&
+ 		    (UPP(8) == 'E')) {
+ 		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, '>', 0, 0, 0, 1) < 0))
++		        (htmlParseLookupSequence(ctxt, ">", 0, 1) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5568,7 +5542,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		if ((cur == '<') && (next == '!') &&
+ 		    (in->cur[2] == '-') && (in->cur[3] == '-')) {
+ 		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, '-', '-', '>', 1, 1) < 0))
++		        (htmlParseLookupSequence(ctxt, "-->", 1, 1) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5578,7 +5552,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		    ctxt->instate = XML_PARSER_PROLOG;
+ 	        } else if ((cur == '<') && (next == '?')) {
+ 		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, '>', 0, 0, 0, 1) < 0))
++		        (htmlParseLookupSequence(ctxt, ">", 0, 1) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5615,7 +5589,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 	        if ((cur == '<') && (next == '!') &&
+ 		    (in->cur[2] == '-') && (in->cur[3] == '-')) {
+ 		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, '-', '-', '>', 1, 1) < 0))
++		        (htmlParseLookupSequence(ctxt, "-->", 1, 1) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5625,7 +5599,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		    ctxt->instate = XML_PARSER_EPILOG;
+ 	        } else if ((cur == '<') && (next == '?')) {
+ 		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, '>', 0, 0, 0, 1) < 0))
++		        (htmlParseLookupSequence(ctxt, ">", 0, 1) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5689,7 +5663,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		    break;
+ 		}
+ 		if ((!terminate) &&
+-		    (htmlParseLookupSequence(ctxt, '>', 0, 0, 0, 1) < 0))
++		    (htmlParseLookupSequence(ctxt, ">", 0, 1) < 0))
+ 		    goto done;
+ 
+                 /* Capture start position */
+@@ -5836,7 +5810,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		        int idx;
+ 			xmlChar val;
+ 
+-			idx = htmlParseLookupSequence(ctxt, '<', '/', 0, 0, 0);
++			idx = htmlParseLookupSequence(ctxt, "</", 0, 0);
+ 			if (idx < 0)
+ 			    goto done;
+ 		        val = in->cur[idx + 2];
+@@ -5863,7 +5837,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 			(UPP(6) == 'Y') && (UPP(7) == 'P') &&
+ 			(UPP(8) == 'E')) {
+ 			if ((!terminate) &&
+-			    (htmlParseLookupSequence(ctxt, '>', 0, 0, 0, 1) < 0))
++			    (htmlParseLookupSequence(ctxt, ">", 0, 1) < 0))
+ 			    goto done;
+ 			htmlParseErr(ctxt, XML_HTML_STRUCURE_ERROR,
+ 			             "Misplaced DOCTYPE declaration\n",
+@@ -5872,8 +5846,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		    } else if ((cur == '<') && (next == '!') &&
+ 			(in->cur[2] == '-') && (in->cur[3] == '-')) {
+ 			if ((!terminate) &&
+-			    (htmlParseLookupSequence(
+-				ctxt, '-', '-', '>', 1, 1) < 0))
++			    (htmlParseLookupSequence(ctxt, "-->", 1, 1) < 0))
+ 			    goto done;
+ #ifdef DEBUG_PUSH
+ 			xmlGenericError(xmlGenericErrorContext,
+@@ -5883,7 +5856,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 			ctxt->instate = XML_PARSER_CONTENT;
+ 		    } else if ((cur == '<') && (next == '?')) {
+ 			if ((!terminate) &&
+-			    (htmlParseLookupSequence(ctxt, '>', 0, 0, 0, 1) < 0))
++			    (htmlParseLookupSequence(ctxt, ">", 0, 1) < 0))
+ 			    goto done;
+ #ifdef DEBUG_PUSH
+ 			xmlGenericError(xmlGenericErrorContext,
+@@ -5954,7 +5927,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		if (avail < 2)
+ 		    goto done;
+ 		if ((!terminate) &&
+-		    (htmlParseLookupSequence(ctxt, '>', 0, 0, 0, 1) < 0))
++		    (htmlParseLookupSequence(ctxt, ">", 0, 1) < 0))
+ 		    goto done;
+ 		htmlParseEndTag(ctxt);
+ 		if (ctxt->nameNr == 0) {
+-- 
+2.25.1
+

--- a/patches/libxml2/0008-use-new-htmlParseLookupCommentEnd-to-find-comment-en.patch
+++ b/patches/libxml2/0008-use-new-htmlParseLookupCommentEnd-to-find-comment-en.patch
@@ -1,0 +1,97 @@
+From 91dfae053744c33280f0d3567034c17c2f4cf0db Mon Sep 17 00:00:00 2001
+From: Mike Dalessio <mike.dalessio@gmail.com>
+Date: Sun, 11 Oct 2020 14:15:37 -0400
+Subject: [PATCH 2/2] use new htmlParseLookupCommentEnd to find comment ends
+
+See guidance provided on incorrectly-closed comments here:
+
+https://html.spec.whatwg.org/multipage/parsing.html#parse-error-incorrectly-closed-comment
+---
+ HTMLparser.c | 43 +++++++++++++++++++++++++++++++++++--------
+ 1 file changed, 35 insertions(+), 8 deletions(-)
+
+diff --git a/HTMLparser.c b/HTMLparser.c
+index 123dff5..269f015 100644
+--- a/HTMLparser.c
++++ b/HTMLparser.c
+@@ -5305,6 +5305,37 @@ htmlParseLookupChars(htmlParserCtxtPtr ctxt, const xmlChar * stop,
+     return (-1);
+ }
+ 
++/**
++ * htmlParseLookupCommentEnd:
++ * @ctxt: an HTML parser context
++ *
++ * Try to find a comment end tag in the input stream
++ * The search includes "-->" as well as WHATWG-recommended incorrectly-closed tags.
++ * (See https://html.spec.whatwg.org/multipage/parsing.html#parse-error-incorrectly-closed-comment)
++ * This function has a side effect of (possibly) incrementing ctxt->checkIndex
++ * to avoid rescanning sequences of bytes, it DOES change the state of the
++ * parser, do not use liberally.
++ * This wraps to htmlParseLookupSequence()
++ *
++ * Returns the index to the current parsing point if the full sequence is available, -1 otherwise.
++ */
++static int
++htmlParseLookupCommentEnd(htmlParserCtxtPtr ctxt)
++{
++    int save_checkindex = ctxt->checkIndex;
++    int loc;
++
++    loc = htmlParseLookupSequence(ctxt, "-->", 1, 1);
++    if (loc >= 0) {
++        return loc;
++    }
++
++    ctxt->checkIndex = save_checkindex;
++    loc = htmlParseLookupSequence(ctxt, "--!>", 1, 1);
++    return loc;
++}
++
++
+ /**
+  * htmlParseTryOrFinish:
+  * @ctxt:  an HTML parser context
+@@ -5481,8 +5512,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		cur = in->cur[0];
+ 	        if ((cur == '<') && (next == '!') &&
+ 		    (in->cur[2] == '-') && (in->cur[3] == '-')) {
+-		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, "-->", 1, 1) < 0))
++		    if ((!terminate) && (htmlParseLookupCommentEnd(ctxt) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5541,8 +5571,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		next = in->cur[1];
+ 		if ((cur == '<') && (next == '!') &&
+ 		    (in->cur[2] == '-') && (in->cur[3] == '-')) {
+-		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, "-->", 1, 1) < 0))
++		    if ((!terminate) && (htmlParseLookupCommentEnd(ctxt) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5588,8 +5617,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 		next = in->cur[1];
+ 	        if ((cur == '<') && (next == '!') &&
+ 		    (in->cur[2] == '-') && (in->cur[3] == '-')) {
+-		    if ((!terminate) &&
+-		        (htmlParseLookupSequence(ctxt, "-->", 1, 1) < 0))
++		    if ((!terminate) && (htmlParseLookupCommentEnd(ctxt) < 0))
+ 			goto done;
+ #ifdef DEBUG_PUSH
+ 		    xmlGenericError(xmlGenericErrorContext,
+@@ -5845,8 +5873,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
+ 			htmlParseDocTypeDecl(ctxt);
+ 		    } else if ((cur == '<') && (next == '!') &&
+ 			(in->cur[2] == '-') && (in->cur[3] == '-')) {
+-			if ((!terminate) &&
+-			    (htmlParseLookupSequence(ctxt, "-->", 1, 1) < 0))
++			if ((!terminate) && (htmlParseLookupCommentEnd(ctxt) < 0))
+ 			    goto done;
+ #ifdef DEBUG_PUSH
+ 			xmlGenericError(xmlGenericErrorContext,
+-- 
+2.25.1
+

--- a/test/html/test_comments.rb
+++ b/test/html/test_comments.rb
@@ -1,0 +1,185 @@
+require "helper"
+
+module Nokogiri
+  module HTML
+    # testing error edge cases of HTML comments from the living WHATWG spec
+    # as of 2020-08-03
+    # https://html.spec.whatwg.org/multipage/parsing.html
+    class TestComment < Nokogiri::TestCase
+      # https://html.spec.whatwg.org/multipage/parsing.html#parse-error-abrupt-closing-of-empty-comment
+      #
+      # This error occurs if the parser encounters an empty comment
+      # that is abruptly closed by a U+003E (>) code point (i.e.,
+      # <!--> or <!--->). The parser behaves as if the comment is
+      # closed correctly.
+      describe "abrupt closing of empty comment" do
+        let(:doc) { Nokogiri::HTML(html) }
+        let(:subject) { doc.at_css("div#under-test") }
+        let(:other_div) { doc.at_css("div#also-here") }
+
+        describe "two dashes" do
+          let(:html) { "<html><body><div id=under-test><!--></div><div id=also-here></div></body></html>" }
+
+          if Nokogiri.uses_libxml?
+            it "behaves as if the comment is unterminated and doesn't exist" do # NON-COMPLIANT
+              assert_equal 0, subject.children.length
+              assert_equal 1, doc.errors.length
+              assert_match(/Comment not terminated/, doc.errors.first.to_s)
+              assert !other_div
+            end
+          end
+
+          if Nokogiri.jruby?
+            it "behaves as if the comment is closed correctly" do # COMPLIANT
+              assert_equal 1, subject.children.length
+              assert subject.children.first.comment?
+              assert_equal "", subject.children.first.content
+              assert other_div
+            end
+          end
+        end
+
+        describe "three dashes" do
+          let(:html) { "<html><body><div id=under-test><!---></div><div id=also-here></div></body></html>" }
+
+          if Nokogiri.uses_libxml?
+            it "behaves as if the comment is unterminated and doesn't exist" do # NON-COMPLIANT
+              assert_equal 0, subject.children.length
+              assert_equal 1, doc.errors.length
+              assert_match(/Comment not terminated/, doc.errors.first.to_s)
+              assert !other_div
+            end
+          end
+
+          if Nokogiri.jruby?
+            it "behaves as if the comment is closed correctly" do # COMPLIANT
+              assert_equal 1, subject.children.length
+              assert subject.children.first.comment?
+              assert_equal "-", subject.children.first.content # curious
+              assert other_div
+            end
+          end
+        end
+
+        describe "four dashes" do
+          let(:html) { "<html><body><div id=under-test><!----></div><div id=also-here></div></body></html>" }
+
+          it "behaves as if the comment is closed correctly" do # COMPLIANT
+            assert_equal 1, subject.children.length
+            assert subject.children.first.comment?
+            assert_equal "", subject.children.first.content
+            assert other_div
+          end
+        end
+      end
+
+      # https://html.spec.whatwg.org/multipage/parsing.html#parse-error-eof-in-comment
+      #
+      # This error occurs if the parser encounters the end of the
+      # input stream in a comment. The parser treats such comments as
+      # if they are closed immediately before the end of the input
+      # stream.
+      describe "eof in comment" do
+        let(:html) { "<html><body><div id=under-test><!--start of unterminated comment" }
+        let(:doc) { Nokogiri::HTML(html) }
+        let(:subject) { doc.at_css("div#under-test") }
+
+        if Nokogiri.uses_libxml?
+          it "behaves as if the comment is unterminated and doesn't exist" do # NON-COMPLIANT
+            assert_equal 0, subject.children.length
+            assert_equal 1, doc.errors.length
+            assert_match(/Comment not terminated/, doc.errors.first.to_s)
+          end
+        end
+
+        if Nokogiri.jruby?
+          it "behaves as if the comment is closed immediately before the end of the input stream" do # COMPLIANT
+            assert_equal 1, subject.children.length
+            assert subject.children.first.comment?
+            assert_equal "start of unterminated comment", subject.children.first.content
+          end
+        end
+      end
+
+      # https://html.spec.whatwg.org/multipage/parsing.html#parse-error-incorrectly-closed-comment
+      #
+      # This error occurs if the parser encounters a comment that is
+      # closed by the "--!>" code point sequence. The parser treats
+      # such comments as if they are correctly closed by the "-->"
+      # code point sequence.
+      describe "incorrectly closed comment" do
+        let(:html) { "<html><body><div id=under-test><!--foo--!><div id=do-i-exist></div><!--bar--></div></body></html>" }
+        let(:doc) { Nokogiri::HTML(html) }
+        let(:subject) { doc.at_css("div#under-test") }
+        let(:inner_div) { doc.at_css("div#do-i-exist") }
+
+        it "behaves as if the comment encompasses the inner div" do # NON-COMPLIANT
+          assert_equal 1, subject.children.length
+          assert subject.children.first.comment?
+          assert !inner_div
+          assert_match(/id=do-i-exist/, subject.children.first.content)
+          assert_equal 0, doc.errors.length
+        end
+      end
+
+      # https://html.spec.whatwg.org/multipage/parsing.html#parse-error-incorrectly-opened-comment
+      #
+      # This error occurs if the parser encounters the "<!" code point
+      # sequence that is not immidiately followed by two U+002D (-)
+      # code points and that is not the start of a DOCTYPE or a CDATA
+      # section. All content that follows the "<!" code point sequence
+      # up to a U+003E (>) code point (if present) or to the end of
+      # the input stream is treated as a comment.
+      describe "incorrectly opened comment" do
+        let(:html) { "<html><body><div id=under-test><! comment <div id=do-i-exist>inner content</div>-->hello</div></body></html>" }
+
+        let(:doc) { Nokogiri::HTML(html) }
+        let(:body) { doc.at_css("body") }
+        let(:subject) { doc.at_css("div#under-test") }
+
+        if Nokogiri.uses_libxml?
+          it "ignores up to the next '>'" do # NON-COMPLIANT
+            assert_equal 2, body.children.length
+            assert_equal body.children[0], subject
+            assert_equal 1, subject.children.length
+            assert subject.children[0].text?
+            assert_equal "inner content", subject.children[0].content
+            assert body.children[1].text?
+            assert_equal "-->hello", body.children[1].content
+          end
+        end
+
+        if Nokogiri.jruby?
+          it "ignores up to the next '-->'" do # NON-COMPLIANT
+            assert_equal 1, subject.children.length
+            assert subject.children[0].text?
+            assert_equal "hello", subject.children[0].content
+          end
+        end
+      end
+
+      # https://html.spec.whatwg.org/multipage/parsing.html#parse-error-nested-comment
+      #
+      # This error occurs if the parser encounters a nested comment
+      # (e.g., <!-- <!-- nested --> -->). Such a comment will be
+      # closed by the first occuring "-->" code point sequence and
+      # everything that follows will be treated as markup.
+      describe "nested comment" do
+        let(:html) { "<html><body><div id=under-test><!-- outer <!-- inner --><div id=do-i-exist></div>--></div></body></html>" }
+        let(:doc) { Nokogiri::HTML(html) }
+        let(:subject) { doc.at_css("div#under-test") }
+        let(:inner_div) { doc.at_css("div#do-i-exist") }
+
+        it "ignores to the next '-->'" do # COMPLIANT
+          assert_equal 3, subject.children.length
+          assert subject.children[0].comment?
+          assert_equal " outer <!-- inner ", subject.children[0].content
+          assert inner_div
+          assert_equal inner_div, subject.children[1]
+          assert subject.children[2].text?
+          assert_equal "-->", subject.children[2].content
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This changeset introduces test coverage for both JRuby and CRuby implementations with respect to handling HTML parse errors within comments.

It then introduces a libxml2 patch to comply with the behavior suggested by the [WHATWG "Living Standard" doc](https://html.spec.whatwg.org/multipage/parsing.html#parse-error-incorrectly-closed-comment) with respect to incorrectly-closed comments.

It's important to note that WHATWG's guidance is non-normative, but is what's followed by most popular browsers. Further, the difference in behavior between browsers and server-side sanitization done by a library relying on Nokogiri and libxml2 allows opportunity for XSS attacks (https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A7-Cross-Site_Scripting_(XSS)).