### PR TITLE
Fixes to allow C code to compile with Visual C++ compiler

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -55,7 +55,7 @@ static void dealloc(xmlDocPtr doc)
 
   node_hash  = DOC_UNLINKED_NODE_HASH(doc);
 
-  st_foreach(node_hash, dealloc_node_i, (st_data_t)doc);
+  st_foreach(node_hash, (int(*)(st_data_t, st_data_t, st_data_t))dealloc_node_i, (st_data_t)doc);
   st_free_table(node_hash);
 
   free(doc->_private);

--- a/ext/nokogiri/xml_io.c
+++ b/ext/nokogiri/xml_io.c
@@ -17,7 +17,7 @@ int io_read_callback(void * ctx, char * buffer, int len) {
   args[0] = (VALUE)ctx;
   args[1] = INT2NUM(len);
 
-  string = rb_rescue(read_check, (VALUE)args, read_failed, 0);
+  string = rb_rescue((VALUE(*)(VALUE))read_check, (VALUE)args, (VALUE(*)(VALUE,VALUE))read_failed, 0);
 
   if (NIL_P(string)) return 0;
   if (string == Qundef) return -1;
@@ -44,7 +44,7 @@ int io_write_callback(void * ctx, char * buffer, int len) {
   args[0] = (VALUE)ctx;
   args[1] = rb_str_new(buffer, (long)len);
 
-  size = rb_rescue(write_check, (VALUE)args, write_failed, 0);
+  size = rb_rescue((VALUE(*)(VALUE))write_check, (VALUE)args, (VALUE(*)(VALUE,VALUE))write_failed, 0);
 
   if (size == Qundef) return -1;
 


### PR DESCRIPTION
---

Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the questions below when you submit this pull request.

The Nokogiri core team work off of `master`, so please submit all PRs based on the `master` branch. We generally will cherry-pick relevant bug fixes onto the current release branch.


**What problem is this PR intended to solve?**

This allows the C code to compile when compiling with the C compiler from Microsoft Visual Studio (Microsoft (R) C/C++ Optimizing Compiler Version 19.26.28805 for x64).

This is relevant because if you compile Ruby with that compiler, that would be the compiler you use for compiling native extensions.

Related to #2015.


**Have you included adequate test coverage?**

These changes are not intended to cause any changes in behavior.


**Does this change affect the C or the Java implementations?**

These changes are only relevant to the C implementation.