### PR TITLE
Fix gcc warings - alternative to #2061

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -1,6 +1,6 @@
 #include <xml_document.h>
 
-static int dealloc_node_i(xmlNodePtr key, xmlNodePtr node, xmlDocPtr doc)
+static int dealloc_node_i2(xmlNodePtr key, xmlNodePtr node, xmlDocPtr doc)
 {
   switch(node->type) {
   case XML_ATTRIBUTE_NODE:
@@ -18,6 +18,11 @@ static int dealloc_node_i(xmlNodePtr key, xmlNodePtr node, xmlDocPtr doc)
     }
   }
   return ST_CONTINUE;
+}
+
+static int dealloc_node_i(st_data_t key, st_data_t node, st_data_t doc)
+{
+  return dealloc_node_i2((xmlNodePtr)key, (xmlNodePtr)node, (xmlDocPtr)doc);
 }
 
 static void remove_private(xmlNodePtr node)

--- a/ext/nokogiri/xml_io.c
+++ b/ext/nokogiri/xml_io.c
@@ -2,12 +2,13 @@
 
 static ID id_read, id_write;
 
-VALUE read_check(VALUE *args) {
+VALUE read_check(VALUE val) {
+  VALUE *args = (VALUE *)val;
   return rb_funcall(args[0], id_read, 1, args[1]);
 }
 
-VALUE read_failed(void) {
-	return Qundef;
+VALUE read_failed(VALUE arg, VALUE exc) {
+  return Qundef;
 }
 
 int io_read_callback(void * ctx, char * buffer, int len) {
@@ -30,12 +31,13 @@ int io_read_callback(void * ctx, char * buffer, int len) {
   return (int)safe_len;
 }
 
-VALUE write_check(VALUE *args) {
+VALUE write_check(VALUE val) {
+  VALUE *args = (VALUE *)val;
   return rb_funcall(args[0], id_write, 1, args[1]);
 }
 
-VALUE write_failed(void) {
-	return Qundef;
+VALUE write_failed(VALUE arg, VALUE exc) {
+  return Qundef;
 }
 
 int io_write_callback(void * ctx, char * buffer, int len) {


### PR DESCRIPTION
**What problem is this PR intended to solve?**

GCC raises warnings for the function pointer mismatches and Visual-C raises errors in #2061 . Both should be fixed by this patch. In contrast to #2061 this patch ensures type safety for the single values to be passed to the callback.

**Have you included adequate test coverage?**

Visual-C is not tested.

**Does this change affect the C or the Java implementations?**

Only C.