### PR TITLE
Issue reproduction for ISO-8859-1 parsing on JRuby

### DIFF
--- a/test/files/iso-8859-1.xml
+++ b/test/files/iso-8859-1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<FEED>
+  <DATA>Accepté</DATA>
+  <DATA>Something</DATA>
+</FEED>

--- a/test/test_iso.rb
+++ b/test/test_iso.rb
@@ -1,0 +1,15 @@
+require "helper"
+
+class TestISO < Nokogiri::TestCase
+  def test_iso_content_not_lacking_accents
+    data = IO.binread('test/files/iso-8859-1.xml')
+    document = Nokogiri::XML(data)
+    assert_equal "Accepté", document.at('DATA').text
+  end
+
+  def test_iso_content_not_truncated
+    data = IO.binread('test/files/iso-8859-1.xml')
+    document = Nokogiri::XML(data)
+    assert_equal 2, document.search('DATA').count
+  end
+end


### PR DESCRIPTION
As commented in [this discussion](https://github.com/sparklemotion/nokogiri/issues/2075#issuecomment-688985289), I've experienced regressions while parsing ISO-8859-1 documents under JRuby, with the recent release candidates (`1.11.0.rc1`, `1.11.0.rc2`, `1.11.0.rc3`), something which did not happen with `1.10.10`.

I'm creating this first PR as an attempt to show the reproduction to Nokogiri maintainers (hopefully the build will fail, but we'll see!).

I will try to come back with a `git bisect` test later to isolate the commit which introduced this change.