### PR TITLE
Fix the tests in #2080

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ This release ends support for:
 * [CRuby] Fixed installation on AIX with respect to `vasprintf`. [[#1908](https://github.com/sparklemotion/nokogiri/issues/1908)]
 * [JRuby] Standardize reading from IO like objects, including StringIO. [[#1888](https://github.com/sparklemotion/nokogiri/issues/1888), [#1897](https://github.com/sparklemotion/nokogiri/issues/1897)]
 * [Windows Visual C++] Fixed compiler warnings and errors. [[#2061](https://github.com/sparklemotion/nokogiri/issues/2061), [#2068](https://github.com/sparklemotion/nokogiri/issues/2068)]
+* [JRuby] Fixed document encoding regression in v1.11.0 release candidates. [[#2080](https://github.com/sparklemotion/nokogiri/issues/2080), [#2083](https://github.com/sparklemotion/nokogiri/issues/2083)] (Thanks, [@thbar](https://github.com/thbar)!)
 
 
 ### Removed

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -759,15 +759,13 @@ public class XmlNode extends RubyObject {
             klass = getNokogiriClass(runtime, "Nokogiri::HTML::Document");
             ctx = new HtmlDomParserContext(runtime, options);
             ((HtmlDomParserContext) ctx).enableDocumentFragment();
-            istream = new ByteArrayInputStream((rubyStringToString(str)).getBytes());
+            ctx.setStringInputSource(context, str, context.nil);
         } else {
             klass = getNokogiriClass(runtime, "Nokogiri::XML::Document");
             ctx = new XmlDomParserContext(runtime, options);
-            String input = rubyStringToString(str);
-            istream = new ByteArrayInputStream(input.getBytes());
+            ctx.setStringInputSource(context, str, context.nil);
         }
 
-        ctx.setInputSource(istream);
         // TODO: for some reason, document.getEncoding() can be null or nil (don't know why)
         // run `test_parse_with_unparented_html_text_context_node' few times to see this happen
         if (document instanceof HtmlDocument && !(document.getEncoding() == null || document.getEncoding().isNil())) {

--- a/ext/java/nokogiri/internals/HtmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/HtmlDomParserContext.java
@@ -66,11 +66,12 @@ import org.w3c.dom.NodeList;
 public class HtmlDomParserContext extends XmlDomParserContext {
 
 	public HtmlDomParserContext(Ruby runtime, IRubyObject options) {
-        super(runtime, options);
+        this(runtime, runtime.getNil(), options);
     }
-    
+
     public HtmlDomParserContext(Ruby runtime, IRubyObject encoding, IRubyObject options) {
         super(runtime, encoding, options);
+        java_encoding = NokogiriHelpers.getValidEncoding(encoding);
     }
 
     @Override

--- a/ext/java/nokogiri/internals/XmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/XmlDomParserContext.java
@@ -93,7 +93,7 @@ public class XmlDomParserContext extends ParserContext {
     public XmlDomParserContext(Ruby runtime, IRubyObject encoding, IRubyObject options) {
         super(runtime);
         this.options = new ParserContext.Options(RubyFixnum.fix2long(options));
-        java_encoding = NokogiriHelpers.getValidEncoding(encoding);
+        java_encoding = NokogiriHelpers.getValidEncodingOrNull(encoding);
         ruby_encoding = encoding;
         initErrorHandler();
         initParser(runtime);

--- a/test/files/iso-8859-1.xml
+++ b/test/files/iso-8859-1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<FEED>
+  <DATA>Accepté</DATA>
+  <DATA>Something</DATA>
+</FEED>

--- a/test/test_iso.rb
+++ b/test/test_iso.rb
@@ -1,0 +1,15 @@
+require "helper"
+
+class TestISO < Nokogiri::TestCase
+  def test_iso_content_not_lacking_accents
+    data = IO.binread('test/files/iso-8859-1.xml')
+    document = Nokogiri::XML(data)
+    assert_equal "Accepté", document.at('DATA').text
+  end
+
+  def test_iso_content_not_truncated
+    data = IO.binread('test/files/iso-8859-1.xml')
+    document = Nokogiri::XML(data)
+    assert_equal 2, document.search('DATA').count
+  end
+end


### PR DESCRIPTION
This PR introduces three new commits on top of #2080/386ebcb5 in which @thbar adds tests showing a JRuby regression when parsing ISO-8859-1 content.