### PR TITLE
Add a note that NOKOGIRI_USE_SYSTEM_LIBRARIES is used by TruffleRuby

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -382,6 +382,7 @@ def lib_a(ldflag)
 end
 
 def using_system_libraries?
+  # NOTE: TruffleRuby uses this env var as it does not support using static libraries yet.
   arg_config('--use-system-libraries', !!ENV['NOKOGIRI_USE_SYSTEM_LIBRARIES'])
 end
 


### PR DESCRIPTION
See https://github.com/oracle/truffleruby/blob/d0c380361d65fd9cc89f98efdf7c7f956f073720/lib/mri/mkmf.rb#L52-L54

I'll add a note in the TruffleRuby code that once we solve this we can remove the comment here too.

It's not so trivial to solve, so I think it's worthwhile adding a comment here.

Potentially compiling libxml2 with the GraalVM LLVM toolchain might allow using static libraries, but that would then mean running all of libxml2 in Sulong (instead of precompiled native code) which needs to be evaluated if it works and if it's fast.