### PR TITLE
Reduce allocations from hack in document_fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ### Improved
 
+* Reduce the number of object allocations needed when parsing an HTML::DocumentFragment. [[#2087](https://github.com/sparklemotion/nokogiri/issues/2087)] (Thanks, [@ashmaroli](https://github.com/ashmaroli)!)
 * [JRuby] Update the algorithm used to calculate `Node#line` to be wrong less-often. The underlying parser, Xerces, does not track line numbers, and so we've always used a hacky solution for this method. [[#1223](https://github.com/sparklemotion/nokogiri/issues/1223)]
 
 

--- a/lib/nokogiri/html/document_fragment.rb
+++ b/lib/nokogiri/html/document_fragment.rb
@@ -33,7 +33,7 @@ module Nokogiri
           self.errors = document.errors - preexisting_errors
         else
           # This is a horrible hack, but I don't care
-          if tags.strip =~ /^<body/i
+          if /^\s*?<body/i.match?(tags)
             path = "/html/body"
           else
             path = "/html/body/node()"

--- a/lib/nokogiri/html/document_fragment.rb
+++ b/lib/nokogiri/html/document_fragment.rb
@@ -4,26 +4,26 @@ module Nokogiri
     class DocumentFragment < Nokogiri::XML::DocumentFragment
       ####
       # Create a Nokogiri::XML::DocumentFragment from +tags+, using +encoding+
-      def self.parse tags, encoding = nil
+      def self.parse(tags, encoding = nil)
         doc = HTML::Document.new
 
         encoding ||= if tags.respond_to?(:encoding)
-                       encoding = tags.encoding
-                       if encoding == ::Encoding::ASCII_8BIT
-                         'UTF-8'
-                       else
-                         encoding.name
-                       end
-                     else
-                       'UTF-8'
-                     end
+          encoding = tags.encoding
+          if encoding == ::Encoding::ASCII_8BIT
+            'UTF-8'
+          else
+            encoding.name
+          end
+        else
+          'UTF-8'
+        end
 
         doc.encoding = encoding
 
         new(doc, tags)
       end
 
-      def initialize document, tags = nil, ctx = nil
+      def initialize(document, tags = nil, ctx = nil)
         return self unless tags
 
         if ctx
@@ -33,13 +33,13 @@ module Nokogiri
           self.errors = document.errors - preexisting_errors
         else
           # This is a horrible hack, but I don't care
-          if /^\s*?<body/i.match?(tags)
-            path = "/html/body"
+          path = if /^\s*?<body/i.match?(tags)
+            "/html/body"
           else
-            path = "/html/body/node()"
+            "/html/body/node()"
           end
 
-          temp_doc = HTML::Document.parse "<html><body>#{tags}", nil, document.encoding
+          temp_doc = HTML::Document.parse("<html><body>#{tags}", nil, document.encoding)
           temp_doc.xpath(path).each { |child| child.parent = self }
           self.errors = temp_doc.errors
         end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Reduce object allocations from a hack in the constructor of `Nokogiri::HTML::DocumentFragment`.

Nokogiri 1.11 requires at least Ruby 2.4.0. Therefore, we can safely use `Regexp#match?` instead of `String#=~`.
The advantages are:
- `Regexp#match?` doesn't allocate `MatchData` objects.
- Modifying the regex itself allows not using `String#strip` which duplicates the given string.

**Have you included adequate test coverage?**

This change should be covered by existing tests.

**Does this change affect the C or the Java implementations?**

No, it doesn't.
