### PR TITLE
Compile native extensions with '-O2 -g' flags

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -294,7 +294,7 @@ def process_recipe(name, version, static_p, cross_p)
         "--disable-shared",
         "--enable-static",
       ]
-      env['CFLAGS'] = "-fPIC -O2 -g #{env['CFLAGS']}"
+      env['CFLAGS'] = "-fPIC -O2 -U_FORTIFY_SOURCE -g #{env['CFLAGS']}"
     else
       recipe.configure_options += [
         "--enable-shared",

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -294,7 +294,7 @@ def process_recipe(name, version, static_p, cross_p)
         "--disable-shared",
         "--enable-static",
       ]
-      env['CFLAGS'] = "-fPIC #{env['CFLAGS']}"
+      env['CFLAGS'] = "-fPIC -O2 -g #{env['CFLAGS']}"
     else
       recipe.configure_options += [
         "--enable-shared",
@@ -540,7 +540,6 @@ else
           }]
         recipe.configure_options += [
           "CPPFLAGS=-Wall",
-          "CFLAGS=-O2 -g",
           "CXXFLAGS=-O2 -g",
           "LDFLAGS="
         ]


### PR DESCRIPTION
Resolves #2022.

In my case parsing of a big HTML file decreased from 1.1 seconds to 210 ms.

@flavorjones Regarding the final challenge, I haven't cleaned up `process_recipe` and `configure_options`, but I can try if you add some guidance or vision of the result.

And thanks for the detailed issue description. It was pretty straightforward to make this change.