### PR TITLE
Add explicit Racc depenency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ This release ends support for:
 
 #### Gems
 
+* Explicitly add racc as a runtime dependency. [[#1988](https://github.com/sparklemotion/nokogiri/issues/1988)] (Thanks, [@voxik](https://github.com/voxik)!)
 * [MRI] Upgrade mini_portile2 dependency from `~> 2.4.0` to `~> 2.5.0` [[#2005](https://github.com/sparklemotion/nokogiri/issues/2005)] (Thanks, [@alejandroperea](https://github.com/alejandroperea)!)
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@
 
 source "https://rubygems.org/"
 
+gem "racc", "~>1.4"
 gem "mini_portile2", "~>2.5.0"
 
 gem "concourse", "~>0.38", :group => [:development, :test]
@@ -14,7 +15,6 @@ gem "hoe-gemspec", "~>1.0", :group => [:development, :test]
 gem "hoe-git", "~>1.6", :group => [:development, :test]
 gem "hoe-markdown", "~>1.1", :group => [:development, :test]
 gem "minitest", "~>5.8", :group => [:development, :test]
-gem "racc", "~>1.5.0", :group => [:development, :test]
 gem "rake", "~>13.0", :group => [:development, :test]
 gem "rake-compiler", "~>1.1", :group => [:development, :test]
 gem "rake-compiler-dock", "~>1.0", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,10 @@ HOE = Hoe.spec "nokogiri" do |hoe|
   ]
   hoe.clean_globs += Dir.glob("ports/*").reject { |d| d =~ %r{/archives$} }
 
+  hoe.extra_deps += [
+    ["racc", "~> 1.4"],
+  ]
+
   unless java?
     hoe.extra_deps += [
       ["mini_portile2", "~> 2.5.0"], # keep version in sync with extconf.rb
@@ -56,7 +60,6 @@ HOE = Hoe.spec "nokogiri" do |hoe|
     ["hoe-git", "~> 1.6"],
     ["hoe-markdown", "~> 1.1"],
     ["minitest", "~> 5.8"],
-    ["racc", "~> 1.5.0"],
     ["rake", "~> 13.0"],
     ["rake-compiler", "~> 1.1"],
     ["rake-compiler-dock", "~> 1.0"],


### PR DESCRIPTION
Nokogiri always have had dependency on Racc, but it was never stated explicitly. This is possible issue for several reasons:

1) There is no way RubyGems/Bundler could avoid loading wrong version of Racc if other package in application specifies different version of Racc then Nokogiri needs.
2) If there is released incompatible Racc 2.x, all old versions of Nokogiri will be broken just because it does not specify its dependencies properly.
3) If Ruby decides to drop Racc from StdLib, all Nokogiri versions will be broken (unnoticeably). Or Ruby will be forced to carry Racc around around although it is possibly obsolete.

Fixes #1988
