### PR TITLE
fix: avoid collision with glibc's canonicalize() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ This release ends support for:
 
 * The switch to turn off the CSS-to-XPath cache is now thread-local, rather than being shared mutable state. [[#1935](https://github.com/sparklemotion/nokogiri/issues/1935)]
 * [CRuby] Fixed installation on AIX with respect to `vasprintf`. [[#1908](https://github.com/sparklemotion/nokogiri/issues/1908)]
+* [CRuby] On some platforms, avoid symbol name collision with glibc's `canonicalize`. [[#2105](https://github.com/sparklemotion/nokogiri/issues/2105)]
 * [JRuby] Standardize reading from IO like objects, including StringIO. [[#1888](https://github.com/sparklemotion/nokogiri/issues/1888), [#1897](https://github.com/sparklemotion/nokogiri/issues/1897)]
 * [Windows Visual C++] Fixed compiler warnings and errors. [[#2061](https://github.com/sparklemotion/nokogiri/issues/2061), [#2068](https://github.com/sparklemotion/nokogiri/issues/2068)]
 * [JRuby] Fixed document encoding regression in v1.11.0 release candidates. [[#2080](https://github.com/sparklemotion/nokogiri/issues/2080), [#2083](https://github.com/sparklemotion/nokogiri/issues/2083)] (Thanks, [@thbar](https://github.com/thbar)!)

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -506,7 +506,7 @@ static int block_caller(void * ctx, xmlNodePtr _node, xmlNodePtr _parent)
  * The block must return a non-nil, non-false value if the +obj+ passed in
  * should be included in the canonicalized document.
  */
-static VALUE canonicalize(int argc, VALUE* argv, VALUE self)
+static VALUE nokogiri_xml_document_canonicalize(int argc, VALUE* argv, VALUE self)
 {
   VALUE mode;
   VALUE incl_ns;
@@ -587,7 +587,7 @@ void init_xml_document()
   rb_define_method(klass, "encoding", encoding, 0);
   rb_define_method(klass, "encoding=", set_encoding, 1);
   rb_define_method(klass, "version", version, 0);
-  rb_define_method(klass, "canonicalize", canonicalize, -1);
+  rb_define_method(klass, "canonicalize", nokogiri_xml_document_canonicalize, -1);
   rb_define_method(klass, "dup", duplicate_document, -1);
   rb_define_method(klass, "url", url, 0);
   rb_define_method(klass, "create_entity", create_entity, -1);


### PR DESCRIPTION
Closes #2105

---

**What problem is this PR intended to solve?**

#2105 

**Have you included adequate test coverage?**

No functional changes

**Does this change affect the C or the Java implementations?**

Only CRuby
