### PR TITLE
extconf: clean up pkg config logic

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,16 +15,25 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.7'
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
       - name: Set ENV
         run: |
           echo "MAKEFLAGS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
           echo "NOKOGIRI_USE_SYSTEM_LIBRARIES=t" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
+          bundle config --local path vendor/bundle
           bundle config jobs $((1 + $(sysctl -n hw.activecpu)))
           bundle install
-      - run: rake compile
-      - run: rake test
+      - run: bundle exec rake compile
+      - run: bundle exec rake test
+
   cruby-test-vendored-libraries:
     runs-on: macos-latest
     steps:
@@ -32,12 +41,26 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.7'
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - uses: actions/cache@v2
+        with:
+          path: ports/archives
+          key: tarballs-${{ hashFiles('**/dependencies.yml') }}
+          restore-keys: |
+            tarballs-
+
       - name: Set ENV
         run: |
           echo "MAKEFLAGS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
+          bundle config --local path vendor/bundle
           bundle config jobs $((1 + $(sysctl -n hw.activecpu)))
           bundle install
-      - run: rake compile
-      - run: rake test
+      - run: bundle exec rake compile
+      - run: bundle exec rake test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Set ENV
         run: |
           echo "MAKEFLAGS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
-          echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
           echo "NOKOGIRI_USE_SYSTEM_LIBRARIES=t" >> $GITHUB_ENV
       - name: Install dependencies
         run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,15 +23,33 @@ test_script:
 environment:
   matrix:
     - ruby_version: head-x64
+    - ruby_version: head-x64
       INSTALL_PACKAGES: "mingw-w64-x86_64-libxslt"
       EXTCONF_PARAMS: "--use-system-libraries"
+
+    - ruby_version: 27-x64
     - ruby_version: 27-x64
       INSTALL_PACKAGES: "mingw-w64-x86_64-libxslt"
       EXTCONF_PARAMS: "--use-system-libraries"
-    - ruby_version: 26
-    - ruby_version: 25-x64
-    - ruby_version: 24
+
+    - ruby_version: 27
+    - ruby_version: 27
       INSTALL_PACKAGES: "mingw-w64-i686-libxslt"
+      EXTCONF_PARAMS: "--use-system-libraries"
+
+    - ruby_version: 26-x64
+    - ruby_version: 26-x64
+      INSTALL_PACKAGES: "mingw-w64-x86_64-libxslt"
+      EXTCONF_PARAMS: "--use-system-libraries"
+
+    - ruby_version: 25-x64
+    - ruby_version: 25-x64
+      INSTALL_PACKAGES: "mingw-w64-x86_64-libxslt"
+      EXTCONF_PARAMS: "--use-system-libraries"
+
+    - ruby_version: 24-x64
+    - ruby_version: 24-x64
+      INSTALL_PACKAGES: "mingw-w64-x86_64-libxslt"
       EXTCONF_PARAMS: "--use-system-libraries"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,16 @@
 image: Visual Studio 2019
 
+branches:
+  only:
+  - master
+
+skip_branch_with_pr: true
+
 clone_depth: 1
+
+cache:
+  - vendor/bundle
+  - ports/archives
 
 install:
   - SET PATH=C:\ruby%ruby_version%\bin;%PATH%
@@ -12,6 +22,7 @@ install:
   - ruby --version
   - gem --version
   - gem install bundler --conservative
+  - bundle config --local path vendor/bundle
   - bundle install
   - IF DEFINED INSTALL_PACKAGES ( ridk exec pacman --noconfirm --needed --sync %INSTALL_PACKAGES% )
 

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -164,7 +164,7 @@ end
 
 def using_system_libraries?
   # NOTE: TruffleRuby uses this env var as it does not support using static libraries yet.
-  arg_config('--use-system-libraries', !!ENV['NOKOGIRI_USE_SYSTEM_LIBRARIES'])
+  arg_config('--use-system-libraries', ENV.key?("NOKOGIRI_USE_SYSTEM_LIBRARIES"))
 end
 
 def have_libxml_headers?(version=nil)

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -50,9 +50,9 @@ def concat_flags *args
   args.compact.join(" ")
 end
 
-def package_config pkg, options={}
-  # use MakeMakefile#pkg_config, which uses the system utility `pkg-config`.
-  package = pkg_config(pkg)
+def package_config pc_name, options={}
+  # try MakeMakefile#pkg_config, which uses the system utility `pkg-config`.
+  package = pkg_config(pc_name)
   return package if package
 
   # `pkg-config` probably isn't installed, which appears to be the case for lots of freebsd systems.
@@ -64,7 +64,7 @@ def package_config pkg, options={}
     require 'pkg-config' and message("Using pkg-config gem version #{PKGConfig::VERSION}\n")
   rescue LoadError
     message <<~EOM
-      pkg-config could not be used to find #{pkg}
+      pkg-config could not be used to find #{pc_name}
       Please install either `pkg-config` or the pkg-config gem per
 
           gem install pkg-config -v #{REQUIRED_PKG_CONFIG_VERSION}
@@ -73,13 +73,13 @@ def package_config pkg, options={}
     return nil
   end
 
-  return nil unless PKGConfig.have_package(pkg)
+  return nil unless PKGConfig.have_package(pc_name)
 
-  cflags  = PKGConfig.cflags(pkg)
-  ldflags = PKGConfig.libs_only_L(pkg)
-  libs    = PKGConfig.libs_only_l(pkg)
+  cflags  = PKGConfig.cflags(pc_name)
+  ldflags = PKGConfig.libs_only_L(pc_name)
+  libs    = PKGConfig.libs_only_l(pc_name)
 
-  Logging::message "PKGConfig package configuration for %s\n", pkg
+  Logging::message "pkg-config gem found package configuration for %s\n", pc_name
   Logging::message "cflags: %s\nldflags: %s\nlibs: %s\n\n", cflags, ldflags, libs
 
   [cflags, ldflags, libs]

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -93,7 +93,7 @@ ensure
 end
 
 def abort_could_not_find_library(lib)
-  abort "-----\n#{lib} is missing.  Please locate mkmf.log to investigate how it is failing.\n-----"
+  abort "-----\n#{caller[0]}\n#{lib} is missing. Please locate mkmf.log to investigate how it is failing.\n-----"
 end
 
 def chdir_for_build

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -333,29 +333,84 @@ def do_help
   print <<~HELP
     usage: ruby #{$0} [options]
 
-        --disable-clean
-            Do not clean out intermediate files after successful build.
+      Environment variables used:
 
-        --disable-static
-            Do not statically link bundled libraries.
+        NOKOGIRI_USE_SYSTEM_LIBRARIES
+            When set, even if nil or blank, use system libraries instead of building and using the
+            packaged libraries. Equivalent to `--use-system-libraries`.
 
-        --with-iconv-dir=DIR
-            Use the iconv library placed under DIR.
+        CC
+            Use this path to invoke the compiler instead of `RbConfig::CONFIG['CC']`
 
-        --with-zlib-dir=DIR
-            Use the zlib library placed under DIR.
+        CPPFLAGS
+            If this string is accepted by the C preprocessor, add it to the flags passed to the C preprocessor
+
+        CFLAGS
+            If this string is accepted by the compiler, add it to the flags passed to the compiler
+
+        LDFLAGS
+            If this string is accepted by the linker, add it to the flags passed to the linker
+
+        LIBS
+            Add this string to the flags passed to the linker
+
+
+      Flags that are always used:
 
         --use-system-libraries
-            Use system libraries instead of building and using the bundled
-            libraries.
+            Use system libraries instead of building and using the packaged libraries
 
-        --with-xml2-dir=DIR / --with-xml2-config=CONFIG
-        --with-xslt-dir=DIR / --with-xslt-config=CONFIG
-        --with-exslt-dir=DIR / --with-exslt-config=CONFIG
-            Use libxml2/libxslt/libexslt as specified.
+        --with-zlib-dir=DIR
+            Look for zlib header and library in DIRECTORY
+
+        --disable-clean
+            Do not clean out intermediate files after successful build
+
+
+      Flags only used when using system libraries:
+
+        --with-opt-dir=DIRECTORY
+            Look for headers and libraries in DIRECTORY
+
+        --with-iconv-dir=DIRECTORY
+            Look for iconv header and library in DIRECTORY
+
+        --with-xml2-dir=DIRECTORY
+            Look for xml2 headers and library in DIRECTORY
+
+        --with-xml2-lib=DIRECTORY
+            Look for xml2 library in DIRECTORY
+
+        --with-xslt-include=DIRECTORY
+            Look for xslt headers in DIRECTORY
+
+        --with-xslt-dir=DIRECTORY
+            Look for xslt headers and library in DIRECTORY
+
+        --with-xslt-lib=DIRECTORY
+            Look for xslt library in DIRECTORY
+
+        --with-xslt-include=DIRECTORY
+            Look for xslt headers in DIRECTORY
+
+        --with-exslt-dir=DIRECTORY
+            Look for exslt headers and library in DIRECTORY
+
+        --with-exslt-lib=DIRECTORY
+            Look for exslt library in DIRECTORY
+
+        --with-exslt-include=DIRECTORY
+            Look for exslt headers in DIRECTORY
+
+
+      Flags only used when building and using the packaged libraries:
+
+        --disable-static
+            Do not statically link packaged libraries, instead use shared libraries
 
         --enable-cross-build
-            Do cross-build.
+            Enable cross-build mode. (You probably do not want to set this manually.)
+
   HELP
   exit! 0
 end
@@ -426,8 +481,8 @@ if using_system_libraries? && darwin? && Dir.exist?(macos_mojave_sdk_include_pat
   append_cppflags("-I#{macos_mojave_sdk_include_path}")
 end
 
-# Work around a character escaping bug in MSYS by passing an arbitrary
-# double quoted parameter to gcc. See https://sourceforge.net/p/mingw/bugs/2142
+# Work around a character escaping bug in MSYS by passing an arbitrary double-quoted parameter to gcc.
+# See https://sourceforge.net/p/mingw/bugs/2142
 append_cppflags(' "-Idummypath"') if windows?
 
 if using_system_libraries?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,7 @@ require 'minitest/pride'
 require 'fileutils'
 require 'tempfile'
 require 'pp'
+require 'yaml'
 
 require 'nokogiri'
 
@@ -26,7 +27,8 @@ if ENV['TEST_NOKOGIRI_WITH_LIBXML_RUBY']
   warn "#{__FILE__}:#{__LINE__}: loaded libxml-ruby '#{LibXML::XML::VERSION}'"
 end
 
-warn "#{__FILE__}:#{__LINE__}: version info: #{Nokogiri::VERSION_INFO.inspect}"
+warn "#{__FILE__}:#{__LINE__}: version info:"
+warn Nokogiri::VERSION_INFO.to_yaml
 
 module Nokogiri
   class TestCase < MiniTest::Spec


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Part of continuing work to simplify extconf.rb

**Have you included adequate test coverage?**

Test coverage of extconf.rb is still inadequate in my mind, but this doesn't make the problem worse, and in fact adds two flags to test variations of pkg-config.

**Does this change affect the C or the Java implementations?**

Only the compilation/installation of C extensions. No functional change outside that.