### PR TITLE
chore: update depend file and provide a rake task to regenerate it

### DIFF
--- a/ext/nokogiri/depend
+++ b/ext/nokogiri/depend
@@ -1,358 +1,1155 @@
-html_document.o: html_document.c html_document.h nokogiri.h xml_io.h	\
-  xml_document.h html_entity_lookup.h xml_node.h xml_text.h		\
-  xml_cdata.h xml_attr.h xml_processing_instruction.h			\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h xml_relax_ng.h			\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+html_document.o: ./html_document.h \
+                 ./html_element_description.h \
+                 ./html_entity_lookup.h \
+                 ./html_sax_parser_context.h \
+                 ./html_sax_push_parser.h \
+                 ./nokogiri.h \
+                 ./xml_attr.h \
+                 ./xml_attribute_decl.h \
+                 ./xml_cdata.h \
+                 ./xml_comment.h \
+                 ./xml_document.h \
+                 ./xml_document_fragment.h \
+                 ./xml_dtd.h \
+                 ./xml_element_content.h \
+                 ./xml_element_decl.h \
+                 ./xml_encoding_handler.h \
+                 ./xml_entity_decl.h \
+                 ./xml_entity_reference.h \
+                 ./xml_io.h \
+                 ./xml_libxml2_hacks.h \
+                 ./xml_namespace.h \
+                 ./xml_node.h \
+                 ./xml_node_set.h \
+                 ./xml_processing_instruction.h \
+                 ./xml_reader.h \
+                 ./xml_relax_ng.h \
+                 ./xml_sax_parser.h \
+                 ./xml_sax_parser_context.h \
+                 ./xml_sax_push_parser.h \
+                 ./xml_schema.h \
+                 ./xml_syntax_error.h \
+                 ./xml_text.h \
+                 ./xml_xpath_context.h \
+                 ./xslt_stylesheet.h
 
-html_element_description.o: html_element_description.c			\
- html_element_description.h nokogiri.h xml_io.h xml_document.h		\
- html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
- xml_cdata.h xml_attr.h xml_processing_instruction.h			\
- xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
- xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
- xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
- xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
- xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
- xml_syntax_error.h xml_schema.h xml_relax_ng.h xml_namespace.h		\
- xml_encoding_handler.h
+html_element_description.o: ./html_document.h \
+                            ./html_element_description.h \
+                            ./html_entity_lookup.h \
+                            ./html_sax_parser_context.h \
+                            ./html_sax_push_parser.h \
+                            ./nokogiri.h \
+                            ./xml_attr.h \
+                            ./xml_attribute_decl.h \
+                            ./xml_cdata.h \
+                            ./xml_comment.h \
+                            ./xml_document.h \
+                            ./xml_document_fragment.h \
+                            ./xml_dtd.h \
+                            ./xml_element_content.h \
+                            ./xml_element_decl.h \
+                            ./xml_encoding_handler.h \
+                            ./xml_entity_decl.h \
+                            ./xml_entity_reference.h \
+                            ./xml_io.h \
+                            ./xml_libxml2_hacks.h \
+                            ./xml_namespace.h \
+                            ./xml_node.h \
+                            ./xml_node_set.h \
+                            ./xml_processing_instruction.h \
+                            ./xml_reader.h \
+                            ./xml_relax_ng.h \
+                            ./xml_sax_parser.h \
+                            ./xml_sax_parser_context.h \
+                            ./xml_sax_push_parser.h \
+                            ./xml_schema.h \
+                            ./xml_syntax_error.h \
+                            ./xml_text.h \
+                            ./xml_xpath_context.h \
+                            ./xslt_stylesheet.h
 
-html_entity_lookup.o: html_entity_lookup.c html_entity_lookup.h		\
-  nokogiri.h xml_io.h xml_document.h html_document.h xml_node.h		\
-  xml_text.h xml_cdata.h xml_attr.h xml_processing_instruction.h	\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h xml_relax_ng.h			\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+html_entity_lookup.o: ./html_document.h \
+                      ./html_element_description.h \
+                      ./html_entity_lookup.h \
+                      ./html_sax_parser_context.h \
+                      ./html_sax_push_parser.h \
+                      ./nokogiri.h \
+                      ./xml_attr.h \
+                      ./xml_attribute_decl.h \
+                      ./xml_cdata.h \
+                      ./xml_comment.h \
+                      ./xml_document.h \
+                      ./xml_document_fragment.h \
+                      ./xml_dtd.h \
+                      ./xml_element_content.h \
+                      ./xml_element_decl.h \
+                      ./xml_encoding_handler.h \
+                      ./xml_entity_decl.h \
+                      ./xml_entity_reference.h \
+                      ./xml_io.h \
+                      ./xml_libxml2_hacks.h \
+                      ./xml_namespace.h \
+                      ./xml_node.h \
+                      ./xml_node_set.h \
+                      ./xml_processing_instruction.h \
+                      ./xml_reader.h \
+                      ./xml_relax_ng.h \
+                      ./xml_sax_parser.h \
+                      ./xml_sax_parser_context.h \
+                      ./xml_sax_push_parser.h \
+                      ./xml_schema.h \
+                      ./xml_syntax_error.h \
+                      ./xml_text.h \
+                      ./xml_xpath_context.h \
+                      ./xslt_stylesheet.h
 
-html_sax_parser_context.o: html_sax_parser_context.c			\
- html_sax_parser_context.h nokogiri.h xml_io.h xml_document.h		\
- html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
- xml_cdata.h xml_attr.h xml_processing_instruction.h			\
- xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
- xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
- xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
- xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
- xml_reader.h xslt_stylesheet.h xml_syntax_error.h xml_schema.h		\
- xml_relax_ng.h html_element_description.h xml_namespace.h		\
- xml_encoding_handler.h
+html_sax_parser_context.o: ./html_document.h \
+                           ./html_element_description.h \
+                           ./html_entity_lookup.h \
+                           ./html_sax_parser_context.h \
+                           ./html_sax_push_parser.h \
+                           ./nokogiri.h \
+                           ./xml_attr.h \
+                           ./xml_attribute_decl.h \
+                           ./xml_cdata.h \
+                           ./xml_comment.h \
+                           ./xml_document.h \
+                           ./xml_document_fragment.h \
+                           ./xml_dtd.h \
+                           ./xml_element_content.h \
+                           ./xml_element_decl.h \
+                           ./xml_encoding_handler.h \
+                           ./xml_entity_decl.h \
+                           ./xml_entity_reference.h \
+                           ./xml_io.h \
+                           ./xml_libxml2_hacks.h \
+                           ./xml_namespace.h \
+                           ./xml_node.h \
+                           ./xml_node_set.h \
+                           ./xml_processing_instruction.h \
+                           ./xml_reader.h \
+                           ./xml_relax_ng.h \
+                           ./xml_sax_parser.h \
+                           ./xml_sax_parser_context.h \
+                           ./xml_sax_push_parser.h \
+                           ./xml_schema.h \
+                           ./xml_syntax_error.h \
+                           ./xml_text.h \
+                           ./xml_xpath_context.h \
+                           ./xslt_stylesheet.h
 
-nokogiri.o: nokogiri.c nokogiri.h xml_io.h xml_document.h		\
-  html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
-  xml_cdata.h xml_attr.h xml_processing_instruction.h			\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h xml_relax_ng.h			\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+html_sax_push_parser.o: ./html_document.h \
+                        ./html_element_description.h \
+                        ./html_entity_lookup.h \
+                        ./html_sax_parser_context.h \
+                        ./html_sax_push_parser.h \
+                        ./nokogiri.h \
+                        ./xml_attr.h \
+                        ./xml_attribute_decl.h \
+                        ./xml_cdata.h \
+                        ./xml_comment.h \
+                        ./xml_document.h \
+                        ./xml_document_fragment.h \
+                        ./xml_dtd.h \
+                        ./xml_element_content.h \
+                        ./xml_element_decl.h \
+                        ./xml_encoding_handler.h \
+                        ./xml_entity_decl.h \
+                        ./xml_entity_reference.h \
+                        ./xml_io.h \
+                        ./xml_libxml2_hacks.h \
+                        ./xml_namespace.h \
+                        ./xml_node.h \
+                        ./xml_node_set.h \
+                        ./xml_processing_instruction.h \
+                        ./xml_reader.h \
+                        ./xml_relax_ng.h \
+                        ./xml_sax_parser.h \
+                        ./xml_sax_parser_context.h \
+                        ./xml_sax_push_parser.h \
+                        ./xml_schema.h \
+                        ./xml_syntax_error.h \
+                        ./xml_text.h \
+                        ./xml_xpath_context.h \
+                        ./xslt_stylesheet.h
 
-xml_attr.o: xml_attr.c xml_attr.h nokogiri.h xml_io.h xml_document.h	\
-  html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
-  xml_cdata.h xml_processing_instruction.h xml_entity_reference.h	\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
-  html_sax_parser_context.h xslt_stylesheet.h xml_syntax_error.h	\
-  xml_schema.h xml_relax_ng.h html_element_description.h		\
-  xml_namespace.h xml_encoding_handler.h
+nokogiri.o: ./html_document.h \
+            ./html_element_description.h \
+            ./html_entity_lookup.h \
+            ./html_sax_parser_context.h \
+            ./html_sax_push_parser.h \
+            ./nokogiri.h \
+            ./xml_attr.h \
+            ./xml_attribute_decl.h \
+            ./xml_cdata.h \
+            ./xml_comment.h \
+            ./xml_document.h \
+            ./xml_document_fragment.h \
+            ./xml_dtd.h \
+            ./xml_element_content.h \
+            ./xml_element_decl.h \
+            ./xml_encoding_handler.h \
+            ./xml_entity_decl.h \
+            ./xml_entity_reference.h \
+            ./xml_io.h \
+            ./xml_libxml2_hacks.h \
+            ./xml_namespace.h \
+            ./xml_node.h \
+            ./xml_node_set.h \
+            ./xml_processing_instruction.h \
+            ./xml_reader.h \
+            ./xml_relax_ng.h \
+            ./xml_sax_parser.h \
+            ./xml_sax_parser_context.h \
+            ./xml_sax_push_parser.h \
+            ./xml_schema.h \
+            ./xml_syntax_error.h \
+            ./xml_text.h \
+            ./xml_xpath_context.h \
+            ./xslt_stylesheet.h
 
-xml_attribute_decl.o: xml_attribute_decl.c xml_attribute_decl.h		\
-  nokogiri.h xml_io.h xml_document.h html_entity_lookup.h		\
-  html_document.h xml_node.h xml_text.h xml_cdata.h xml_attr.h		\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_element_decl.h xml_entity_decl.h xml_xpath_context.h		\
-  xml_element_content.h xml_sax_parser_context.h xml_sax_parser.h	\
-  xml_sax_push_parser.h xml_reader.h html_sax_parser_context.h		\
-  xslt_stylesheet.h xml_syntax_error.h xml_schema.h xml_relax_ng.h	\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_attr.o: ./html_document.h \
+            ./html_element_description.h \
+            ./html_entity_lookup.h \
+            ./html_sax_parser_context.h \
+            ./html_sax_push_parser.h \
+            ./nokogiri.h \
+            ./xml_attr.h \
+            ./xml_attribute_decl.h \
+            ./xml_cdata.h \
+            ./xml_comment.h \
+            ./xml_document.h \
+            ./xml_document_fragment.h \
+            ./xml_dtd.h \
+            ./xml_element_content.h \
+            ./xml_element_decl.h \
+            ./xml_encoding_handler.h \
+            ./xml_entity_decl.h \
+            ./xml_entity_reference.h \
+            ./xml_io.h \
+            ./xml_libxml2_hacks.h \
+            ./xml_namespace.h \
+            ./xml_node.h \
+            ./xml_node_set.h \
+            ./xml_processing_instruction.h \
+            ./xml_reader.h \
+            ./xml_relax_ng.h \
+            ./xml_sax_parser.h \
+            ./xml_sax_parser_context.h \
+            ./xml_sax_push_parser.h \
+            ./xml_schema.h \
+            ./xml_syntax_error.h \
+            ./xml_text.h \
+            ./xml_xpath_context.h \
+            ./xslt_stylesheet.h
 
-xml_cdata.o: xml_cdata.c xml_cdata.h nokogiri.h xml_io.h		\
-  xml_document.h html_entity_lookup.h html_document.h xml_node.h	\
-  xml_text.h xml_attr.h xml_processing_instruction.h			\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h xml_relax_ng.h			\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_attribute_decl.o: ./html_document.h \
+                      ./html_element_description.h \
+                      ./html_entity_lookup.h \
+                      ./html_sax_parser_context.h \
+                      ./html_sax_push_parser.h \
+                      ./nokogiri.h \
+                      ./xml_attr.h \
+                      ./xml_attribute_decl.h \
+                      ./xml_cdata.h \
+                      ./xml_comment.h \
+                      ./xml_document.h \
+                      ./xml_document_fragment.h \
+                      ./xml_dtd.h \
+                      ./xml_element_content.h \
+                      ./xml_element_decl.h \
+                      ./xml_encoding_handler.h \
+                      ./xml_entity_decl.h \
+                      ./xml_entity_reference.h \
+                      ./xml_io.h \
+                      ./xml_libxml2_hacks.h \
+                      ./xml_namespace.h \
+                      ./xml_node.h \
+                      ./xml_node_set.h \
+                      ./xml_processing_instruction.h \
+                      ./xml_reader.h \
+                      ./xml_relax_ng.h \
+                      ./xml_sax_parser.h \
+                      ./xml_sax_parser_context.h \
+                      ./xml_sax_push_parser.h \
+                      ./xml_schema.h \
+                      ./xml_syntax_error.h \
+                      ./xml_text.h \
+                      ./xml_xpath_context.h \
+                      ./xslt_stylesheet.h
 
-xml_comment.o: xml_comment.c xml_comment.h nokogiri.h xml_io.h		\
-  xml_document.h html_entity_lookup.h html_document.h xml_node.h	\
-  xml_text.h xml_cdata.h xml_attr.h xml_processing_instruction.h	\
-  xml_entity_reference.h xml_document_fragment.h xml_node_set.h		\
-  xml_dtd.h xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h	\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
-  html_sax_parser_context.h xslt_stylesheet.h xml_syntax_error.h	\
-  xml_schema.h xml_relax_ng.h html_element_description.h		\
-  xml_namespace.h xml_encoding_handler.h
+xml_cdata.o: ./html_document.h \
+             ./html_element_description.h \
+             ./html_entity_lookup.h \
+             ./html_sax_parser_context.h \
+             ./html_sax_push_parser.h \
+             ./nokogiri.h \
+             ./xml_attr.h \
+             ./xml_attribute_decl.h \
+             ./xml_cdata.h \
+             ./xml_comment.h \
+             ./xml_document.h \
+             ./xml_document_fragment.h \
+             ./xml_dtd.h \
+             ./xml_element_content.h \
+             ./xml_element_decl.h \
+             ./xml_encoding_handler.h \
+             ./xml_entity_decl.h \
+             ./xml_entity_reference.h \
+             ./xml_io.h \
+             ./xml_libxml2_hacks.h \
+             ./xml_namespace.h \
+             ./xml_node.h \
+             ./xml_node_set.h \
+             ./xml_processing_instruction.h \
+             ./xml_reader.h \
+             ./xml_relax_ng.h \
+             ./xml_sax_parser.h \
+             ./xml_sax_parser_context.h \
+             ./xml_sax_push_parser.h \
+             ./xml_schema.h \
+             ./xml_syntax_error.h \
+             ./xml_text.h \
+             ./xml_xpath_context.h \
+             ./xslt_stylesheet.h
 
-xml_document.o: xml_document.c xml_document.h nokogiri.h xml_io.h	\
-  html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
-  xml_cdata.h xml_attr.h xml_processing_instruction.h			\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h xml_relax_ng.h			\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_comment.o: ./html_document.h \
+               ./html_element_description.h \
+               ./html_entity_lookup.h \
+               ./html_sax_parser_context.h \
+               ./html_sax_push_parser.h \
+               ./nokogiri.h \
+               ./xml_attr.h \
+               ./xml_attribute_decl.h \
+               ./xml_cdata.h \
+               ./xml_comment.h \
+               ./xml_document.h \
+               ./xml_document_fragment.h \
+               ./xml_dtd.h \
+               ./xml_element_content.h \
+               ./xml_element_decl.h \
+               ./xml_encoding_handler.h \
+               ./xml_entity_decl.h \
+               ./xml_entity_reference.h \
+               ./xml_io.h \
+               ./xml_libxml2_hacks.h \
+               ./xml_namespace.h \
+               ./xml_node.h \
+               ./xml_node_set.h \
+               ./xml_processing_instruction.h \
+               ./xml_reader.h \
+               ./xml_relax_ng.h \
+               ./xml_sax_parser.h \
+               ./xml_sax_parser_context.h \
+               ./xml_sax_push_parser.h \
+               ./xml_schema.h \
+               ./xml_syntax_error.h \
+               ./xml_text.h \
+               ./xml_xpath_context.h \
+               ./xslt_stylesheet.h
 
-xml_document_fragment.o: xml_document_fragment.c			\
-  xml_document_fragment.h nokogiri.h xml_io.h xml_document.h		\
-  html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
-  xml_cdata.h xml_attr.h xml_processing_instruction.h			\
-  xml_entity_reference.h xml_comment.h xml_node_set.h xml_dtd.h		\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
-  html_sax_parser_context.h xslt_stylesheet.h xml_syntax_error.h	\
-  xml_schema.h xml_relax_ng.h html_element_description.h		\
-  xml_namespace.h xml_encoding_handler.h
+xml_document.o: ./html_document.h \
+                ./html_element_description.h \
+                ./html_entity_lookup.h \
+                ./html_sax_parser_context.h \
+                ./html_sax_push_parser.h \
+                ./nokogiri.h \
+                ./xml_attr.h \
+                ./xml_attribute_decl.h \
+                ./xml_cdata.h \
+                ./xml_comment.h \
+                ./xml_document.h \
+                ./xml_document_fragment.h \
+                ./xml_dtd.h \
+                ./xml_element_content.h \
+                ./xml_element_decl.h \
+                ./xml_encoding_handler.h \
+                ./xml_entity_decl.h \
+                ./xml_entity_reference.h \
+                ./xml_io.h \
+                ./xml_libxml2_hacks.h \
+                ./xml_namespace.h \
+                ./xml_node.h \
+                ./xml_node_set.h \
+                ./xml_processing_instruction.h \
+                ./xml_reader.h \
+                ./xml_relax_ng.h \
+                ./xml_sax_parser.h \
+                ./xml_sax_parser_context.h \
+                ./xml_sax_push_parser.h \
+                ./xml_schema.h \
+                ./xml_syntax_error.h \
+                ./xml_text.h \
+                ./xml_xpath_context.h \
+                ./xslt_stylesheet.h
 
-xml_dtd.o: xml_dtd.c xml_dtd.h nokogiri.h xml_io.h xml_document.h	\
-  html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
-  xml_cdata.h xml_attr.h xml_processing_instruction.h			\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_attribute_decl.h xml_element_decl.h		\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h xml_relax_ng.h			\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_document_fragment.o: ./html_document.h \
+                         ./html_element_description.h \
+                         ./html_entity_lookup.h \
+                         ./html_sax_parser_context.h \
+                         ./html_sax_push_parser.h \
+                         ./nokogiri.h \
+                         ./xml_attr.h \
+                         ./xml_attribute_decl.h \
+                         ./xml_cdata.h \
+                         ./xml_comment.h \
+                         ./xml_document.h \
+                         ./xml_document_fragment.h \
+                         ./xml_dtd.h \
+                         ./xml_element_content.h \
+                         ./xml_element_decl.h \
+                         ./xml_encoding_handler.h \
+                         ./xml_entity_decl.h \
+                         ./xml_entity_reference.h \
+                         ./xml_io.h \
+                         ./xml_libxml2_hacks.h \
+                         ./xml_namespace.h \
+                         ./xml_node.h \
+                         ./xml_node_set.h \
+                         ./xml_processing_instruction.h \
+                         ./xml_reader.h \
+                         ./xml_relax_ng.h \
+                         ./xml_sax_parser.h \
+                         ./xml_sax_parser_context.h \
+                         ./xml_sax_push_parser.h \
+                         ./xml_schema.h \
+                         ./xml_syntax_error.h \
+                         ./xml_text.h \
+                         ./xml_xpath_context.h \
+                         ./xslt_stylesheet.h
 
-xml_element_content.o: xml_element_content.c xml_element_content.h	\
-  nokogiri.h xml_io.h xml_document.h html_entity_lookup.h		\
-  html_document.h xml_node.h xml_text.h xml_cdata.h xml_attr.h		\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_sax_parser_context.h xml_sax_parser.h		\
-  xml_sax_push_parser.h xml_reader.h html_sax_parser_context.h		\
-  xslt_stylesheet.h xml_syntax_error.h xml_schema.h xml_relax_ng.h	\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_dtd.o: ./html_document.h \
+           ./html_element_description.h \
+           ./html_entity_lookup.h \
+           ./html_sax_parser_context.h \
+           ./html_sax_push_parser.h \
+           ./nokogiri.h \
+           ./xml_attr.h \
+           ./xml_attribute_decl.h \
+           ./xml_cdata.h \
+           ./xml_comment.h \
+           ./xml_document.h \
+           ./xml_document_fragment.h \
+           ./xml_dtd.h \
+           ./xml_element_content.h \
+           ./xml_element_decl.h \
+           ./xml_encoding_handler.h \
+           ./xml_entity_decl.h \
+           ./xml_entity_reference.h \
+           ./xml_io.h \
+           ./xml_libxml2_hacks.h \
+           ./xml_namespace.h \
+           ./xml_node.h \
+           ./xml_node_set.h \
+           ./xml_processing_instruction.h \
+           ./xml_reader.h \
+           ./xml_relax_ng.h \
+           ./xml_sax_parser.h \
+           ./xml_sax_parser_context.h \
+           ./xml_sax_push_parser.h \
+           ./xml_schema.h \
+           ./xml_syntax_error.h \
+           ./xml_text.h \
+           ./xml_xpath_context.h \
+           ./xslt_stylesheet.h
 
-xml_element_decl.o: xml_element_decl.c xml_element_decl.h nokogiri.h	\
-  xml_io.h xml_document.h html_entity_lookup.h html_document.h		\
-  xml_node.h xml_text.h xml_cdata.h xml_attr.h				\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_entity_decl.h xml_xpath_context.h		\
-  xml_element_content.h xml_sax_parser_context.h xml_sax_parser.h	\
-  xml_sax_push_parser.h xml_reader.h html_sax_parser_context.h		\
-  xslt_stylesheet.h xml_syntax_error.h xml_schema.h xml_relax_ng.h	\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_element_content.o: ./html_document.h \
+                       ./html_element_description.h \
+                       ./html_entity_lookup.h \
+                       ./html_sax_parser_context.h \
+                       ./html_sax_push_parser.h \
+                       ./nokogiri.h \
+                       ./xml_attr.h \
+                       ./xml_attribute_decl.h \
+                       ./xml_cdata.h \
+                       ./xml_comment.h \
+                       ./xml_document.h \
+                       ./xml_document_fragment.h \
+                       ./xml_dtd.h \
+                       ./xml_element_content.h \
+                       ./xml_element_decl.h \
+                       ./xml_encoding_handler.h \
+                       ./xml_entity_decl.h \
+                       ./xml_entity_reference.h \
+                       ./xml_io.h \
+                       ./xml_libxml2_hacks.h \
+                       ./xml_namespace.h \
+                       ./xml_node.h \
+                       ./xml_node_set.h \
+                       ./xml_processing_instruction.h \
+                       ./xml_reader.h \
+                       ./xml_relax_ng.h \
+                       ./xml_sax_parser.h \
+                       ./xml_sax_parser_context.h \
+                       ./xml_sax_push_parser.h \
+                       ./xml_schema.h \
+                       ./xml_syntax_error.h \
+                       ./xml_text.h \
+                       ./xml_xpath_context.h \
+                       ./xslt_stylesheet.h
 
-xml_encoding_handler.o: xml_encoding_handler.c xml_encoding_handler.h	\
-  nokogiri.h xml_io.h xml_document.h html_entity_lookup.h		\
-  html_document.h xml_node.h xml_text.h xml_cdata.h xml_attr.h		\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
-  html_sax_parser_context.h xslt_stylesheet.h xml_syntax_error.h	\
-  xml_schema.h xml_relax_ng.h html_element_description.h		\
-  xml_namespace.h
+xml_element_decl.o: ./html_document.h \
+                    ./html_element_description.h \
+                    ./html_entity_lookup.h \
+                    ./html_sax_parser_context.h \
+                    ./html_sax_push_parser.h \
+                    ./nokogiri.h \
+                    ./xml_attr.h \
+                    ./xml_attribute_decl.h \
+                    ./xml_cdata.h \
+                    ./xml_comment.h \
+                    ./xml_document.h \
+                    ./xml_document_fragment.h \
+                    ./xml_dtd.h \
+                    ./xml_element_content.h \
+                    ./xml_element_decl.h \
+                    ./xml_encoding_handler.h \
+                    ./xml_entity_decl.h \
+                    ./xml_entity_reference.h \
+                    ./xml_io.h \
+                    ./xml_libxml2_hacks.h \
+                    ./xml_namespace.h \
+                    ./xml_node.h \
+                    ./xml_node_set.h \
+                    ./xml_processing_instruction.h \
+                    ./xml_reader.h \
+                    ./xml_relax_ng.h \
+                    ./xml_sax_parser.h \
+                    ./xml_sax_parser_context.h \
+                    ./xml_sax_push_parser.h \
+                    ./xml_schema.h \
+                    ./xml_syntax_error.h \
+                    ./xml_text.h \
+                    ./xml_xpath_context.h \
+                    ./xslt_stylesheet.h
 
-xml_entity_decl.o: xml_entity_decl.c xml_entity_decl.h nokogiri.h	\
-  xml_io.h xml_document.h html_entity_lookup.h html_document.h		\
-  xml_node.h xml_text.h xml_cdata.h xml_attr.h				\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_xpath_context.h		\
-  xml_element_content.h xml_sax_parser_context.h xml_sax_parser.h	\
-  xml_sax_push_parser.h xml_reader.h html_sax_parser_context.h		\
-  xslt_stylesheet.h xml_syntax_error.h xml_schema.h xml_relax_ng.h	\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_encoding_handler.o: ./html_document.h \
+                        ./html_element_description.h \
+                        ./html_entity_lookup.h \
+                        ./html_sax_parser_context.h \
+                        ./html_sax_push_parser.h \
+                        ./nokogiri.h \
+                        ./xml_attr.h \
+                        ./xml_attribute_decl.h \
+                        ./xml_cdata.h \
+                        ./xml_comment.h \
+                        ./xml_document.h \
+                        ./xml_document_fragment.h \
+                        ./xml_dtd.h \
+                        ./xml_element_content.h \
+                        ./xml_element_decl.h \
+                        ./xml_encoding_handler.h \
+                        ./xml_entity_decl.h \
+                        ./xml_entity_reference.h \
+                        ./xml_io.h \
+                        ./xml_libxml2_hacks.h \
+                        ./xml_namespace.h \
+                        ./xml_node.h \
+                        ./xml_node_set.h \
+                        ./xml_processing_instruction.h \
+                        ./xml_reader.h \
+                        ./xml_relax_ng.h \
+                        ./xml_sax_parser.h \
+                        ./xml_sax_parser_context.h \
+                        ./xml_sax_push_parser.h \
+                        ./xml_schema.h \
+                        ./xml_syntax_error.h \
+                        ./xml_text.h \
+                        ./xml_xpath_context.h \
+                        ./xslt_stylesheet.h
 
-xml_entity_reference.o: xml_entity_reference.c xml_entity_reference.h	\
-  nokogiri.h xml_io.h xml_document.h html_entity_lookup.h		\
-  html_document.h xml_node.h xml_text.h xml_cdata.h xml_attr.h		\
-  xml_processing_instruction.h xml_document_fragment.h xml_comment.h	\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h xml_relax_ng.h			\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_entity_decl.o: ./html_document.h \
+                   ./html_element_description.h \
+                   ./html_entity_lookup.h \
+                   ./html_sax_parser_context.h \
+                   ./html_sax_push_parser.h \
+                   ./nokogiri.h \
+                   ./xml_attr.h \
+                   ./xml_attribute_decl.h \
+                   ./xml_cdata.h \
+                   ./xml_comment.h \
+                   ./xml_document.h \
+                   ./xml_document_fragment.h \
+                   ./xml_dtd.h \
+                   ./xml_element_content.h \
+                   ./xml_element_decl.h \
+                   ./xml_encoding_handler.h \
+                   ./xml_entity_decl.h \
+                   ./xml_entity_reference.h \
+                   ./xml_io.h \
+                   ./xml_libxml2_hacks.h \
+                   ./xml_namespace.h \
+                   ./xml_node.h \
+                   ./xml_node_set.h \
+                   ./xml_processing_instruction.h \
+                   ./xml_reader.h \
+                   ./xml_relax_ng.h \
+                   ./xml_sax_parser.h \
+                   ./xml_sax_parser_context.h \
+                   ./xml_sax_push_parser.h \
+                   ./xml_schema.h \
+                   ./xml_syntax_error.h \
+                   ./xml_text.h \
+                   ./xml_xpath_context.h \
+                   ./xslt_stylesheet.h
 
-xml_io.o: xml_io.c xml_io.h nokogiri.h xml_document.h			\
-  html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
-  xml_cdata.h xml_attr.h xml_processing_instruction.h			\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h xml_relax_ng.h			\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_entity_reference.o: ./html_document.h \
+                        ./html_element_description.h \
+                        ./html_entity_lookup.h \
+                        ./html_sax_parser_context.h \
+                        ./html_sax_push_parser.h \
+                        ./nokogiri.h \
+                        ./xml_attr.h \
+                        ./xml_attribute_decl.h \
+                        ./xml_cdata.h \
+                        ./xml_comment.h \
+                        ./xml_document.h \
+                        ./xml_document_fragment.h \
+                        ./xml_dtd.h \
+                        ./xml_element_content.h \
+                        ./xml_element_decl.h \
+                        ./xml_encoding_handler.h \
+                        ./xml_entity_decl.h \
+                        ./xml_entity_reference.h \
+                        ./xml_io.h \
+                        ./xml_libxml2_hacks.h \
+                        ./xml_namespace.h \
+                        ./xml_node.h \
+                        ./xml_node_set.h \
+                        ./xml_processing_instruction.h \
+                        ./xml_reader.h \
+                        ./xml_relax_ng.h \
+                        ./xml_sax_parser.h \
+                        ./xml_sax_parser_context.h \
+                        ./xml_sax_push_parser.h \
+                        ./xml_schema.h \
+                        ./xml_syntax_error.h \
+                        ./xml_text.h \
+                        ./xml_xpath_context.h \
+                        ./xslt_stylesheet.h
 
-xml_namespace.o: xml_namespace.c xml_namespace.h nokogiri.h xml_io.h	\
-  xml_document.h html_entity_lookup.h html_document.h xml_node.h	\
-  xml_text.h xml_cdata.h xml_attr.h xml_processing_instruction.h	\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h xml_relax_ng.h			\
-  html_element_description.h xml_encoding_handler.h
+xml_io.o: ./html_document.h \
+          ./html_element_description.h \
+          ./html_entity_lookup.h \
+          ./html_sax_parser_context.h \
+          ./html_sax_push_parser.h \
+          ./nokogiri.h \
+          ./xml_attr.h \
+          ./xml_attribute_decl.h \
+          ./xml_cdata.h \
+          ./xml_comment.h \
+          ./xml_document.h \
+          ./xml_document_fragment.h \
+          ./xml_dtd.h \
+          ./xml_element_content.h \
+          ./xml_element_decl.h \
+          ./xml_encoding_handler.h \
+          ./xml_entity_decl.h \
+          ./xml_entity_reference.h \
+          ./xml_io.h \
+          ./xml_libxml2_hacks.h \
+          ./xml_namespace.h \
+          ./xml_node.h \
+          ./xml_node_set.h \
+          ./xml_processing_instruction.h \
+          ./xml_reader.h \
+          ./xml_relax_ng.h \
+          ./xml_sax_parser.h \
+          ./xml_sax_parser_context.h \
+          ./xml_sax_push_parser.h \
+          ./xml_schema.h \
+          ./xml_syntax_error.h \
+          ./xml_text.h \
+          ./xml_xpath_context.h \
+          ./xslt_stylesheet.h
 
-xml_node.o: xml_node.c xml_node.h nokogiri.h xml_io.h xml_document.h	\
-  html_entity_lookup.h html_document.h xml_text.h xml_cdata.h		\
-  xml_attr.h xml_processing_instruction.h xml_entity_reference.h	\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
-  html_sax_parser_context.h xslt_stylesheet.h xml_syntax_error.h	\
-  xml_schema.h xml_relax_ng.h html_element_description.h		\
-  xml_namespace.h xml_encoding_handler.h
+xml_namespace.o: ./html_document.h \
+                 ./html_element_description.h \
+                 ./html_entity_lookup.h \
+                 ./html_sax_parser_context.h \
+                 ./html_sax_push_parser.h \
+                 ./nokogiri.h \
+                 ./xml_attr.h \
+                 ./xml_attribute_decl.h \
+                 ./xml_cdata.h \
+                 ./xml_comment.h \
+                 ./xml_document.h \
+                 ./xml_document_fragment.h \
+                 ./xml_dtd.h \
+                 ./xml_element_content.h \
+                 ./xml_element_decl.h \
+                 ./xml_encoding_handler.h \
+                 ./xml_entity_decl.h \
+                 ./xml_entity_reference.h \
+                 ./xml_io.h \
+                 ./xml_libxml2_hacks.h \
+                 ./xml_namespace.h \
+                 ./xml_node.h \
+                 ./xml_node_set.h \
+                 ./xml_processing_instruction.h \
+                 ./xml_reader.h \
+                 ./xml_relax_ng.h \
+                 ./xml_sax_parser.h \
+                 ./xml_sax_parser_context.h \
+                 ./xml_sax_push_parser.h \
+                 ./xml_schema.h \
+                 ./xml_syntax_error.h \
+                 ./xml_text.h \
+                 ./xml_xpath_context.h \
+                 ./xslt_stylesheet.h
 
-xml_node_set.o: xml_node_set.c xml_node_set.h nokogiri.h xml_io.h	\
-  xml_document.h html_entity_lookup.h html_document.h xml_node.h	\
-  xml_text.h xml_cdata.h xml_attr.h xml_processing_instruction.h	\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_dtd.h xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h	\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
-  html_sax_parser_context.h xslt_stylesheet.h xml_syntax_error.h	\
-  xml_schema.h xml_relax_ng.h html_element_description.h		\
-  xml_namespace.h xml_encoding_handler.h
+xml_node.o: ./html_document.h \
+            ./html_element_description.h \
+            ./html_entity_lookup.h \
+            ./html_sax_parser_context.h \
+            ./html_sax_push_parser.h \
+            ./nokogiri.h \
+            ./xml_attr.h \
+            ./xml_attribute_decl.h \
+            ./xml_cdata.h \
+            ./xml_comment.h \
+            ./xml_document.h \
+            ./xml_document_fragment.h \
+            ./xml_dtd.h \
+            ./xml_element_content.h \
+            ./xml_element_decl.h \
+            ./xml_encoding_handler.h \
+            ./xml_entity_decl.h \
+            ./xml_entity_reference.h \
+            ./xml_io.h \
+            ./xml_libxml2_hacks.h \
+            ./xml_namespace.h \
+            ./xml_node.h \
+            ./xml_node_set.h \
+            ./xml_processing_instruction.h \
+            ./xml_reader.h \
+            ./xml_relax_ng.h \
+            ./xml_sax_parser.h \
+            ./xml_sax_parser_context.h \
+            ./xml_sax_push_parser.h \
+            ./xml_schema.h \
+            ./xml_syntax_error.h \
+            ./xml_text.h \
+            ./xml_xpath_context.h \
+            ./xslt_stylesheet.h
 
-xml_processing_instruction.o: xml_processing_instruction.c		\
- xml_processing_instruction.h nokogiri.h xml_io.h xml_document.h	\
- html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
- xml_cdata.h xml_attr.h xml_entity_reference.h xml_document_fragment.h	\
- xml_comment.h xml_node_set.h xml_dtd.h xml_attribute_decl.h		\
- xml_element_decl.h xml_entity_decl.h xml_xpath_context.h		\
- xml_element_content.h xml_sax_parser_context.h xml_sax_parser.h	\
- xml_sax_push_parser.h xml_reader.h html_sax_parser_context.h		\
- xslt_stylesheet.h xml_syntax_error.h xml_schema.h xml_relax_ng.h	\
- html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_node_set.o: ./html_document.h \
+                ./html_element_description.h \
+                ./html_entity_lookup.h \
+                ./html_sax_parser_context.h \
+                ./html_sax_push_parser.h \
+                ./nokogiri.h \
+                ./xml_attr.h \
+                ./xml_attribute_decl.h \
+                ./xml_cdata.h \
+                ./xml_comment.h \
+                ./xml_document.h \
+                ./xml_document_fragment.h \
+                ./xml_dtd.h \
+                ./xml_element_content.h \
+                ./xml_element_decl.h \
+                ./xml_encoding_handler.h \
+                ./xml_entity_decl.h \
+                ./xml_entity_reference.h \
+                ./xml_io.h \
+                ./xml_libxml2_hacks.h \
+                ./xml_namespace.h \
+                ./xml_node.h \
+                ./xml_node_set.h \
+                ./xml_processing_instruction.h \
+                ./xml_reader.h \
+                ./xml_relax_ng.h \
+                ./xml_sax_parser.h \
+                ./xml_sax_parser_context.h \
+                ./xml_sax_push_parser.h \
+                ./xml_schema.h \
+                ./xml_syntax_error.h \
+                ./xml_text.h \
+                ./xml_xpath_context.h \
+                ./xslt_stylesheet.h
 
-xml_reader.o: xml_reader.c xml_reader.h nokogiri.h xml_io.h		\
-  xml_document.h html_entity_lookup.h html_document.h xml_node.h	\
-  xml_text.h xml_cdata.h xml_attr.h xml_processing_instruction.h	\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  html_sax_parser_context.h xslt_stylesheet.h xml_syntax_error.h	\
-  xml_schema.h xml_relax_ng.h html_element_description.h		\
-  xml_namespace.h xml_encoding_handler.h
+xml_processing_instruction.o: ./html_document.h \
+                              ./html_element_description.h \
+                              ./html_entity_lookup.h \
+                              ./html_sax_parser_context.h \
+                              ./html_sax_push_parser.h \
+                              ./nokogiri.h \
+                              ./xml_attr.h \
+                              ./xml_attribute_decl.h \
+                              ./xml_cdata.h \
+                              ./xml_comment.h \
+                              ./xml_document.h \
+                              ./xml_document_fragment.h \
+                              ./xml_dtd.h \
+                              ./xml_element_content.h \
+                              ./xml_element_decl.h \
+                              ./xml_encoding_handler.h \
+                              ./xml_entity_decl.h \
+                              ./xml_entity_reference.h \
+                              ./xml_io.h \
+                              ./xml_libxml2_hacks.h \
+                              ./xml_namespace.h \
+                              ./xml_node.h \
+                              ./xml_node_set.h \
+                              ./xml_processing_instruction.h \
+                              ./xml_reader.h \
+                              ./xml_relax_ng.h \
+                              ./xml_sax_parser.h \
+                              ./xml_sax_parser_context.h \
+                              ./xml_sax_push_parser.h \
+                              ./xml_schema.h \
+                              ./xml_syntax_error.h \
+                              ./xml_text.h \
+                              ./xml_xpath_context.h \
+                              ./xslt_stylesheet.h
 
-xml_relax_ng.o: xml_relax_ng.c xml_relax_ng.h nokogiri.h xml_io.h	\
-  xml_document.h html_entity_lookup.h html_document.h xml_node.h	\
-  xml_text.h xml_cdata.h xml_attr.h xml_processing_instruction.h	\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_schema.h html_element_description.h		\
-  xml_namespace.h xml_encoding_handler.h
+xml_reader.o: ./html_document.h \
+              ./html_element_description.h \
+              ./html_entity_lookup.h \
+              ./html_sax_parser_context.h \
+              ./html_sax_push_parser.h \
+              ./nokogiri.h \
+              ./xml_attr.h \
+              ./xml_attribute_decl.h \
+              ./xml_cdata.h \
+              ./xml_comment.h \
+              ./xml_document.h \
+              ./xml_document_fragment.h \
+              ./xml_dtd.h \
+              ./xml_element_content.h \
+              ./xml_element_decl.h \
+              ./xml_encoding_handler.h \
+              ./xml_entity_decl.h \
+              ./xml_entity_reference.h \
+              ./xml_io.h \
+              ./xml_libxml2_hacks.h \
+              ./xml_namespace.h \
+              ./xml_node.h \
+              ./xml_node_set.h \
+              ./xml_processing_instruction.h \
+              ./xml_reader.h \
+              ./xml_relax_ng.h \
+              ./xml_sax_parser.h \
+              ./xml_sax_parser_context.h \
+              ./xml_sax_push_parser.h \
+              ./xml_schema.h \
+              ./xml_syntax_error.h \
+              ./xml_text.h \
+              ./xml_xpath_context.h \
+              ./xslt_stylesheet.h
 
-xml_sax_parser.o: xml_sax_parser.c xml_sax_parser.h nokogiri.h		\
-  xml_io.h xml_document.h html_entity_lookup.h html_document.h		\
-  xml_node.h xml_text.h xml_cdata.h xml_attr.h				\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_push_parser.h xml_reader.h html_sax_parser_context.h		\
-  xslt_stylesheet.h xml_syntax_error.h xml_schema.h xml_relax_ng.h	\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_relax_ng.o: ./html_document.h \
+                ./html_element_description.h \
+                ./html_entity_lookup.h \
+                ./html_sax_parser_context.h \
+                ./html_sax_push_parser.h \
+                ./nokogiri.h \
+                ./xml_attr.h \
+                ./xml_attribute_decl.h \
+                ./xml_cdata.h \
+                ./xml_comment.h \
+                ./xml_document.h \
+                ./xml_document_fragment.h \
+                ./xml_dtd.h \
+                ./xml_element_content.h \
+                ./xml_element_decl.h \
+                ./xml_encoding_handler.h \
+                ./xml_entity_decl.h \
+                ./xml_entity_reference.h \
+                ./xml_io.h \
+                ./xml_libxml2_hacks.h \
+                ./xml_namespace.h \
+                ./xml_node.h \
+                ./xml_node_set.h \
+                ./xml_processing_instruction.h \
+                ./xml_reader.h \
+                ./xml_relax_ng.h \
+                ./xml_sax_parser.h \
+                ./xml_sax_parser_context.h \
+                ./xml_sax_push_parser.h \
+                ./xml_schema.h \
+                ./xml_syntax_error.h \
+                ./xml_text.h \
+                ./xml_xpath_context.h \
+                ./xslt_stylesheet.h
 
-xml_sax_parser_context.o: xml_sax_parser_context.c			\
- xml_sax_parser_context.h nokogiri.h xml_io.h xml_document.h		\
- html_entity_lookup.h html_document.h xml_node.h xml_text.h		\
- xml_cdata.h xml_attr.h xml_processing_instruction.h			\
- xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
- xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
- xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
- xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
- html_sax_parser_context.h xslt_stylesheet.h xml_syntax_error.h		\
- xml_schema.h xml_relax_ng.h html_element_description.h			\
- xml_namespace.h xml_encoding_handler.h
+xml_sax_parser.o: ./html_document.h \
+                  ./html_element_description.h \
+                  ./html_entity_lookup.h \
+                  ./html_sax_parser_context.h \
+                  ./html_sax_push_parser.h \
+                  ./nokogiri.h \
+                  ./xml_attr.h \
+                  ./xml_attribute_decl.h \
+                  ./xml_cdata.h \
+                  ./xml_comment.h \
+                  ./xml_document.h \
+                  ./xml_document_fragment.h \
+                  ./xml_dtd.h \
+                  ./xml_element_content.h \
+                  ./xml_element_decl.h \
+                  ./xml_encoding_handler.h \
+                  ./xml_entity_decl.h \
+                  ./xml_entity_reference.h \
+                  ./xml_io.h \
+                  ./xml_libxml2_hacks.h \
+                  ./xml_namespace.h \
+                  ./xml_node.h \
+                  ./xml_node_set.h \
+                  ./xml_processing_instruction.h \
+                  ./xml_reader.h \
+                  ./xml_relax_ng.h \
+                  ./xml_sax_parser.h \
+                  ./xml_sax_parser_context.h \
+                  ./xml_sax_push_parser.h \
+                  ./xml_schema.h \
+                  ./xml_syntax_error.h \
+                  ./xml_text.h \
+                  ./xml_xpath_context.h \
+                  ./xslt_stylesheet.h
 
-xml_sax_push_parser.o: xml_sax_push_parser.c xml_sax_push_parser.h	\
-  nokogiri.h xml_io.h xml_document.h html_entity_lookup.h		\
-  html_document.h xml_node.h xml_text.h xml_cdata.h xml_attr.h		\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_reader.h html_sax_parser_context.h		\
-  xslt_stylesheet.h xml_syntax_error.h xml_schema.h xml_relax_ng.h	\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_sax_parser_context.o: ./html_document.h \
+                          ./html_element_description.h \
+                          ./html_entity_lookup.h \
+                          ./html_sax_parser_context.h \
+                          ./html_sax_push_parser.h \
+                          ./nokogiri.h \
+                          ./xml_attr.h \
+                          ./xml_attribute_decl.h \
+                          ./xml_cdata.h \
+                          ./xml_comment.h \
+                          ./xml_document.h \
+                          ./xml_document_fragment.h \
+                          ./xml_dtd.h \
+                          ./xml_element_content.h \
+                          ./xml_element_decl.h \
+                          ./xml_encoding_handler.h \
+                          ./xml_entity_decl.h \
+                          ./xml_entity_reference.h \
+                          ./xml_io.h \
+                          ./xml_libxml2_hacks.h \
+                          ./xml_namespace.h \
+                          ./xml_node.h \
+                          ./xml_node_set.h \
+                          ./xml_processing_instruction.h \
+                          ./xml_reader.h \
+                          ./xml_relax_ng.h \
+                          ./xml_sax_parser.h \
+                          ./xml_sax_parser_context.h \
+                          ./xml_sax_push_parser.h \
+                          ./xml_schema.h \
+                          ./xml_syntax_error.h \
+                          ./xml_text.h \
+                          ./xml_xpath_context.h \
+                          ./xslt_stylesheet.h
 
-xml_schema.o: xml_schema.c xml_schema.h nokogiri.h xml_io.h		\
-  xml_document.h html_entity_lookup.h html_document.h xml_node.h	\
-  xml_text.h xml_cdata.h xml_attr.h xml_processing_instruction.h	\
-  xml_entity_reference.h xml_document_fragment.h xml_comment.h		\
-  xml_node_set.h xml_dtd.h xml_attribute_decl.h xml_element_decl.h	\
-  xml_entity_decl.h xml_xpath_context.h xml_element_content.h		\
-  xml_sax_parser_context.h xml_sax_parser.h xml_sax_push_parser.h	\
-  xml_reader.h html_sax_parser_context.h xslt_stylesheet.h		\
-  xml_syntax_error.h xml_relax_ng.h html_element_description.h		\
-  xml_namespace.h xml_encoding_handler.h
+xml_sax_push_parser.o: ./html_document.h \
+                       ./html_element_description.h \
+                       ./html_entity_lookup.h \
+                       ./html_sax_parser_context.h \
+                       ./html_sax_push_parser.h \
+                       ./nokogiri.h \
+                       ./xml_attr.h \
+                       ./xml_attribute_decl.h \
+                       ./xml_cdata.h \
+                       ./xml_comment.h \
+                       ./xml_document.h \
+                       ./xml_document_fragment.h \
+                       ./xml_dtd.h \
+                       ./xml_element_content.h \
+                       ./xml_element_decl.h \
+                       ./xml_encoding_handler.h \
+                       ./xml_entity_decl.h \
+                       ./xml_entity_reference.h \
+                       ./xml_io.h \
+                       ./xml_libxml2_hacks.h \
+                       ./xml_namespace.h \
+                       ./xml_node.h \
+                       ./xml_node_set.h \
+                       ./xml_processing_instruction.h \
+                       ./xml_reader.h \
+                       ./xml_relax_ng.h \
+                       ./xml_sax_parser.h \
+                       ./xml_sax_parser_context.h \
+                       ./xml_sax_push_parser.h \
+                       ./xml_schema.h \
+                       ./xml_syntax_error.h \
+                       ./xml_text.h \
+                       ./xml_xpath_context.h \
+                       ./xslt_stylesheet.h
 
-xml_syntax_error.o: xml_syntax_error.c xml_syntax_error.h nokogiri.h	\
-  xml_io.h xml_document.h html_entity_lookup.h html_document.h		\
-  xml_node.h xml_text.h xml_cdata.h xml_attr.h				\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
-  html_sax_parser_context.h xslt_stylesheet.h xml_schema.h		\
-  xml_relax_ng.h html_element_description.h xml_namespace.h		\
-  xml_encoding_handler.h
+xml_schema.o: ./html_document.h \
+              ./html_element_description.h \
+              ./html_entity_lookup.h \
+              ./html_sax_parser_context.h \
+              ./html_sax_push_parser.h \
+              ./nokogiri.h \
+              ./xml_attr.h \
+              ./xml_attribute_decl.h \
+              ./xml_cdata.h \
+              ./xml_comment.h \
+              ./xml_document.h \
+              ./xml_document_fragment.h \
+              ./xml_dtd.h \
+              ./xml_element_content.h \
+              ./xml_element_decl.h \
+              ./xml_encoding_handler.h \
+              ./xml_entity_decl.h \
+              ./xml_entity_reference.h \
+              ./xml_io.h \
+              ./xml_libxml2_hacks.h \
+              ./xml_namespace.h \
+              ./xml_node.h \
+              ./xml_node_set.h \
+              ./xml_processing_instruction.h \
+              ./xml_reader.h \
+              ./xml_relax_ng.h \
+              ./xml_sax_parser.h \
+              ./xml_sax_parser_context.h \
+              ./xml_sax_push_parser.h \
+              ./xml_schema.h \
+              ./xml_syntax_error.h \
+              ./xml_text.h \
+              ./xml_xpath_context.h \
+              ./xslt_stylesheet.h
 
-xml_text.o: xml_text.c xml_text.h nokogiri.h xml_io.h xml_document.h	\
-  html_entity_lookup.h html_document.h xml_node.h xml_cdata.h		\
-  xml_attr.h xml_processing_instruction.h xml_entity_reference.h	\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
-  html_sax_parser_context.h xslt_stylesheet.h xml_syntax_error.h	\
-  xml_schema.h xml_relax_ng.h html_element_description.h		\
-  xml_namespace.h xml_encoding_handler.h
+xml_syntax_error.o: ./html_document.h \
+                    ./html_element_description.h \
+                    ./html_entity_lookup.h \
+                    ./html_sax_parser_context.h \
+                    ./html_sax_push_parser.h \
+                    ./nokogiri.h \
+                    ./xml_attr.h \
+                    ./xml_attribute_decl.h \
+                    ./xml_cdata.h \
+                    ./xml_comment.h \
+                    ./xml_document.h \
+                    ./xml_document_fragment.h \
+                    ./xml_dtd.h \
+                    ./xml_element_content.h \
+                    ./xml_element_decl.h \
+                    ./xml_encoding_handler.h \
+                    ./xml_entity_decl.h \
+                    ./xml_entity_reference.h \
+                    ./xml_io.h \
+                    ./xml_libxml2_hacks.h \
+                    ./xml_namespace.h \
+                    ./xml_node.h \
+                    ./xml_node_set.h \
+                    ./xml_processing_instruction.h \
+                    ./xml_reader.h \
+                    ./xml_relax_ng.h \
+                    ./xml_sax_parser.h \
+                    ./xml_sax_parser_context.h \
+                    ./xml_sax_push_parser.h \
+                    ./xml_schema.h \
+                    ./xml_syntax_error.h \
+                    ./xml_text.h \
+                    ./xml_xpath_context.h \
+                    ./xslt_stylesheet.h
 
-xml_xpath_context.o: xml_xpath_context.c xml_xpath_context.h		\
-  nokogiri.h xml_io.h xml_document.h html_entity_lookup.h		\
-  html_document.h xml_node.h xml_text.h xml_cdata.h xml_attr.h		\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_element_content.h xml_sax_parser_context.h xml_sax_parser.h	\
-  xml_sax_push_parser.h xml_reader.h html_sax_parser_context.h		\
-  xslt_stylesheet.h xml_syntax_error.h xml_schema.h xml_relax_ng.h	\
-  html_element_description.h xml_namespace.h xml_encoding_handler.h
+xml_text.o: ./html_document.h \
+            ./html_element_description.h \
+            ./html_entity_lookup.h \
+            ./html_sax_parser_context.h \
+            ./html_sax_push_parser.h \
+            ./nokogiri.h \
+            ./xml_attr.h \
+            ./xml_attribute_decl.h \
+            ./xml_cdata.h \
+            ./xml_comment.h \
+            ./xml_document.h \
+            ./xml_document_fragment.h \
+            ./xml_dtd.h \
+            ./xml_element_content.h \
+            ./xml_element_decl.h \
+            ./xml_encoding_handler.h \
+            ./xml_entity_decl.h \
+            ./xml_entity_reference.h \
+            ./xml_io.h \
+            ./xml_libxml2_hacks.h \
+            ./xml_namespace.h \
+            ./xml_node.h \
+            ./xml_node_set.h \
+            ./xml_processing_instruction.h \
+            ./xml_reader.h \
+            ./xml_relax_ng.h \
+            ./xml_sax_parser.h \
+            ./xml_sax_parser_context.h \
+            ./xml_sax_push_parser.h \
+            ./xml_schema.h \
+            ./xml_syntax_error.h \
+            ./xml_text.h \
+            ./xml_xpath_context.h \
+            ./xslt_stylesheet.h
 
-xslt_stylesheet.o: xslt_stylesheet.c xslt_stylesheet.h nokogiri.h	\
-  xml_io.h xml_document.h html_entity_lookup.h html_document.h		\
-  xml_node.h xml_text.h xml_cdata.h xml_attr.h				\
-  xml_processing_instruction.h xml_entity_reference.h			\
-  xml_document_fragment.h xml_comment.h xml_node_set.h xml_dtd.h	\
-  xml_attribute_decl.h xml_element_decl.h xml_entity_decl.h		\
-  xml_xpath_context.h xml_element_content.h xml_sax_parser_context.h	\
-  xml_sax_parser.h xml_sax_push_parser.h xml_reader.h			\
-  html_sax_parser_context.h xml_syntax_error.h xml_schema.h		\
-  xml_relax_ng.h html_element_description.h xml_namespace.h		\
-  xml_encoding_handler.h
+xml_xpath_context.o: ./html_document.h \
+                     ./html_element_description.h \
+                     ./html_entity_lookup.h \
+                     ./html_sax_parser_context.h \
+                     ./html_sax_push_parser.h \
+                     ./nokogiri.h \
+                     ./xml_attr.h \
+                     ./xml_attribute_decl.h \
+                     ./xml_cdata.h \
+                     ./xml_comment.h \
+                     ./xml_document.h \
+                     ./xml_document_fragment.h \
+                     ./xml_dtd.h \
+                     ./xml_element_content.h \
+                     ./xml_element_decl.h \
+                     ./xml_encoding_handler.h \
+                     ./xml_entity_decl.h \
+                     ./xml_entity_reference.h \
+                     ./xml_io.h \
+                     ./xml_libxml2_hacks.h \
+                     ./xml_namespace.h \
+                     ./xml_node.h \
+                     ./xml_node_set.h \
+                     ./xml_processing_instruction.h \
+                     ./xml_reader.h \
+                     ./xml_relax_ng.h \
+                     ./xml_sax_parser.h \
+                     ./xml_sax_parser_context.h \
+                     ./xml_sax_push_parser.h \
+                     ./xml_schema.h \
+                     ./xml_syntax_error.h \
+                     ./xml_text.h \
+                     ./xml_xpath_context.h \
+                     ./xslt_stylesheet.h
+
+xslt_stylesheet.o: ./html_document.h \
+                   ./html_element_description.h \
+                   ./html_entity_lookup.h \
+                   ./html_sax_parser_context.h \
+                   ./html_sax_push_parser.h \
+                   ./nokogiri.h \
+                   ./xml_attr.h \
+                   ./xml_attribute_decl.h \
+                   ./xml_cdata.h \
+                   ./xml_comment.h \
+                   ./xml_document.h \
+                   ./xml_document_fragment.h \
+                   ./xml_dtd.h \
+                   ./xml_element_content.h \
+                   ./xml_element_decl.h \
+                   ./xml_encoding_handler.h \
+                   ./xml_entity_decl.h \
+                   ./xml_entity_reference.h \
+                   ./xml_io.h \
+                   ./xml_libxml2_hacks.h \
+                   ./xml_namespace.h \
+                   ./xml_node.h \
+                   ./xml_node_set.h \
+                   ./xml_processing_instruction.h \
+                   ./xml_reader.h \
+                   ./xml_relax_ng.h \
+                   ./xml_sax_parser.h \
+                   ./xml_sax_parser_context.h \
+                   ./xml_sax_push_parser.h \
+                   ./xml_schema.h \
+                   ./xml_syntax_error.h \
+                   ./xml_text.h \
+                   ./xml_xpath_context.h \
+                   ./xslt_stylesheet.h
+

--- a/rakelib/cext-depend.rake
+++ b/rakelib/cext-depend.rake
@@ -1,0 +1,37 @@
+require "set"
+
+desc "Regenerate C extension dependencies in #{File.dirname(HOE.spec.extensions.first)}/depend"
+task :depend do
+  # this task requires the `makedepend` utility
+  
+
+  ext_dir = File.dirname(HOE.spec.extensions.first)
+  Dir.chdir(ext_dir) do
+    File.open("depend", "w") do |depend|
+      deps = {}
+
+      makedepend = `makedepend -f- -Y -I. *.c 2> /dev/null`
+      makedepend.split("\n").each do |line|
+        next unless line =~ /:/
+        obj_file = line[/(.*):/, 1]
+        deps[obj_file] ||= Set.new
+        line[/:(.*)/, 1].split.each do |dep|
+          deps[obj_file].add dep
+        end
+      end
+
+      deps.keys.sort.each do |obj_file|
+        obj_deps = deps[obj_file].to_a.sort
+        depend.print "#{obj_file}: "
+        obj_deps.each_with_index do |obj_dep, j|
+          depend.print obj_dep
+          if j+1 < obj_deps.length
+            depend.print " \\\n#{" " * obj_file.length}  "
+          end
+        end
+        depend.puts
+        depend.puts
+      end
+    end
+  end
+end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

When developing Nokogiri, having correct dependencies in the Makefile is helpful and necessary to a tight feedback loop.

The `ext/nokogiri/depend` file was generated over ten years ago by Nobu and I'd like to have a way to easily keep it up-to-date.

**Have you included adequate test coverage?**

Normal CI test suite should provide adequate coverage of compilation-during-installation.

**Does this change affect the C or the Java implementations?**

No functional changes for end users.