### PR TITLE
fix(memory): Ensure RelaxNG parsing does not leak the parser context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,9 @@ This release ends support for:
 * The Node methods add_previous_sibling, previous=, before, add_next_sibling, next=, after, replace, and swap now correctly use their parent as the context node for parsing markup. These methods now also raise a RuntimeError if they are called on a node with no parent. [[nokogumbo#160](https://github.com/rubys/nokogumbo/issues/160)
 * [CRuby] Fixed installation on AIX with respect to `vasprintf`. [[#1908](https://github.com/sparklemotion/nokogiri/issues/1908)]
 * [CRuby] On some platforms, avoid symbol name collision with glibc's `canonicalize`. [[#2105](https://github.com/sparklemotion/nokogiri/issues/2105)]
-* [JRuby] Standardize reading from IO like objects, including StringIO. [[#1888](https://github.com/sparklemotion/nokogiri/issues/1888), [#1897](https://github.com/sparklemotion/nokogiri/issues/1897)]
+* [CRuby] `RelaxNG.from_document` no longer leaks memory. [[#2114](https://github.com/sparklemotion/nokogiri/issues/2114)]
 * [Windows Visual C++] Fixed compiler warnings and errors. [[#2061](https://github.com/sparklemotion/nokogiri/issues/2061), [#2068](https://github.com/sparklemotion/nokogiri/issues/2068)]
+* [JRuby] Standardize reading from IO like objects, including StringIO. [[#1888](https://github.com/sparklemotion/nokogiri/issues/1888), [#1897](https://github.com/sparklemotion/nokogiri/issues/1897)]
 * [JRuby] Fixed document encoding regression in v1.11.0 release candidates. [[#2080](https://github.com/sparklemotion/nokogiri/issues/2080), [#2083](https://github.com/sparklemotion/nokogiri/issues/2083)] (Thanks, [@thbar](https://github.com/thbar)!)
 
 

--- a/ext/nokogiri/xml_relax_ng.c
+++ b/ext/nokogiri/xml_relax_ng.c
@@ -129,6 +129,7 @@ static VALUE from_document(VALUE klass, VALUE document)
   schema = xmlRelaxNGParse(ctx);
 
   xmlSetStructuredErrorFunc(NULL, NULL);
+  xmlRelaxNGFreeParserCtxt(ctx);
 
   if(NULL == schema) {
     xmlErrorPtr error = xmlGetLastError();

--- a/test/test_memory_leak.rb
+++ b/test/test_memory_leak.rb
@@ -199,6 +199,23 @@ EOF
         puts MemInfo.rss if (i % 1000 == 0)
       end
     end
+
+    describe "#2114 RelaxNG schema parsing has a small memory leak" do
+      it "no longer leaks" do
+        prev_rss = MemInfo.rss
+        100_001.times do |j|
+          Nokogiri::XML::RelaxNG.from_document(Nokogiri::XML::Document.parse(File.read(ADDRESS_SCHEMA_FILE)))
+          if (j % 10_000 == 0)
+            curr_rss = MemInfo.rss
+            diff_rss = curr_rss - prev_rss
+            printf("\n(iter %d) %d", j, curr_rss)
+            printf(" (%s%d)", diff_rss >= 0 ? "+" : "-", diff_rss) if j > 0
+            prev_rss = curr_rss
+          end
+        end
+        puts
+      end
+    end
   end # if NOKOGIRI_GC
 
   module MemInfo


### PR DESCRIPTION
**What problem is this PR intended to solve?**

https://github.com/sparklemotion/nokogiri/issues/2114

**Have you included adequate test coverage?**

Tests for specific memory leaks has provided little value to prevent regressions over the years; this leak in particular is unlikely to regress, but that said, I've added a test to `test/test_memory_leak.rb` which can be run with:

```
NOKOGIRI_GC=t bundle exec ruby -Ilib:test test/test_memory_leak.rb -n/#2114/ -v
```

Before this change, that test shows increasing memory usage:

```
#2114 RelaxNG schema parsing has a small memory leak#test_0001_no longer leaks = 
(iter 0) 39720
(iter 10000) 77532 (+37812)
(iter 20000) 77532 (+0)
(iter 30000) 78852 (+1320)
(iter 40000) 81756 (+2904)
(iter 50000) 84396 (+2640)
(iter 60000) 87036 (+2640)
(iter 70000) 89676 (+2640)
(iter 80000) 94692 (+5016)
(iter 90000) 95484 (+792)
(iter 100000) 97860 (+2376)
!6.48 s = .
```

And after, it shows stable memory usage:

```
#2114 RelaxNG schema parsing has a small memory leak#test_0001_no longer leaks = 
(iter 0) 39572
(iter 10000) 76632 (+37060)
(iter 20000) 76632 (+0)
(iter 30000) 76632 (+0)
(iter 40000) 76632 (+0)
(iter 50000) 76632 (+0)
(iter 60000) 76632 (+0)
(iter 70000) 76632 (+0)
(iter 80000) 76632 (+0)
(iter 90000) 76632 (+0)
(iter 100000) 76632 (+0)
!6.25 s = .
```

**Does this change affect the C or the Java implementations?**

This change is made only in the C implementation, and there are no functional changes.