### PR TITLE
Native gems: CI should test Linux native 32-bit gem

### DIFF
--- a/concourse/images/Dockerfile.alpine32.erb
+++ b/concourse/images/Dockerfile.alpine32.erb
@@ -1,0 +1,13 @@
+FROM i386/ruby:alpine
+
+# prelude
+RUN apk update
+RUN apk add bash build-base
+
+# valgrind
+RUN apk add valgrind
+
+# libxml-et-al
+RUN apk add libxml2-dev libxslt-dev pkgconfig
+
+<%= File.read "bundle-install.step" %>

--- a/concourse/images/Dockerfile.bionic32.erb
+++ b/concourse/images/Dockerfile.bionic32.erb
@@ -1,0 +1,9 @@
+FROM i386/ubuntu:bionic
+
+<%= File.read "debian-prelude.step" %>
+
+<%= File.read "debian-libxml-et-al.step" %>
+
+<%= File.read "debian-ruby.step" %>
+
+<%= File.read "bundle-install.step" %>

--- a/concourse/nokogiri.yml
+++ b/concourse/nokogiri.yml
@@ -51,6 +51,19 @@ jobs:
             TEST_WITH_SYSTEM_LIBRARIES: t
           run:
             path: ci/concourse/tasks/rake-test/run.sh
+      - task: rake-test-i386
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: {repository: "flavorjones/nokogiri-test", tag: bionic32}
+          inputs:
+            - name: ci
+            - name: nokogiri
+          params:
+            NOKOGIRI_USE_SYSTEM_LIBRARIES: t
+          run:
+            path: ci/concourse/tasks/rake-test/run.sh
 
 
   <% RUBIES[:mri].each do |ruby_version| %>
@@ -333,6 +346,60 @@ jobs:
             image_resource:
               type: registry-image
               source: {repository: "flavorjones/nokogiri-test", tag: "alpine"}
+            inputs:
+              - name: ci
+              - name: nokogiri
+              - name: gems
+            run:
+              path: ci/concourse/tasks/gem-test/gem-install-and-test.sh
+
+
+  - name: cruby-native-gem-test-32bit
+    public: true
+    on_failure: *notify_failure_to_irc
+    plan:
+      - get: ci
+      - get: nokogiri
+        trigger: true
+        version: every
+        passed:
+          <% RUBIES[:mri].each do |ruby_version| %>
+          - cruby-<%= ruby_version %>
+          <% end %>
+      - task: build
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: {repository: "larskanis/rake-compiler-dock-mri-x86-linux", tag: "<%= RakeCompilerDock::IMAGE_VERSION %>"}
+          inputs:
+            - name: ci
+            - name: nokogiri
+          outputs:
+            - name: gems
+          params:
+            BUILD_NATIVE_GEM: "x86-linux"
+          run:
+            path: ci/concourse/tasks/gem-test/gem-build.sh
+      - in_parallel:
+        - task: install-and-test-on-vanilla-32bit-ubuntu
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source: {repository: "flavorjones/nokogiri-test", tag: "bionic32"}
+            inputs:
+              - name: ci
+              - name: nokogiri
+              - name: gems
+            run:
+              path: ci/concourse/tasks/gem-test/gem-install-and-test.sh
+        - task: install-and-test-on-32bit-musl
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source: {repository: "flavorjones/nokogiri-test", tag: "alpine32"}
             inputs:
               - name: ci
               - name: nokogiri

--- a/concourse/tasks/gem-test/gem-build.sh
+++ b/concourse/tasks/gem-test/gem-build.sh
@@ -31,7 +31,7 @@ if [ -n "${BUILD_NATIVE_GEM:-}" ] ; then
     sudo sed -i 's/callback.call(spec) if callback/@cross_compiling.call(spec) if @cross_compiling/' $f
   done
 
-  bundle exec rake gem:x86_64-linux:guest
+  bundle exec rake gem:${BUILD_NATIVE_GEM}:guest
 else
   # TODO we're only compiling so that we retrieve libxml2/libxslt
   # tarballs, we can do better a couple of different ways

--- a/concourse/tasks/gem-test/gem-install-and-test.sh
+++ b/concourse/tasks/gem-test/gem-install-and-test.sh
@@ -16,7 +16,9 @@ popd
 
 pushd nokogiri
 
-  export BUNDLE_CACHE_PATH="${BUNDLE_APP_CONFIG}/cache"
+  if [ -n "${BUNDLE_APP_CONFIG:-}" ] ; then
+    export BUNDLE_CACHE_PATH="${BUNDLE_APP_CONFIG}/cache"
+  fi
   bundle -v
   bundle config
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Add test coverage for 32-bit Linux native gems.

We already have coverage for 32-bit Windows native gems within Appveyor: https://github.com/sparklemotion/nokogiri/blob/fbd65cd466d51119fb817677e7d1fd0c5d16dbb9/appveyor.yml#L46-L49

This is follow-on work related to https://github.com/sparklemotion/nokogiri/issues/1984


**Have you included adequate test coverage?**

The purpose of this PR is to add test coverage.


**Does this change affect the C or the Java implementations?**

No functional changes.