### PR TITLE
add native gem support for ruby 3

### DIFF
--- a/.cross_rubies
+++ b/.cross_rubies
@@ -1,3 +1,4 @@
+3.0.0:x86_64-darwin
 2.7.0:i686-w64-mingw32
 2.7.0:x86_64-w64-mingw32
 2.7.0:i686-linux-gnu

--- a/.cross_rubies
+++ b/.cross_rubies
@@ -1,3 +1,7 @@
+3.0.0:i686-w64-mingw32
+3.0.0:x86_64-w64-mingw32
+3.0.0:i686-linux-gnu
+3.0.0:x86_64-linux-gnu
 3.0.0:x86_64-darwin
 2.7.0:i686-w64-mingw32
 2.7.0:x86_64-w64-mingw32

--- a/concourse/nokogiri-pr.yml
+++ b/concourse/nokogiri-pr.yml
@@ -302,7 +302,7 @@ jobs:
       - #@ pend_pr("nokogiri-pr", job_name)
       - task: build
         config:
-          "_": #@ template.replace(registry_image("larskanis/rake-compiler-dock-mri-x86_64-linux", "<%= RakeCompilerDock::IMAGE_VERSION %>"))
+          "_": #@ template.replace(registry_image("flavorjones/rake-compiler-dock-mri-x86_64-linux", "<%= RakeCompilerDock::IMAGE_VERSION %>"))
           inputs: #@ task_inputs()
           outputs:
             - name: gems
@@ -340,7 +340,7 @@ jobs:
       - #@ pend_pr("nokogiri-pr", job_name)
       - task: build
         config:
-          "_": #@ template.replace(registry_image("larskanis/rake-compiler-dock-mri-x86_64-linux", "<%= RakeCompilerDock::IMAGE_VERSION %>"))
+          "_": #@ template.replace(registry_image("flavorjones/rake-compiler-dock-mri-x86_64-linux", "<%= RakeCompilerDock::IMAGE_VERSION %>"))
           inputs: #@ task_inputs()
           outputs:
             - name: gems
@@ -350,6 +350,7 @@ jobs:
             path: ci/concourse/tasks/gem-test/gem-build.sh
       - in_parallel:
         <% $native_ruby_versions.each do |ruby_version| %>
+          <% ruby_version = "3.0-rc" if ruby_version == "3.0" %>
         - task: install-and-test-<%= ruby_version %>
           config:
             "_": #@ template.replace(registry_image("flavorjones/nokogiri-test", "mri-<%= ruby_version %>"))

--- a/concourse/nokogiri-pr.yml.generated
+++ b/concourse/nokogiri-pr.yml.generated
@@ -922,7 +922,7 @@ jobs:
   - config:
       image_resource:
         source:
-          repository: larskanis/rake-compiler-dock-mri-x86_64-linux
+          repository: flavorjones/rake-compiler-dock-mri-x86_64-linux
           tag: 1.0.0
         type: registry-image
       inputs:
@@ -1021,7 +1021,7 @@ jobs:
   - config:
       image_resource:
         source:
-          repository: larskanis/rake-compiler-dock-mri-x86_64-linux
+          repository: flavorjones/rake-compiler-dock-mri-x86_64-linux
           tag: 1.0.0
         type: registry-image
       inputs:
@@ -1098,6 +1098,21 @@ jobs:
           run:
             path: ci/concourse/tasks/gem-test/gem-install-and-test.sh
         task: install-and-test-2.7
+      - config:
+          image_resource:
+            source:
+              repository: flavorjones/nokogiri-test
+              tag: mri-3.0-rc
+            type: registry-image
+          inputs:
+          - name: ci
+          - name: nokogiri-pr
+            path: nokogiri
+          - name: gems
+          platform: linux
+          run:
+            path: ci/concourse/tasks/gem-test/gem-install-and-test.sh
+        task: install-and-test-3.0-rc
       - config:
           image_resource:
             source:

--- a/concourse/nokogiri.yml
+++ b/concourse/nokogiri.yml
@@ -56,9 +56,7 @@ jobs:
   <% RUBIES[:mri].each do |ruby_version| %>
   - name: cruby-<%= ruby_version %>
     public: true
-    <% if Concourse.production_rubies.include?(ruby_version) %>
     on_failure: { in_parallel: [*notify_failure_to_irc, *notify_failure_to_gitter] }
-    <% end %>
     plan:
       - get: ci
       - get: nokogiri
@@ -250,7 +248,7 @@ jobs:
           platform: linux
           image_resource:
             type: registry-image
-            source: {repository: "larskanis/rake-compiler-dock-mri-x86_64-linux", tag: "<%= RakeCompilerDock::IMAGE_VERSION %>"}
+            source: {repository: "flavorjones/rake-compiler-dock-mri-x86_64-linux", tag: "<%= RakeCompilerDock::IMAGE_VERSION %>"}
           inputs:
             - name: ci
             - name: nokogiri
@@ -302,7 +300,7 @@ jobs:
           platform: linux
           image_resource:
             type: registry-image
-            source: {repository: "larskanis/rake-compiler-dock-mri-x86_64-linux", tag: "<%= RakeCompilerDock::IMAGE_VERSION %>"}
+            source: {repository: "flavorjones/rake-compiler-dock-mri-x86_64-linux", tag: "<%= RakeCompilerDock::IMAGE_VERSION %>"}
           inputs:
             - name: ci
             - name: nokogiri
@@ -314,6 +312,7 @@ jobs:
             path: ci/concourse/tasks/gem-test/gem-build.sh
       - in_parallel:
         <% $native_ruby_versions.each do |ruby_version| %>
+          <% ruby_version = "3.0-rc" if ruby_version == "3.0" %>
         - task: install-and-test-<%= ruby_version %>
           config:
             platform: linux

--- a/concourse/nokogiri.yml.generated
+++ b/concourse/nokogiri.yml.generated
@@ -285,6 +285,15 @@ jobs:
     task: rake-test-valgrind
   public: true
 - name: cruby-3.0-rc
+  on_failure:
+    in_parallel:
+      steps:
+      - params:
+          message: ($BUILD_PIPELINE_NAME/$BUILD_JOB_NAME) The build failed ($BUILD_URL)
+        put: irc
+      - params:
+          status: failed
+        put: gitter
   plan:
   - get: ci
   - get: nokogiri
@@ -531,7 +540,7 @@ jobs:
   - config:
       image_resource:
         source:
-          repository: larskanis/rake-compiler-dock-mri-x86_64-linux
+          repository: flavorjones/rake-compiler-dock-mri-x86_64-linux
           tag: 1.0.0
         type: registry-image
       inputs:
@@ -597,7 +606,7 @@ jobs:
   - config:
       image_resource:
         source:
-          repository: larskanis/rake-compiler-dock-mri-x86_64-linux
+          repository: flavorjones/rake-compiler-dock-mri-x86_64-linux
           tag: 1.0.0
         type: registry-image
       inputs:
@@ -669,6 +678,20 @@ jobs:
           run:
             path: ci/concourse/tasks/gem-test/gem-install-and-test.sh
         task: install-and-test-2.7
+      - config:
+          image_resource:
+            source:
+              repository: flavorjones/nokogiri-test
+              tag: mri-3.0-rc
+            type: registry-image
+          inputs:
+          - name: ci
+          - name: nokogiri
+          - name: gems
+          platform: linux
+          run:
+            path: ci/concourse/tasks/gem-test/gem-install-and-test.sh
+        task: install-and-test-3.0-rc
       - config:
           image_resource:
             source:

--- a/scripts/setup-osx-native-builders
+++ b/scripts/setup-osx-native-builders
@@ -32,6 +32,10 @@ for ruby in $RUBIES ; do
   ruby_fullname="native-builder-${ruby}"
   ruby_minor="${ruby}.0"
 
+  if [[ $ruby == "3.0" ]] ; then
+    ruby="3.0.0-preview1"
+  fi
+
   rbconfig=$(echo ${RUBIES_DIR}/${ruby_fullname}/lib/ruby/${ruby_minor}/*/rbconfig.rb)
   if [[ ! -e $rbconfig ]] ; then
     echo "installing $ruby_fullname ..."


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See #2123, we want to ship a release candidate of native gems that support the current Ruby 3.0.0-preview1 and potentially the upcoming Ruby 3.0.0 final release.


**Have you included adequate test coverage?**

Yes, additional CI task has been created to ensure that the native gem builds and packages a `nokogiri.so` that supports ruby 3.0, but also exercises that the gem can be installed and runs correctly.


**Does this change affect the behavior of either the C or the Java implementations?**

This change only impacts the build and packaging of native gems.