### PR TITLE
native gems noted in versioninfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,25 +144,29 @@ the output of `nokogiri -v` will also reflect these changes.
 * `libxml/libxml2_path`
 * `libxml/libxslt_path`
 
+`Nokogiri::VersionInfo` now contains native gem metadata for libxml:
+* `libxml/precompiled` (`true` if the gem installed was a native gem, otherwise `false`)
+* `libxml/iconv_enabled` (`true` if libxml2 was built with iconv support, otherwise `false`)
+
 `Nokogiri::VersionInfo` now contains version metadata for libxslt:
 * `libxslt/source` (either "packaged" or "system", similar to `libxml/source`)
-* `libxslt/compiled` (the version of libxslt compiled at installation time, similar to `libxml/compiled`)
+* `libxslt/precompiled` (`true` if the gem installed was a native gem, otherwise `false`)
+* `libxslt/compiled` (the version of libxslt the gem was compiled against, similar to `libxml/compiled`)
 * `libxslt/loaded` (the version of libxslt loaded at runtime, similar to `libxml/loaded`)
 * `libxslt/patches` moved from `libxml/libxslt_patches`
 
 `Nokogiri::VersionInfo` key `libxml/libxml2_patches` has been renamed to `libxml/patches`
 
-These C macros will no longer be defined:
-* `NOKOGIRI_LIBXML2_PATH`
-* `NOKOGIRI_LIBXSLT_PATH`
-
-These global variables will no longer be defined:
+These global variables are no longer be defined:
 * `NOKOGIRI_LIBXML2_PATH`
 * `NOKOGIRI_LIBXSLT_PATH`
 
 These constants have been renamed:
 * `Nokogiri::LIBXML_VERSION` is now `Nokogiri::LIBXML_COMPILED_VERSION`
 * `Nokogiri::LIBXML_PARSER_VERSION` is now `Nokogiri::LIBXML_LOADED_VERSION`
+* `Nokogiri::NOKOGIRI_LIBXML2_PATCHES` is now `Nokogiri::LIBXML2_PATCHES`
+* `Nokogiri::NOKOGIRI_LIBXSLT_PATCHES` is now `Nokogiri::LIBXSLT_PATCHES`
+* `Nokogiri::NOKOGIRI_USE_PACKAGED_LIBRARIES` is now `Nokogiri::PACKAGED_LIBRARIES`
 
 These methods have been renamed and the return type changed from `String` to `Gem::Version`:
 * `VersionInfo#loaded_parser_version` is now `#loaded_libxml_version`
@@ -205,21 +209,29 @@ but now looks like:
     warnings: []
     nokogiri: 1.11.0
     ruby:
-      version: 2.7.0
+      version: 2.7.2
       platform: x86_64-linux
-      description: ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-linux]
+      gem_platform: x86_64-linux
+      description: ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
       engine: ruby
     libxml:
       source: packaged
+      precompiled: false
       patches:
       - 0001-Revert-Do-not-URI-escape-in-server-side-includes.patch
       - 0002-Remove-script-macro-support.patch
       - 0003-Update-entities-to-remove-handling-of-ssi.patch
       - 0004-libxml2.la-is-in-top_builddir.patch
+      - 0005-Fix-infinite-loop-in-xmlStringLenDecodeEntities.patch
+      - 0006-htmlParseComment-treat-as-if-it-closed-the-comment.patch
+      - 0007-rewrite-htmlParseLookupSequence-to-accept-an-arbitra.patch
+      - '0008-use-new-htmlParseLookupCommentEnd-to-find-comment-en.patch'
+      iconv_enabled: true
       compiled: 2.9.10
       loaded: 2.9.10
     libxslt:
       source: packaged
+      precompiled: false
       patches: []
       compiled: 1.1.34
       loaded: 1.1.34

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -687,7 +687,9 @@ else
     ]
   end
 
-  $CFLAGS = concat_flags($CFLAGS, "-DNOKOGIRI_USE_PACKAGED_LIBRARIES")
+  append_cflags("-DNOKOGIRI_PACKAGED_LIBRARIES")
+  append_cflags("-DNOKOGIRI_PRECOMPILED_LIBRARIES") if cross_build_p
+
   $LIBPATH = ["#{zlib_recipe.path}/lib"] | $LIBPATH if zlib_recipe
   $LIBPATH = ["#{libiconv_recipe.path}/lib"] | $LIBPATH if libiconv_recipe
 

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -20,8 +20,9 @@ int vasprintf(char **strp, const char *fmt, va_list ap)
   char tmp[1];
   int len = vsnprintf (tmp, 1, fmt, ap) + 1;
   char *res = (char *)malloc((unsigned int)len);
-  if (res == NULL)
-      return -1;
+  if (res == NULL) {
+    return -1;
+  }
   *strp = res;
   return vsnprintf(res, (unsigned int)len, fmt, ap);
 }
@@ -35,7 +36,7 @@ void nokogiri_root_node(xmlNodePtr node)
   nokogiriTuplePtr tuple;
 
   doc = node->doc;
-  if (doc->type == XML_DOCUMENT_FRAG_NODE) doc = doc->doc;
+  if (doc->type == XML_DOCUMENT_FRAG_NODE) { doc = doc->doc; }
   tuple = (nokogiriTuplePtr)doc->_private;
   st_insert(tuple->unlinkedNodes, (st_data_t)node, (st_data_t)node);
 }
@@ -44,7 +45,7 @@ void nokogiri_root_nsdef(xmlNsPtr ns, xmlDocPtr doc)
 {
   nokogiriTuplePtr tuple;
 
-  if (doc->type == XML_DOCUMENT_FRAG_NODE) doc = doc->doc;
+  if (doc->type == XML_DOCUMENT_FRAG_NODE) { doc = doc->doc; }
   tuple = (nokogiriTuplePtr)doc->_private;
   st_insert(tuple->unlinkedNodes, (st_data_t)ns, (st_data_t)ns);
 }
@@ -52,10 +53,10 @@ void nokogiri_root_nsdef(xmlNsPtr ns, xmlDocPtr doc)
 void Init_nokogiri()
 {
   xmlMemSetup(
-      (xmlFreeFunc)ruby_xfree,
-      (xmlMallocFunc)ruby_xmalloc,
-      (xmlReallocFunc)ruby_xrealloc,
-      ruby_strdup
+    (xmlFreeFunc)ruby_xfree,
+    (xmlMallocFunc)ruby_xmalloc,
+    (xmlReallocFunc)ruby_xrealloc,
+    ruby_strdup
   );
 
   mNokogiri         = rb_define_module("Nokogiri");
@@ -65,24 +66,12 @@ void Init_nokogiri()
   mNokogiriXmlSax   = rb_define_module_under(mNokogiriXml, "SAX");
   mNokogiriHtmlSax  = rb_define_module_under(mNokogiriHtml, "SAX");
 
-  rb_const_set( mNokogiri,
-                rb_intern("LIBXML_COMPILED_VERSION"),
-                NOKOGIRI_STR_NEW2(LIBXML_DOTTED_VERSION)
-              );
-  rb_const_set( mNokogiri,
-                rb_intern("LIBXML_LOADED_VERSION"),
-                NOKOGIRI_STR_NEW2(xmlParserVersion)
-              );
+  rb_const_set(mNokogiri, rb_intern("LIBXML_COMPILED_VERSION"), NOKOGIRI_STR_NEW2(LIBXML_DOTTED_VERSION));
+  rb_const_set(mNokogiri, rb_intern("LIBXML_LOADED_VERSION"), NOKOGIRI_STR_NEW2(xmlParserVersion));
 
+  rb_const_set(mNokogiri, rb_intern("LIBXSLT_COMPILED_VERSION"), NOKOGIRI_STR_NEW2(LIBXSLT_DOTTED_VERSION));
+  rb_const_set(mNokogiri, rb_intern("LIBXSLT_LOADED_VERSION"), NOKOGIRI_STR_NEW2(xsltEngineVersion));
 
-  rb_const_set( mNokogiri,
-                rb_intern("LIBXSLT_COMPILED_VERSION"),
-                NOKOGIRI_STR_NEW2(LIBXSLT_DOTTED_VERSION)
-              );
-  rb_const_set( mNokogiri,
-                rb_intern("LIBXSLT_LOADED_VERSION"),
-                NOKOGIRI_STR_NEW2(xsltEngineVersion)
-              );
 
 #ifdef NOKOGIRI_USE_PACKAGED_LIBRARIES
   rb_const_set(mNokogiri, rb_intern("NOKOGIRI_USE_PACKAGED_LIBRARIES"), Qtrue);

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -72,15 +72,20 @@ void Init_nokogiri()
   rb_const_set(mNokogiri, rb_intern("LIBXSLT_COMPILED_VERSION"), NOKOGIRI_STR_NEW2(LIBXSLT_DOTTED_VERSION));
   rb_const_set(mNokogiri, rb_intern("LIBXSLT_LOADED_VERSION"), NOKOGIRI_STR_NEW2(xsltEngineVersion));
 
-
-#ifdef NOKOGIRI_USE_PACKAGED_LIBRARIES
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_USE_PACKAGED_LIBRARIES"), Qtrue);
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXML2_PATCHES"), rb_str_split(NOKOGIRI_STR_NEW2(NOKOGIRI_LIBXML2_PATCHES), " "));
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXSLT_PATCHES"), rb_str_split(NOKOGIRI_STR_NEW2(NOKOGIRI_LIBXSLT_PATCHES), " "));
+#ifdef NOKOGIRI_PACKAGED_LIBRARIES
+  rb_const_set(mNokogiri, rb_intern("PACKAGED_LIBRARIES"), Qtrue);
+#ifdef NOKOGIRI_PRECOMPILED_LIBRARIES
+  rb_const_set(mNokogiri, rb_intern("PRECOMPILED_LIBRARIES"), Qtrue);
 #else
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_USE_PACKAGED_LIBRARIES"), Qfalse);
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXML2_PATCHES"), Qnil);
-  rb_const_set(mNokogiri, rb_intern("NOKOGIRI_LIBXSLT_PATCHES"), Qnil);
+  rb_const_set(mNokogiri, rb_intern("PRECOMPILED_LIBRARIES"), Qfalse);
+#endif
+  rb_const_set(mNokogiri, rb_intern("LIBXML2_PATCHES"), rb_str_split(NOKOGIRI_STR_NEW2(NOKOGIRI_LIBXML2_PATCHES), " "));
+  rb_const_set(mNokogiri, rb_intern("LIBXSLT_PATCHES"), rb_str_split(NOKOGIRI_STR_NEW2(NOKOGIRI_LIBXSLT_PATCHES), " "));
+#else
+  rb_const_set(mNokogiri, rb_intern("PACKAGED_LIBRARIES"), Qfalse);
+  rb_const_set(mNokogiri, rb_intern("PRECOMPILED_LIBRARIES"), Qfalse);
+  rb_const_set(mNokogiri, rb_intern("LIBXML2_PATCHES"), Qnil);
+  rb_const_set(mNokogiri, rb_intern("LIBXSLT_PATCHES"), Qnil);
 #endif
 
 #ifdef LIBXML_ICONV_ENABLED

--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -10,25 +10,25 @@ module Nokogiri
     end
 
     def loaded_libxml_version
-      Gem::Version.new(LIBXML_LOADED_VERSION.
-        scan(/^(\d+)(\d\d)(\d\d)(?!\d)/).first.
-        collect(&:to_i).
-        join("."))
+      Gem::Version.new(LIBXML_LOADED_VERSION
+        .scan(/^(\d+)(\d\d)(\d\d)(?!\d)/).first
+        .collect(&:to_i)
+        .join("."))
     end
 
     def compiled_libxml_version
-      Gem::Version.new LIBXML_COMPILED_VERSION
+      Gem::Version.new(LIBXML_COMPILED_VERSION)
     end
 
     def loaded_libxslt_version
-      Gem::Version.new(LIBXSLT_LOADED_VERSION.
-        scan(/^(\d+)(\d\d)(\d\d)(?!\d)/).first.
-        collect(&:to_i).
-        join("."))
+      Gem::Version.new(LIBXSLT_LOADED_VERSION
+        .scan(/^(\d+)(\d\d)(\d\d)(?!\d)/).first
+        .collect(&:to_i)
+        .join("."))
     end
 
     def compiled_libxslt_version
-      Gem::Version.new LIBXSLT_COMPILED_VERSION
+      Gem::Version.new(LIBXSLT_COMPILED_VERSION)
     end
 
     def libxml2?
@@ -129,7 +129,7 @@ module Nokogiri
   def self.uses_libxml?(requirement = nil) # :nodoc:
     return false unless VersionInfo.instance.libxml2?
     return true unless requirement
-    return Gem::Requirement.new(requirement).satisfied_by?(VersionInfo.instance.loaded_libxml_version)
+    Gem::Requirement.new(requirement).satisfied_by?(VersionInfo.instance.loaded_libxml_version)
   end
 
   def self.jruby? # :nodoc:
@@ -142,7 +142,7 @@ module Nokogiri
   end
   begin
     RUBY_VERSION =~ /(\d+\.\d+)/
-    require "nokogiri/#{$1}/nokogiri"
+    require "nokogiri/#{Regexp.last_match(1)}/nokogiri"
   rescue LoadError
     require "nokogiri/nokogiri"
   end

--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -6,49 +6,49 @@ module Nokogiri
     include Singleton
 
     def jruby?
-      ::JRUBY_VERSION if RUBY_PLATFORM == "java"
+      ::JRUBY_VERSION if ::RUBY_PLATFORM == "java"
     end
 
     def engine
-      defined?(RUBY_ENGINE) ? RUBY_ENGINE : "mri"
+      defined?(::RUBY_ENGINE) ? ::RUBY_ENGINE : "mri"
     end
 
     def loaded_libxml_version
-      Gem::Version.new(LIBXML_LOADED_VERSION
+      Gem::Version.new(Nokogiri::LIBXML_LOADED_VERSION
         .scan(/^(\d+)(\d\d)(\d\d)(?!\d)/).first
         .collect(&:to_i)
         .join("."))
     end
 
     def compiled_libxml_version
-      Gem::Version.new(LIBXML_COMPILED_VERSION)
+      Gem::Version.new(Nokogiri::LIBXML_COMPILED_VERSION)
     end
 
     def loaded_libxslt_version
-      Gem::Version.new(LIBXSLT_LOADED_VERSION
+      Gem::Version.new(Nokogiri::LIBXSLT_LOADED_VERSION
         .scan(/^(\d+)(\d\d)(\d\d)(?!\d)/).first
         .collect(&:to_i)
         .join("."))
     end
 
     def compiled_libxslt_version
-      Gem::Version.new(LIBXSLT_COMPILED_VERSION)
+      Gem::Version.new(Nokogiri::LIBXSLT_COMPILED_VERSION)
     end
 
     def libxml2?
-      defined?(LIBXML_COMPILED_VERSION)
+      defined?(Nokogiri::LIBXML_COMPILED_VERSION)
     end
 
     def libxml2_has_iconv?
-      defined?(LIBXML_ICONV_ENABLED) && LIBXML_ICONV_ENABLED
-    end
-
-    def libxml2_using_system?
-      !libxml2_using_packaged?
+      defined?(Nokogiri::LIBXML_ICONV_ENABLED) && Nokogiri::LIBXML_ICONV_ENABLED
     end
 
     def libxml2_using_packaged?
-      NOKOGIRI_USE_PACKAGED_LIBRARIES
+      libxml2? && Nokogiri::PACKAGED_LIBRARIES
+    end
+
+    def libxml2_using_system?
+      libxml2? && !libxml2_using_packaged?
     end
 
     def warnings
@@ -142,7 +142,7 @@ module Nokogiri
     require "nokogiri/jruby/dependencies"
   end
   begin
-    RUBY_VERSION =~ /(\d+\.\d+)/
+    ::RUBY_VERSION =~ /(\d+\.\d+)/
     require "nokogiri/#{Regexp.last_match(1)}/nokogiri"
   rescue LoadError
     require "nokogiri/nokogiri"

--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
+require "singleton"
+
 module Nokogiri
   class VersionInfo # :nodoc:
+    include Singleton
+
     def jruby?
       ::JRUBY_VERSION if RUBY_PLATFORM == "java"
     end
@@ -118,12 +122,9 @@ module Nokogiri
       YAML.dump(to_hash).each_line.map { |line| "    #{line}" }.join
     end
 
-    # FIXME: maybe switch to singleton?
-    @@instance = new
-    @@instance.warnings.each do |warning|
+    instance.warnings.each do |warning|
       warn "WARNING: #{warning}"
     end
-    def self.instance; @@instance; end
   end
 
   def self.uses_libxml?(requirement = nil) # :nodoc:

--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -51,6 +51,10 @@ module Nokogiri
       libxml2? && !libxml2_using_packaged?
     end
 
+    def libxml2_precompiled?
+      libxml2_using_packaged? && Nokogiri::PRECOMPILED_LIBRARIES
+    end
+
     def warnings
       warnings = []
 
@@ -84,19 +88,21 @@ module Nokogiri
           vi["libxml"] = {}.tap do |libxml|
             if libxml2_using_packaged?
               libxml["source"] = "packaged"
-              libxml["patches"] = NOKOGIRI_LIBXML2_PATCHES
+              libxml["precompiled"] = libxml2_precompiled?
+              libxml["patches"] = Nokogiri::LIBXML2_PATCHES
             else
               libxml["source"] = "system"
             end
+            libxml["iconv_enabled"] = libxml2_has_iconv?
             libxml["compiled"] = compiled_libxml_version.to_s
             libxml["loaded"] = loaded_libxml_version.to_s
-            libxml["iconv_enabled"] = libxml2_has_iconv?
           end
 
           vi["libxslt"] = {}.tap do |libxslt|
             if libxml2_using_packaged?
               libxslt["source"] = "packaged"
-              libxslt["patches"] = NOKOGIRI_LIBXSLT_PATCHES
+              libxslt["precompiled"] = libxml2_precompiled?
+              libxslt["patches"] = Nokogiri::LIBXSLT_PATCHES
             else
               libxslt["source"] = "system"
             end

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -19,12 +19,12 @@ module TestVersionInfoTests
 
   def test_version_info_for_xerces
     skip "xerces is only used for JRuby" unless Nokogiri.jruby?
-    assert_equal @version_info["xerces"], Nokogiri::VERSION_INFO["xerces"]
+    assert_equal @version_info["xerces"], Nokogiri::XERCES_VERSION
   end
 
   def test_version_info_for_nekohtml
     skip "nekohtml is only used for JRuby" unless Nokogiri.jruby?
-    assert_equal @version_info["nekohtml"], Nokogiri::VERSION_INFO["nekohtml"]
+    assert_equal @version_info["nekohtml"], Nokogiri::NEKO_VERSION
   end
 
   def test_version_info_for_libxml

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "rbconfig"
 require "json"
@@ -10,59 +11,59 @@ module TestVersionInfoTests
   #  `nokogiri/version.rb` is required. See #1896 for background.
   #
   def test_version_info_basics
-    assert_match VERSION_MATCH, Nokogiri::VERSION
+    assert_match(VERSION_MATCH, Nokogiri::VERSION)
 
-    assert_equal Nokogiri::VERSION_INFO["ruby"]["version"], ::RUBY_VERSION
-    assert_equal Nokogiri::VERSION_INFO["ruby"]["platform"], ::RUBY_PLATFORM
-    assert_equal Nokogiri::VERSION_INFO["ruby"]["gem_platform"], ::Gem::Platform.local.to_s
+    assert_equal(::RUBY_VERSION, Nokogiri::VERSION_INFO["ruby"]["version"])
+    assert_equal(::RUBY_PLATFORM, Nokogiri::VERSION_INFO["ruby"]["platform"])
+    assert_equal(::Gem::Platform.local.to_s, Nokogiri::VERSION_INFO["ruby"]["gem_platform"])
   end
 
   def test_version_info_for_xerces
-    skip "xerces is only used for JRuby" unless Nokogiri.jruby?
-    assert_equal @version_info["xerces"], Nokogiri::XERCES_VERSION
+    skip("xerces is only used for JRuby") unless Nokogiri.jruby?
+    assert_equal(Nokogiri::XERCES_VERSION, version_info["xerces"])
   end
 
   def test_version_info_for_nekohtml
-    skip "nekohtml is only used for JRuby" unless Nokogiri.jruby?
-    assert_equal @version_info["nekohtml"], Nokogiri::NEKO_VERSION
+    skip("nekohtml is only used for JRuby") unless Nokogiri.jruby?
+    assert_equal(Nokogiri::NEKO_VERSION, version_info["nekohtml"])
   end
 
   def test_version_info_for_libxml
-    skip "libxml2 is only used for CRuby" unless Nokogiri.uses_libxml?
+    skip("libxml2 is only used for CRuby") unless Nokogiri.uses_libxml?
 
-    assert_equal @version_info["libxml"]["compiled"], Nokogiri::LIBXML_COMPILED_VERSION
-    assert_match VERSION_MATCH, @version_info["libxml"]["compiled"]
+    assert_equal(Nokogiri::LIBXML_COMPILED_VERSION, version_info["libxml"]["compiled"])
+    assert_match(VERSION_MATCH, version_info["libxml"]["compiled"])
 
-    assert_match VERSION_MATCH, @version_info["libxml"]["loaded"]
+    assert_match VERSION_MATCH, version_info["libxml"]["loaded"]
     Nokogiri::LIBXML_LOADED_VERSION =~ /(\d)(\d{2})(\d{2})/
-    major = $1.to_i
-    minor = $2.to_i
-    bug = $3.to_i
-    assert_equal "#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxml"]["loaded"]
+    major = Regexp.last_match(1).to_i
+    minor = Regexp.last_match(2).to_i
+    bug = Regexp.last_match(3).to_i
+    assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxml"]["loaded"])
 
-    assert @version_info["libxml"]["source"]
+    assert(version_info["libxml"]["source"])
   end
 
   def test_version_info_for_libxslt
-    skip "libxslt is only used for CRuby" unless Nokogiri.uses_libxml?
+    skip("libxslt is only used for CRuby") unless Nokogiri.uses_libxml?
 
-    assert_equal @version_info["libxslt"]["compiled"], Nokogiri::LIBXSLT_COMPILED_VERSION
-    assert_match VERSION_MATCH, @version_info["libxslt"]["compiled"]
+    assert_equal(Nokogiri::LIBXSLT_COMPILED_VERSION, version_info["libxslt"]["compiled"])
+    assert_match(VERSION_MATCH, version_info["libxslt"]["compiled"])
 
-    assert_match VERSION_MATCH, @version_info["libxslt"]["loaded"]
+    assert_match(VERSION_MATCH, version_info["libxslt"]["loaded"])
     Nokogiri::LIBXSLT_LOADED_VERSION =~ /(\d)(\d{2})(\d{2})/
-    major = $1.to_i
-    minor = $2.to_i
-    bug = $3.to_i
-    assert_equal "#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxslt"]["loaded"]
+    major = Regexp.last_match(1).to_i
+    minor = Regexp.last_match(2).to_i
+    bug = Regexp.last_match(3).to_i
+    assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxslt"]["loaded"])
 
-    assert @version_info["libxslt"]["source"]
+    assert(version_info["libxslt"]["source"])
   end
 
   def test_version_info_for_iconv
-    skip "this value is only set in the C extension when libxml2 is used" if !Nokogiri.uses_libxml?
+    skip("this value is only set in the C extension when libxml2 is used") unless Nokogiri.uses_libxml?
 
-    assert_operator @version_info["libxml"], :key?, "iconv_enabled"
+    assert_operator(version_info["libxml"], :key?, "iconv_enabled")
   end
 end
 
@@ -71,30 +72,23 @@ class TestVersionInfo
   ROOTDIR = File.expand_path(File.join(File.dirname(__FILE__), ".."))
 
   class Base < Nokogiri::TestCase
-    def setup
-      super
+    let(:version_info) do
       version_info = Dir.chdir(ROOTDIR) do
-        `#{RUBYEXEC} -Ilib -rjson -r#{@require_me} -e 'puts Nokogiri::VERSION_INFO.to_json'`
+        %x(#{RUBYEXEC} -Ilib -rjson -r#{require_name} -e 'puts Nokogiri::VERSION_INFO.to_json')
       end
-      @version_info = JSON.parse version_info
+      JSON.parse(version_info)
     end
   end
 
   class RequireNokogiri < TestVersionInfo::Base
     include TestVersionInfoTests
 
-    def setup
-      @require_me = "nokogiri"
-      super
-    end
+    let(:require_name) { "nokogiri" }
   end
 
   class RequireVersionFileOnly < TestVersionInfo::Base
     include TestVersionInfoTests
 
-    def setup
-      @require_me = "nokogiri/version"
-      super
-    end
+    let(:require_name) { "nokogiri/version" }
   end
 end

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -31,6 +31,14 @@ module TestVersionInfoTests
   def test_version_info_for_libxml
     skip("libxml2 is only used for CRuby") unless Nokogiri.uses_libxml?
 
+    if Nokogiri::VersionInfo.instance.libxml2_using_packaged?
+      assert_equal("packaged", version_info["libxml"]["source"])
+      assert(version_info["libxml"]["patches"])
+    end
+    if Nokogiri::VersionInfo.instance.libxml2_using_system?
+      assert_equal("system", version_info["libxml"]["source"])
+    end
+
     assert_equal(Nokogiri::LIBXML_COMPILED_VERSION, version_info["libxml"]["compiled"])
     assert_match(VERSION_MATCH, version_info["libxml"]["compiled"])
 
@@ -41,11 +49,19 @@ module TestVersionInfoTests
     bug = Regexp.last_match(3).to_i
     assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxml"]["loaded"])
 
-    assert(version_info["libxml"]["source"])
+    assert(version_info["libxml"].key?("iconv_enabled"))
   end
 
   def test_version_info_for_libxslt
     skip("libxslt is only used for CRuby") unless Nokogiri.uses_libxml?
+
+    if Nokogiri::VersionInfo.instance.libxml2_using_packaged?
+      assert_equal("packaged", version_info["libxslt"]["source"])
+      assert(version_info["libxslt"]["patches"])
+    end
+    if Nokogiri::VersionInfo.instance.libxml2_using_system?
+      assert_equal("system", version_info["libxslt"]["source"])
+    end
 
     assert_equal(Nokogiri::LIBXSLT_COMPILED_VERSION, version_info["libxslt"]["compiled"])
     assert_match(VERSION_MATCH, version_info["libxslt"]["compiled"])
@@ -56,14 +72,6 @@ module TestVersionInfoTests
     minor = Regexp.last_match(2).to_i
     bug = Regexp.last_match(3).to_i
     assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxslt"]["loaded"])
-
-    assert(version_info["libxslt"]["source"])
-  end
-
-  def test_version_info_for_iconv
-    skip("this value is only set in the C extension when libxml2 is used") unless Nokogiri.uses_libxml?
-
-    assert_operator(version_info["libxml"], :key?, "iconv_enabled")
   end
 end
 

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -34,9 +34,12 @@ module TestVersionInfoTests
     if Nokogiri::VersionInfo.instance.libxml2_using_packaged?
       assert_equal("packaged", version_info["libxml"]["source"])
       assert(version_info["libxml"]["patches"])
+      assert_equal(Nokogiri::VersionInfo.instance.libxml2_precompiled?, version_info["libxml"]["precompiled"])
     end
     if Nokogiri::VersionInfo.instance.libxml2_using_system?
       assert_equal("system", version_info["libxml"]["source"])
+      refute(version_info["libxml"].key?("precompiled"))
+      refute(version_info["libxml"].key?("patches"))
     end
 
     assert_equal(Nokogiri::LIBXML_COMPILED_VERSION, version_info["libxml"]["compiled"])
@@ -58,9 +61,12 @@ module TestVersionInfoTests
     if Nokogiri::VersionInfo.instance.libxml2_using_packaged?
       assert_equal("packaged", version_info["libxslt"]["source"])
       assert(version_info["libxslt"]["patches"])
+      assert_equal(Nokogiri::VersionInfo.instance.libxml2_precompiled?, version_info["libxslt"]["precompiled"])
     end
     if Nokogiri::VersionInfo.instance.libxml2_using_system?
       assert_equal("system", version_info["libxslt"]["source"])
+      refute(version_info["libxslt"].key?("precompiled"))
+      refute(version_info["libxslt"].key?("patches"))
     end
 
     assert_equal(Nokogiri::LIBXSLT_COMPILED_VERSION, version_info["libxslt"]["compiled"])


### PR DESCRIPTION
**What problem is this PR intended to solve?**

When a user installs a native (precompiled) gem, it should be distinguished in some way from the `ruby` platform gem that is compiled during installation. See https://github.com/sparklemotion/nokogiri/issues/2075 for background.

**Have you included adequate test coverage?**

Yes!

**Does this change affect the behavior of either the C or the Java implementations?**

This changes the names of some of the constants in the C implementation, which I don't consider to be a breaking change since `VersionInfo` is intended to be the interface for this kind of metadata.