### PR TITLE
fix: the CSS `~=` operator handles non-space whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ See note below about CVE-2020-26247 in the "Changed" subsection entitled "XML::S
 
 ### Fixed
 
+* The CSS `~=` operator now correctly handles non-space whitespace in the `class` attribute.
 * The switch to turn off the CSS-to-XPath cache is now thread-local, rather than being shared mutable state. [[#1935](https://github.com/sparklemotion/nokogiri/issues/1935)]
 * The Node methods add_previous_sibling, previous=, before, add_next_sibling, next=, after, replace, and swap now correctly use their parent as the context node for parsing markup. These methods now also raise a RuntimeError if they are called on a node with no parent. [[nokogumbo#160](https://github.com/rubys/nokogumbo/issues/160)
 * [CRuby] Fixed installation on AIX with respect to `vasprintf`. [[#1908](https://github.com/sparklemotion/nokogiri/issues/1908)]

--- a/lib/nokogiri/css/xpath_visitor.rb
+++ b/lib/nokogiri/css/xpath_visitor.rb
@@ -3,7 +3,6 @@ module Nokogiri
   module CSS
     class XPathVisitor # :nodoc:
       def visit_function node
-
         msg = :"visit_function_#{node.value.first.gsub(/[(]/, '')}"
         return self.send(msg, node) if self.respond_to?(msg)
 
@@ -75,11 +74,11 @@ module Nokogiri
       end
 
       def visit_attribute_condition node
-         attribute = if (node.value.first.type == :FUNCTION) or (node.value.first.value.first =~ /::/)
-                       ''
-                     else
-                       '@'
-                     end
+        attribute = if (node.value.first.type == :FUNCTION) or (node.value.first.value.first =~ /::/)
+                      ''
+                    else
+                      '@'
+                    end
         attribute += node.value.first.accept(self)
 
         # Support non-standard css
@@ -109,7 +108,7 @@ module Nokogiri
         when :dash_match
           "#{attribute} = #{value} or starts-with(#{attribute}, concat(#{value}, '-'))"
         when :includes
-          "contains(concat(\" \", #{attribute}, \" \"),concat(\" \", #{value}, \" \"))"
+          "contains(concat(' ',normalize-space(#{attribute}),' '),concat(' ',#{value},' '))"
         when :suffix_match
           "substring(#{attribute}, string-length(#{attribute}) - " +
             "string-length(#{value}) + 1, string-length(#{value})) = #{value}"

--- a/test/css/test_css_integration.rb
+++ b/test/css/test_css_integration.rb
@@ -328,6 +328,23 @@ module Nokogiri
         assert_equal expected, result.to_a
       end
 
+      def test_class_attr_selector
+        doc = Nokogiri::HTML::Document.parse(<<~EOF)
+          <html><body>
+            <div class="qwer asdf zxcv">space-delimited</div>
+            <div class="qwer\tasdf\tzxcv">tab-delimited</div>
+            <div class="qwer\nasdf\nzxcv">newline-delimited</div>
+            <div class="qwer\rasdf\rzxcv">carriage-return-delimited</div>
+          </body></html>
+        EOF
+
+        result = doc.css("div[class~='asdf']")
+        assert_equal 4, result.length
+
+        expected = doc.css("div")
+        assert_equal expected, result
+      end
+
       private
 
       def assert_result_rows(intarray, result, word = "row")

--- a/test/css/test_parser.rb
+++ b/test/css/test_parser.rb
@@ -78,9 +78,9 @@ module Nokogiri
       end
 
       def test_includes
-        assert_xpath  "//a[contains(concat(\" \", @class, \" \"),concat(\" \", 'bar', \" \"))]",
+        assert_xpath  "//a[contains(concat(' ',normalize-space(@class),' '),concat(' ','bar',' '))]",
                       @parser.parse("a[@class~='bar']")
-        assert_xpath  "//a[contains(concat(\" \", @class, \" \"),concat(\" \", 'bar', \" \"))]",
+        assert_xpath  "//a[contains(concat(' ',normalize-space(@class),' '),concat(' ','bar',' '))]",
                       @parser.parse("a[@class ~= 'bar']")
       end
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Related to #854, which fixed this problem for CSS class selectors.

The CSS `~=` operator should treat the `class` attribute as a set of whitespace-delimited class names. However, the current implementation only works for spaces (and not tabs, newlines, or carriage returns).

**Have you included adequate test coverage?**

Yes, I've added tests that fail without the `XPathVisitor` change but pass with it.

**Does this change affect the behavior of either the C or the Java implementations?**

No, this change is entirely within rubyspace.