### PR TITLE
fix(jruby): make less-naive inference of xpath custom function ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,8 @@ This CVE's public notice is [#1915](https://github.com/sparklemotion/nokogiri/is
 * [MRI] Address a memory leak when unparenting a DTD. [[#1784](https://github.com/sparklemotion/nokogiri/issues/1784)] (Thanks, [@stevecheckoway](https://github.com/stevecheckoway)!)
 * [MRI] Use RbConfig::CONFIG instead of ::MAKEFILE_CONFIG to fix installations that use Makefile macros. [[#1820](https://github.com/sparklemotion/nokogiri/issues/1820)] (Thanks, [@nobu](https://github.com/nobu)!)
 * [JRuby] Decrease large memory usage when making nested XPath queries. [[#1749](https://github.com/sparklemotion/nokogiri/issues/1749)]
+* [JRuby] Fix how custom XPath function namespaces are inferred to be less naive. [#1890, #2148]
+* [JRuby] Clarify exception message when custom XPath functions can't be resolved.
 * [JRuby] Fix failing tests on JRuby 9.2.x
 * [JRuby] Fix default namespaces in nodes reparented into a different document [[#1774](https://github.com/sparklemotion/nokogiri/issues/1774)]
 * [JRuby] Fix support for Java 9. [[#1759](https://github.com/sparklemotion/nokogiri/issues/1759)] (Thanks, [@Taywee](https://github.com/Taywee)!)

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -162,7 +162,9 @@ public class XmlXpathContext extends RubyObject {
             return tryGetNodeSet(context, expr, fnResolver);
         }
         catch (TransformerException ex) {
-            throw XmlSyntaxError.createXMLXPathSyntaxError(context.runtime, expr, ex).toThrowable(); // Nokogiri::XML::XPath::SyntaxError
+            throw XmlSyntaxError.createXMLXPathSyntaxError(context.runtime,
+                                                           (expr + ": " + ex.toString()),
+                                                           ex).toThrowable();
         }
     }
 

--- a/test/files/staff.xml
+++ b/test/files/staff.xml
@@ -35,7 +35,7 @@
   <employeeId>EMP0003</employeeId>
   <name>Roger
  Jones</name>
-  <position>Department Manager</position>
+  <position id='partial_collision_id'>Department Manager</position>
   <salary>100,000</salary>
   <gender>&ent4;</gender>
   <address domestic="Yes" street="No">PO Box 27 Irving, texas 98553</address>

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -419,7 +419,7 @@ module Nokogiri
 
       def test_validate
         if Nokogiri.uses_libxml?
-          assert_equal 44, @xml.validate.length
+          assert_equal 45, @xml.validate.length
         else
           xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) { |cfg| cfg.dtdvalid }
           assert_equal 40, xml.validate.length

--- a/test/xml/test_dtd.rb
+++ b/test/xml/test_dtd.rb
@@ -150,7 +150,7 @@ module Nokogiri
       def test_validate
         if Nokogiri.uses_libxml?
           list = @xml.internal_subset.validate @xml
-          assert_equal 44, list.length
+          assert_equal 45, list.length
         else
           xml = Nokogiri::XML(File.open(XML_FILE)) {|cfg| cfg.dtdvalid}
           list = xml.internal_subset.validate xml


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Closes #1890
Related to #2147

JRuby's logic for inferring a namespace for the custom XPath function handler has been naive since it was introduced in 468c757. This PR makes it less naive and less likely to break things by looking for function calls in the query via regex, and looking for matches among the handler's declared Ruby methods.

Ideally we should require namespaces in both JRuby and CRuby implementations at some point to avoid having to do this kind of heavy lifting. See #2147 for a proposal.

**Have you included adequate test coverage?**

Sure.


**Does this change affect the behavior of either the C or the Java implementations?**

Only changes the JRuby implementation, to do a better job of matching the CRuby behavior.
