### PR TITLE
fix: emit helpful error when native gem fails to load glibc

### DIFF
--- a/lib/nokogiri.rb
+++ b/lib/nokogiri.rb
@@ -11,7 +11,24 @@ end
 begin
   RUBY_VERSION =~ /(\d+\.\d+)/
   require "nokogiri/#{$1}/nokogiri"
-rescue LoadError
+rescue LoadError => e
+  if e.message =~ /GLIBC/
+    warn <<~EOM
+
+      ERROR: It looks like you're trying to use Nokogiri as a precompiled native gem on a system with glibc < 2.17:
+
+        #{e.message}
+
+        If that's the case, then please install Nokogiri via the `ruby` platform gem:
+            gem install nokogiri --platform=ruby
+        or:
+            bundle config set force_ruby_platform true
+
+        Please visit https://nokogiri.org/tutorials/installing_nokogiri.html for more help.
+
+    EOM
+    raise e
+  end
   require 'nokogiri/nokogiri'
 end
 require 'nokogiri/version'


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Specifically, older systems may not meet our expectations for glibc,
and this commit attempts to help those poor souls find a path forward.

Closes #2081


**Have you included adequate test coverage?**

I manually tested this change using the OCI image at:

  registry.gitlab.com/gitlab-org/gitlab-omnibus-builder/centos_6:0.0.72


**Does this change affect the behavior of either the C or the Java implementations?**

No.