### PR TITLE
ci: switch to the ruby/setup-ruby action

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,26 +12,15 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
+        
       - name: Set ENV
         run: |
           echo "MAKEFLAGS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
           echo "NOKOGIRI_USE_SYSTEM_LIBRARIES=t" >> $GITHUB_ENV
-      - name: Install dependencies
-        run: |
-          gem install bundler
-          bundle config --local path vendor/bundle
-          bundle config jobs $((1 + $(sysctl -n hw.activecpu)))
-          bundle install
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: '2.7'
       - run: bundle exec rake compile
       - run: bundle exec rake test
 
@@ -39,15 +28,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
       - uses: actions/cache@v2
         with:
           path: ports/archives
@@ -58,11 +38,9 @@ jobs:
       - name: Set ENV
         run: |
           echo "MAKEFLAGS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
-      - name: Install dependencies
-        run: |
-          gem install bundler
-          bundle config --local path vendor/bundle
-          bundle config jobs $((1 + $(sysctl -n hw.activecpu)))
-          bundle install
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: '2.7'
       - run: bundle exec rake compile
       - run: bundle exec rake test


### PR DESCRIPTION
**What problem is this PR intended to solve?**

This switches the setup-ruby action to the one created by the
[ruby organisation](https://github.com/ruby/setup-ruby) which has more
advanced features than the one already in use.

Most notably, this handles installing Bundler, bundling, and caching the
resulting bundle.

**Have you included adequate test coverage?**

Yes, which is to say it hasn't changed any code or tests, just how they
are run.

**Does this change affect the behavior of either the C or the Java implementations?**

No, just how CI runs, and you can see the results on this PR 😄.