### PR TITLE
fix: Document#initialize should be called exactly once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## next / unreleased
+
+### Fixed
+
+* [CRuby] `{XML,HTML}::Document.parse` now invokes `#initialize` exactly once. Previously `#initialize` was invoked twice on each object.
+* [JRuby] `{XML,HTML}::Document.parse` now invokes `#initialize` exactly once. Previously `#initialize` was not called, which was a problem for subclassing such as done by `Loofah`.
+
+
 ## v1.11.1 / 2021-01-06
 
 ### Fixed

--- a/ext/java/nokogiri/internals/HtmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/HtmlDomParserContext.java
@@ -52,6 +52,7 @@ import org.cyberneko.html.filters.DefaultFilter;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -133,6 +134,8 @@ public class HtmlDomParserContext extends XmlDomParserContext {
     protected XmlDocument wrapDocument(ThreadContext context, RubyClass klass, Document document) {
         HtmlDocument htmlDocument = new HtmlDocument(context.runtime, klass, document);
         htmlDocument.setDocumentNode(context.runtime, document);
+        Helpers.invoke(context, htmlDocument, "initialize");
+
         if (ruby_encoding.isNil()) {
             // ruby_encoding might have detected by HtmlDocument::EncodingReader
             if (detected_encoding != null && !detected_encoding.isNil()) {

--- a/ext/java/nokogiri/internals/XmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/XmlDomParserContext.java
@@ -46,6 +46,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -213,6 +214,7 @@ public class XmlDomParserContext extends ParserContext {
      */
     protected XmlDocument wrapDocument(ThreadContext context, RubyClass klass, Document doc) {
         XmlDocument xmlDocument = new XmlDocument(context.runtime, klass, doc);
+        Helpers.invoke(context, xmlDocument, "initialize");
         xmlDocument.setEncoding(ruby_encoding);
 
         if (options.dtdLoad) {

--- a/ext/nokogiri/html_document.c
+++ b/ext/nokogiri/html_document.c
@@ -23,8 +23,7 @@ rb_html_document_s_new(int argc, VALUE *argv, VALUE klass)
           RTEST(uri) ? (const xmlChar *)StringValueCStr(uri) : NULL,
           RTEST(external_id) ? (const xmlChar *)StringValueCStr(external_id) : NULL
         );
-  rb_doc = nokogiri_xml_document_wrap(klass, doc);
-  rb_obj_call_init(rb_doc, argc, argv);
+  rb_doc = nokogiri_xml_document_wrap_with_init_args(klass, doc, argc, argv);
   return rb_doc ;
 }
 

--- a/ext/nokogiri/html_document.c
+++ b/ext/nokogiri/html_document.c
@@ -23,7 +23,7 @@ rb_html_document_s_new(int argc, VALUE *argv, VALUE klass)
           RTEST(uri) ? (const xmlChar *)StringValueCStr(uri) : NULL,
           RTEST(external_id) ? (const xmlChar *)StringValueCStr(external_id) : NULL
         );
-  rb_doc = Nokogiri_wrap_xml_document(klass, doc);
+  rb_doc = nokogiri_xml_document_wrap(klass, doc);
   rb_obj_call_init(rb_doc, argc, argv);
   return rb_doc ;
 }
@@ -81,7 +81,7 @@ rb_html_document_s_read_io(VALUE klass, VALUE rb_io, VALUE rb_url, VALUE rb_enco
     return Qnil;
   }
 
-  rb_doc = Nokogiri_wrap_xml_document(klass, c_doc);
+  rb_doc = nokogiri_xml_document_wrap(klass, c_doc);
   rb_iv_set(rb_doc, "@errors", rb_error_list);
   return rb_doc;
 }
@@ -129,7 +129,7 @@ rb_html_document_s_read_memory(VALUE klass, VALUE rb_html, VALUE rb_url, VALUE r
     return Qnil;
   }
 
-  rb_doc = Nokogiri_wrap_xml_document(klass, c_doc);
+  rb_doc = nokogiri_xml_document_wrap(klass, c_doc);
   rb_iv_set(rb_doc, "@errors", rb_error_list);
   return rb_doc;
 }

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -278,7 +278,7 @@ static VALUE read_io( VALUE klass,
     return Qnil;
   }
 
-  document = Nokogiri_wrap_xml_document(klass, doc);
+  document = nokogiri_xml_document_wrap(klass, doc);
   rb_iv_set(document, "@errors", error_list);
   return document;
 }
@@ -322,7 +322,7 @@ static VALUE read_memory( VALUE klass,
     return Qnil;
   }
 
-  document = Nokogiri_wrap_xml_document(klass, doc);
+  document = nokogiri_xml_document_wrap(klass, doc);
   rb_iv_set(document, "@errors", error_list);
   return document;
 }
@@ -351,7 +351,7 @@ static VALUE duplicate_document(int argc, VALUE *argv, VALUE self)
   if(dup == NULL) return Qnil;
 
   dup->type = doc->type;
-  copy = Nokogiri_wrap_xml_document(rb_obj_class(self), dup);
+  copy = nokogiri_xml_document_wrap(rb_obj_class(self), dup);
   error_list = rb_iv_get(self, "@errors");
   rb_iv_set(copy, "@errors", error_list);
   return copy ;
@@ -373,7 +373,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
   if (NIL_P(version)) version = rb_str_new2("1.0");
 
   doc = xmlNewDoc((xmlChar *)StringValueCStr(version));
-  rb_doc = Nokogiri_wrap_xml_document(klass, doc);
+  rb_doc = nokogiri_xml_document_wrap(klass, doc);
   rb_obj_call_init(rb_doc, argc, argv);
   return rb_doc ;
 }
@@ -596,7 +596,7 @@ void init_xml_document()
 
 
 /* this takes klass as a param because it's used for HtmlDocument, too. */
-VALUE Nokogiri_wrap_xml_document(VALUE klass, xmlDocPtr doc)
+VALUE nokogiri_xml_document_wrap(VALUE klass, xmlDocPtr doc)
 {
   nokogiriTuplePtr tuple = (nokogiriTuplePtr)malloc(sizeof(nokogiriTuple));
 

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -339,7 +339,6 @@ static VALUE duplicate_document(int argc, VALUE *argv, VALUE self)
   xmlDocPtr doc, dup;
   VALUE copy;
   VALUE level;
-  VALUE error_list;
 
   if(rb_scan_args(argc, argv, "01", &level) == 0)
     level = INT2NUM((long)1);
@@ -352,8 +351,7 @@ static VALUE duplicate_document(int argc, VALUE *argv, VALUE self)
 
   dup->type = doc->type;
   copy = nokogiri_xml_document_wrap(rb_obj_class(self), dup);
-  error_list = rb_iv_get(self, "@errors");
-  rb_iv_set(copy, "@errors", error_list);
+  rb_iv_set(copy, "@errors", rb_iv_get(self, "@errors"));
   return copy ;
 }
 
@@ -373,8 +371,7 @@ static VALUE new(int argc, VALUE *argv, VALUE klass)
   if (NIL_P(version)) version = rb_str_new2("1.0");
 
   doc = xmlNewDoc((xmlChar *)StringValueCStr(version));
-  rb_doc = nokogiri_xml_document_wrap(klass, doc);
-  rb_obj_call_init(rb_doc, argc, argv);
+  rb_doc = nokogiri_xml_document_wrap_with_init_args(klass, doc, argc, argv);
   return rb_doc ;
 }
 
@@ -564,6 +561,39 @@ static VALUE nokogiri_xml_document_canonicalize(int argc, VALUE* argv, VALUE sel
   return rb_funcall(io, rb_intern("string"), 0);
 }
 
+VALUE nokogiri_xml_document_wrap_with_init_args(VALUE klass, xmlDocPtr doc, int argc, VALUE *argv)
+{
+  nokogiriTuplePtr tuple = (nokogiriTuplePtr)malloc(sizeof(nokogiriTuple));
+
+  VALUE rb_doc = Data_Wrap_Struct(
+    klass ? klass : cNokogiriXmlDocument,
+    mark,
+    dealloc,
+    doc
+    );
+
+  VALUE cache = rb_ary_new();
+  rb_iv_set(rb_doc, "@decorators", Qnil);
+  rb_iv_set(rb_doc, "@errors", Qnil);
+  rb_iv_set(rb_doc, "@node_cache", cache);
+
+  tuple->doc = rb_doc;
+  tuple->unlinkedNodes = st_init_numtable_with_size(128);
+  tuple->node_cache = cache;
+  doc->_private = tuple ;
+
+  rb_obj_call_init(rb_doc, argc, argv);
+
+  return rb_doc ;
+}
+
+
+VALUE nokogiri_xml_document_wrap(VALUE klass, xmlDocPtr doc)
+{
+  return nokogiri_xml_document_wrap_with_init_args(klass, doc, 0, NULL);
+}
+
+
 VALUE cNokogiriXmlDocument ;
 void init_xml_document()
 {
@@ -592,31 +622,4 @@ void init_xml_document()
   rb_define_method(klass, "url", url, 0);
   rb_define_method(klass, "create_entity", create_entity, -1);
   rb_define_method(klass, "remove_namespaces!", remove_namespaces_bang, 0);
-}
-
-
-/* this takes klass as a param because it's used for HtmlDocument, too. */
-VALUE nokogiri_xml_document_wrap(VALUE klass, xmlDocPtr doc)
-{
-  nokogiriTuplePtr tuple = (nokogiriTuplePtr)malloc(sizeof(nokogiriTuple));
-
-  VALUE rb_doc = Data_Wrap_Struct(
-      klass ? klass : cNokogiriXmlDocument,
-      mark,
-      dealloc,
-      doc
-  );
-
-  VALUE cache = rb_ary_new();
-  rb_iv_set(rb_doc, "@decorators", Qnil);
-  rb_iv_set(rb_doc, "@node_cache", cache);
-
-  tuple->doc = rb_doc;
-  tuple->unlinkedNodes = st_init_numtable_with_size(128);
-  tuple->node_cache = cache;
-  doc->_private = tuple ;
-
-  rb_obj_call_init(rb_doc, 0, NULL);
-
-  return rb_doc ;
 }

--- a/ext/nokogiri/xml_document.h
+++ b/ext/nokogiri/xml_document.h
@@ -12,6 +12,7 @@ typedef struct _nokogiriTuple nokogiriTuple;
 typedef nokogiriTuple * nokogiriTuplePtr;
 
 void init_xml_document();
+VALUE nokogiri_xml_document_wrap_with_init_args(VALUE klass, xmlDocPtr doc, int argc, VALUE *argv);
 VALUE nokogiri_xml_document_wrap(VALUE klass, xmlDocPtr doc);
 
 #define DOC_RUBY_OBJECT_TEST(x) ((nokogiriTuplePtr)(x->_private))

--- a/ext/nokogiri/xml_document.h
+++ b/ext/nokogiri/xml_document.h
@@ -12,7 +12,7 @@ typedef struct _nokogiriTuple nokogiriTuple;
 typedef nokogiriTuple * nokogiriTuplePtr;
 
 void init_xml_document();
-VALUE Nokogiri_wrap_xml_document(VALUE klass, xmlDocPtr doc);
+VALUE nokogiri_xml_document_wrap(VALUE klass, xmlDocPtr doc);
 
 #define DOC_RUBY_OBJECT_TEST(x) ((nokogiriTuplePtr)(x->_private))
 #define DOC_RUBY_OBJECT(x) (((nokogiriTuplePtr)(x->_private))->doc)

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -173,7 +173,7 @@ static VALUE transform(int argc, VALUE* argv, VALUE self)
       rb_exc_raise(exception);
     }
 
-    return Nokogiri_wrap_xml_document((VALUE)0, result) ;
+    return nokogiri_xml_document_wrap((VALUE)0, result) ;
 }
 
 static void method_caller(xmlXPathParserContextPtr ctxt, int nargs)

--- a/test/html/test_document.rb
+++ b/test/html/test_document.rb
@@ -4,802 +4,862 @@ require "helper"
 module Nokogiri
   module HTML
     class TestDocument < Nokogiri::TestCase
-      let(:html) { Nokogiri::HTML.parse(File.read(HTML_FILE)) }
+      describe Nokogiri::HTML::Document do
+        let(:html) { Nokogiri::HTML.parse(File.read(HTML_FILE)) }
 
-      def test_nil_css
-        # Behavior is undefined but shouldn't break
-        assert(html.css(nil))
-        assert(html.xpath(nil))
-      end
-
-      def test_does_not_fail_with_illformatted_html
-        doc = Nokogiri::HTML('"</html>";'.dup.force_encoding(Encoding::BINARY))
-        assert_not_nil(doc)
-      end
-
-      def test_exceptions_remove_newlines
-        errors = html.errors
-        assert(errors.length > 0, "has errors")
-        errors.each do |error|
-          assert_equal(error.to_s.chomp, error.to_s)
+        def test_nil_css
+          # Behavior is undefined but shouldn't break
+          assert(html.css(nil))
+          assert(html.xpath(nil))
         end
-      end
 
-      def test_fragment
-        fragment = html.fragment
-        assert_equal(0, fragment.children.length)
-      end
-
-      def test_document_takes_config_block
-        options = nil
-        Nokogiri::HTML(File.read(HTML_FILE), HTML_FILE) do |cfg|
-          options = cfg
-          options.nonet.nowarning.dtdattr
+        def test_does_not_fail_with_illformatted_html
+          doc = Nokogiri::HTML('"</html>";'.dup.force_encoding(Encoding::BINARY))
+          assert_not_nil(doc)
         end
-        assert(options.nonet?)
-        assert(options.nowarning?)
-        assert(options.dtdattr?)
-      end
 
-      def test_parse_takes_config_block
-        options = nil
-        Nokogiri::HTML.parse(File.read(HTML_FILE), HTML_FILE) do |cfg|
-          options = cfg
-          options.nonet.nowarning.dtdattr
-        end
-        assert(options.nonet?)
-        assert(options.nowarning?)
-        assert(options.dtdattr?)
-      end
-
-      def test_subclass
-        klass = Class.new(Nokogiri::HTML::Document)
-        doc = klass.new
-        assert_instance_of(klass, doc)
-      end
-
-      def test_subclass_initialize
-        klass = Class.new(Nokogiri::HTML::Document) do
-          attr_accessor :initialized_with
-
-          def initialize(*args)
-            @initialized_with = args
+        def test_exceptions_remove_newlines
+          errors = html.errors
+          assert(errors.length > 0, "has errors")
+          errors.each do |error|
+            assert_equal(error.to_s.chomp, error.to_s)
           end
         end
-        doc = klass.new("uri", "external_id", 1)
-        assert_equal(["uri", "external_id", 1], doc.initialized_with)
-      end
 
-      def test_subclass_dup
-        klass = Class.new(Nokogiri::HTML::Document)
-        doc = klass.new.dup
-        assert_instance_of(klass, doc)
-      end
-
-      def test_subclass_parse
-        klass = Class.new(Nokogiri::HTML::Document)
-        doc = klass.parse(File.read(HTML_FILE))
-        assert_equal(html.to_s, doc.to_s)
-        assert_instance_of(klass, doc)
-      end
-
-      def test_document_parse_method
-        html = Nokogiri::HTML::Document.parse(File.read(HTML_FILE))
-        assert_equal(html.to_s, html.to_s)
-      end
-
-      def test_document_parse_method_with_url
-        doc = Nokogiri::HTML("<html></html>", "http://foobar.example.com/", "UTF-8")
-        refute_empty(doc.to_s, "Document should not be empty")
-        assert_equal("http://foobar.example.com/", doc.url)
-      end
-
-      ###
-      # Nokogiri::HTML returns an empty Document when given a blank string GH#11
-      def test_empty_string_returns_empty_doc
-        doc = Nokogiri::HTML("")
-        assert_instance_of(Nokogiri::HTML::Document, doc)
-        assert_nil(doc.root)
-      end
-
-      unless Nokogiri.uses_libxml?("~> 2.6.0")
-        def test_to_xhtml_with_indent
-          doc = Nokogiri::HTML("<html><body><a>foo</a></body></html>")
-          doc = Nokogiri::HTML(doc.to_xhtml(indent: 2))
-          assert_indent(2, doc)
+        def test_fragment
+          fragment = html.fragment
+          assert_equal(0, fragment.children.length)
         end
 
-        def test_write_to_xhtml_with_indent
-          io = StringIO.new
-          doc = Nokogiri::HTML("<html><body><a>foo</a></body></html>")
-          doc.write_xhtml_to(io, indent: 5)
-          io.rewind
-          doc = Nokogiri::HTML(io.read)
-          assert_indent(5, doc)
+        def test_document_takes_config_block
+          options = nil
+          Nokogiri::HTML(File.read(HTML_FILE), HTML_FILE) do |cfg|
+            options = cfg
+            options.nonet.nowarning.dtdattr
+          end
+          assert(options.nonet?)
+          assert(options.nowarning?)
+          assert(options.dtdattr?)
         end
-      end
 
-      def test_swap_should_not_exist
-        assert_raises(NoMethodError) do
-          html.swap
+        def test_parse_takes_config_block
+          options = nil
+          Nokogiri::HTML.parse(File.read(HTML_FILE), HTML_FILE) do |cfg|
+            options = cfg
+            options.nonet.nowarning.dtdattr
+          end
+          assert(options.nonet?)
+          assert(options.nowarning?)
+          assert(options.dtdattr?)
         end
-      end
 
-      def test_namespace_should_not_exist
-        assert_raises(NoMethodError) do
-          html.namespace
+        def test_subclass
+          klass = Class.new(Nokogiri::HTML::Document)
+          doc = klass.new
+          assert_instance_of(klass, doc)
         end
-      end
 
-      def test_meta_encoding
-        assert_equal("UTF-8", html.meta_encoding)
-      end
+        def test_subclass_initialize
+          klass = Class.new(Nokogiri::HTML::Document) do
+            attr_accessor :initialized_with
 
-      def test_meta_encoding_is_strict_about_http_equiv
-        doc = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <head>
-              <meta http-equiv="X-Content-Type" content="text/html; charset=Shift_JIS">
-            </head>
-            <body>
-              foo
-            </body>
-          </html>
-        EOHTML
-        assert_nil(doc.meta_encoding)
-      end
+            def initialize(*args)
+              @initialized_with = args
+            end
+          end
+          doc = klass.new("uri", "external_id", 1)
+          assert_equal(["uri", "external_id", 1], doc.initialized_with)
+        end
 
-      def test_meta_encoding_handles_malformed_content_charset
-        doc = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <head>
-              <meta http-equiv="Content-type" content="text/html; utf-8" />
-            </head>
-            <body>
-              foo
-            </body>
-          </html>
-        EOHTML
-        assert_nil(doc.meta_encoding)
-      end
+        def test_subclass_dup
+          klass = Class.new(Nokogiri::HTML::Document)
+          doc = klass.new.dup
+          assert_instance_of(klass, doc)
+        end
 
-      def test_meta_encoding_checks_charset
-        doc = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <head>
+        def test_subclass_parse
+          klass = Class.new(Nokogiri::HTML::Document)
+          doc = klass.parse(File.read(HTML_FILE))
+          assert_equal(html.to_s, doc.to_s)
+          assert_instance_of(klass, doc)
+        end
+
+        def test_document_parse_method
+          html = Nokogiri::HTML::Document.parse(File.read(HTML_FILE))
+          assert_equal(html.to_s, html.to_s)
+        end
+
+        def test_document_parse_method_with_url
+          doc = Nokogiri::HTML("<html></html>", "http://foobar.example.com/", "UTF-8")
+          refute_empty(doc.to_s, "Document should not be empty")
+          assert_equal("http://foobar.example.com/", doc.url)
+        end
+
+        ###
+        # Nokogiri::HTML returns an empty Document when given a blank string GH#11
+        def test_empty_string_returns_empty_doc
+          doc = Nokogiri::HTML("")
+          assert_instance_of(Nokogiri::HTML::Document, doc)
+          assert_nil(doc.root)
+        end
+
+        unless Nokogiri.uses_libxml?("~> 2.6.0")
+          def test_to_xhtml_with_indent
+            doc = Nokogiri::HTML("<html><body><a>foo</a></body></html>")
+            doc = Nokogiri::HTML(doc.to_xhtml(indent: 2))
+            assert_indent(2, doc)
+          end
+
+          def test_write_to_xhtml_with_indent
+            io = StringIO.new
+            doc = Nokogiri::HTML("<html><body><a>foo</a></body></html>")
+            doc.write_xhtml_to(io, indent: 5)
+            io.rewind
+            doc = Nokogiri::HTML(io.read)
+            assert_indent(5, doc)
+          end
+        end
+
+        def test_swap_should_not_exist
+          assert_raises(NoMethodError) do
+            html.swap
+          end
+        end
+
+        def test_namespace_should_not_exist
+          assert_raises(NoMethodError) do
+            html.namespace
+          end
+        end
+
+        def test_meta_encoding
+          assert_equal("UTF-8", html.meta_encoding)
+        end
+
+        def test_meta_encoding_is_strict_about_http_equiv
+          doc = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <head>
+                <meta http-equiv="X-Content-Type" content="text/html; charset=Shift_JIS">
+              </head>
+              <body>
+                foo
+              </body>
+            </html>
+          EOHTML
+          assert_nil(doc.meta_encoding)
+        end
+
+        def test_meta_encoding_handles_malformed_content_charset
+          doc = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <head>
+                <meta http-equiv="Content-type" content="text/html; utf-8" />
+              </head>
+              <body>
+                foo
+              </body>
+            </html>
+          EOHTML
+          assert_nil(doc.meta_encoding)
+        end
+
+        def test_meta_encoding_checks_charset
+          doc = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <head>
+                <meta charset="UTF-8">
+              </head>
+              <body>
+                foo
+              </body>
+            </html>
+          EOHTML
+          assert_equal("UTF-8", doc.meta_encoding)
+        end
+
+        def test_meta_encoding=
+          html.meta_encoding = "EUC-JP"
+          assert_equal("EUC-JP", html.meta_encoding)
+        end
+
+        def test_title
+          assert_equal("Tender Lovemaking  ", html.title)
+          doc = Nokogiri::HTML("<html><body>foo</body></html>")
+          assert_nil(doc.title)
+        end
+
+        def test_title=
+          doc = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <head>
+                <title>old</title>
+              </head>
+              <body>
+                foo
+              </body>
+            </html>
+            EOHTML
+          doc.title = "new"
+          assert_equal(1, doc.css("title").size)
+          assert_equal("new", doc.title)
+
+          doc = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <head>
+                <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+              </head>
+              <body>
+                foo
+              </body>
+            </html>
+            EOHTML
+          doc.title = "new"
+          assert_equal("new", doc.title)
+          title = doc.at("/html/head/title")
+          assert_not_nil(title)
+          assert_equal("new", title.text)
+          assert_equal(-1, doc.at("meta[@http-equiv]") <=> title)
+
+          doc = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <body>
+                foo
+              </body>
+            </html>
+            EOHTML
+          doc.title = "new"
+          assert_equal("new", doc.title)
+          # <head> may or may not be added
+          title = doc.at("/html//title")
+          assert_not_nil(title)
+          assert_equal("new", title.text)
+          assert_equal(-1, title <=> doc.at("body"))
+
+          doc = Nokogiri::HTML(<<~EOHTML)
+            <html>
               <meta charset="UTF-8">
-            </head>
-            <body>
-              foo
-            </body>
-          </html>
-        EOHTML
-        assert_equal("UTF-8", doc.meta_encoding)
-      end
+              <body>
+                foo
+              </body>
+            </html>
+            EOHTML
+          doc.title = "new"
+          assert_equal("new", doc.title)
+          assert_equal(-1, doc.at("meta[@charset]") <=> doc.at("title"))
+          assert_equal(-1, doc.at("title") <=> doc.at("body"))
 
-      def test_meta_encoding=
-        html.meta_encoding = "EUC-JP"
-        assert_equal("EUC-JP", html.meta_encoding)
-      end
+          doc = Nokogiri::HTML("<!DOCTYPE html><p>hello")
+          doc.title = "new"
+          assert_equal("new", doc.title)
+          assert_instance_of(Nokogiri::XML::DTD, doc.children.first)
+          assert_equal(-1, doc.at("title") <=> doc.at("p"))
 
-      def test_title
-        assert_equal("Tender Lovemaking  ", html.title)
-        doc = Nokogiri::HTML("<html><body>foo</body></html>")
-        assert_nil(doc.title)
-      end
+          doc = Nokogiri::HTML("")
+          doc.title = "new"
+          assert_equal("new", doc.title)
+          assert_equal("new", doc.at("/html/head/title/text()").to_s)
+        end
 
-      def test_title=
-        doc = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <head>
-              <title>old</title>
-            </head>
-            <body>
-              foo
-            </body>
-          </html>
-        EOHTML
-        doc.title = "new"
-        assert_equal(1, doc.css("title").size)
-        assert_equal("new", doc.title)
+        def test_meta_encoding_without_head
+          encoding = "EUC-JP"
+          html = Nokogiri::HTML("<html><body>foo</body></html>", nil, encoding)
 
-        doc = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <head>
-              <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-            </head>
-            <body>
-              foo
-            </body>
-          </html>
-        EOHTML
-        doc.title = "new"
-        assert_equal("new", doc.title)
-        title = doc.at("/html/head/title")
-        assert_not_nil(title)
-        assert_equal("new", title.text)
-        assert_equal(-1, doc.at("meta[@http-equiv]") <=> title)
+          assert_nil(html.meta_encoding)
 
-        doc = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <body>
-              foo
-            </body>
-          </html>
-        EOHTML
-        doc.title = "new"
-        assert_equal("new", doc.title)
-        # <head> may or may not be added
-        title = doc.at("/html//title")
-        assert_not_nil(title)
-        assert_equal("new", title.text)
-        assert_equal(-1, title <=> doc.at("body"))
+          html.meta_encoding = encoding
+          assert_equal(encoding, html.meta_encoding)
 
-        doc = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <meta charset="UTF-8">
-            <body>
-              foo
-            </body>
-          </html>
-        EOHTML
-        doc.title = "new"
-        assert_equal("new", doc.title)
-        assert_equal(-1, doc.at("meta[@charset]") <=> doc.at("title"))
-        assert_equal(-1, doc.at("title") <=> doc.at("body"))
+          meta = html.at("/html/head/meta[@http-equiv and boolean(@content)]")
+          assert(meta, "meta is in head")
 
-        doc = Nokogiri::HTML("<!DOCTYPE html><p>hello")
-        doc.title = "new"
-        assert_equal("new", doc.title)
-        assert_instance_of(Nokogiri::XML::DTD, doc.children.first)
-        assert_equal(-1, doc.at("title") <=> doc.at("p"))
+          assert(meta.at("./parent::head/following-sibling::body"), "meta is before body")
+        end
 
-        doc = Nokogiri::HTML("")
-        doc.title = "new"
-        assert_equal("new", doc.title)
-        assert_equal("new", doc.at("/html/head/title/text()").to_s)
-      end
+        def test_html5_meta_encoding_without_head
+          encoding = "EUC-JP"
+          html = Nokogiri::HTML("<!DOCTYPE html><html><body>foo</body></html>", nil, encoding)
 
-      def test_meta_encoding_without_head
-        encoding = "EUC-JP"
-        html = Nokogiri::HTML("<html><body>foo</body></html>", nil, encoding)
+          assert_nil(html.meta_encoding)
 
-        assert_nil(html.meta_encoding)
+          html.meta_encoding = encoding
+          assert_equal(encoding, html.meta_encoding)
 
-        html.meta_encoding = encoding
-        assert_equal(encoding, html.meta_encoding)
+          meta = html.at("/html/head/meta[@charset]")
+          assert(meta, "meta is in head")
 
-        meta = html.at("/html/head/meta[@http-equiv and boolean(@content)]")
-        assert(meta, "meta is in head")
+          assert(meta.at("./parent::head/following-sibling::body"), "meta is before body")
+        end
 
-        assert(meta.at("./parent::head/following-sibling::body"), "meta is before body")
-      end
+        def test_meta_encoding_with_empty_content_type
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <head>
+                <meta http-equiv="Content-Type" content="">
+              </head>
+              <body>
+                foo
+              </body>
+            </html>
+          EOHTML
+          assert_nil(html.meta_encoding)
 
-      def test_html5_meta_encoding_without_head
-        encoding = "EUC-JP"
-        html = Nokogiri::HTML("<!DOCTYPE html><html><body>foo</body></html>", nil, encoding)
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <head>
+                <meta http-equiv="Content-Type">
+              </head>
+              <body>
+                foo
+              </body>
+            </html>
+          EOHTML
+          assert_nil(html.meta_encoding)
+        end
 
-        assert_nil(html.meta_encoding)
+        def test_root_node_parent_is_document
+          parent = html.root.parent
+          assert_equal(html, parent)
+          assert_instance_of(Nokogiri::HTML::Document, parent)
+        end
 
-        html.meta_encoding = encoding
-        assert_equal(encoding, html.meta_encoding)
+        def test_parse_handles_nil_gracefully
+          @doc = Nokogiri::HTML::Document.parse(nil)
+          assert_instance_of(Nokogiri::HTML::Document, @doc)
+        end
 
-        meta = html.at("/html/head/meta[@charset]")
-        assert(meta, "meta is in head")
+        def test_parse_empty_document
+          doc = Nokogiri::HTML("\n")
+          assert_equal(0, doc.css("a").length)
+          assert_equal(0, doc.xpath("//a").length)
+          assert_equal(0, doc.search("//a").length)
+        end
 
-        assert(meta.at("./parent::head/following-sibling::body"), "meta is before body")
-      end
+        def test_HTML_function
+          html = Nokogiri::HTML(File.read(HTML_FILE))
+          assert(html.html?)
+        end
 
-      def test_meta_encoding_with_empty_content_type
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <head>
-              <meta http-equiv="Content-Type" content="">
-            </head>
-            <body>
-              foo
-            </body>
-          </html>
-        EOHTML
-        assert_nil(html.meta_encoding)
+        def test_parse_works_with_an_object_that_responds_to_read
+          klass = Class.new do
+            def initialize
+              @contents = StringIO.new("<div>foo</div>")
+            end
 
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <head>
-              <meta http-equiv="Content-Type">
-            </head>
-            <body>
-              foo
-            </body>
-          </html>
-        EOHTML
-        assert_nil(html.meta_encoding)
-      end
-
-      def test_root_node_parent_is_document
-        parent = html.root.parent
-        assert_equal(html, parent)
-        assert_instance_of(Nokogiri::HTML::Document, parent)
-      end
-
-      def test_parse_handles_nil_gracefully
-        @doc = Nokogiri::HTML::Document.parse(nil)
-        assert_instance_of(Nokogiri::HTML::Document, @doc)
-      end
-
-      def test_parse_empty_document
-        doc = Nokogiri::HTML("\n")
-        assert_equal(0, doc.css("a").length)
-        assert_equal(0, doc.xpath("//a").length)
-        assert_equal(0, doc.search("//a").length)
-      end
-
-      def test_HTML_function
-        html = Nokogiri::HTML(File.read(HTML_FILE))
-        assert(html.html?)
-      end
-
-      def test_parse_works_with_an_object_that_responds_to_read
-        klass = Class.new do
-          def initialize
-            @contents = StringIO.new("<div>foo</div>")
+            def read(*args)
+              @contents.read(*args)
+            end
           end
 
-          def read(*args)
-            @contents.read(*args)
+          doc = Nokogiri::HTML.parse(klass.new)
+          assert_equal("foo", doc.at_css("div").content)
+        end
+
+        def test_parse_temp_file
+          temp_html_file = Tempfile.new("TEMP_HTML_FILE")
+          File.open(HTML_FILE, "rb") { |f| temp_html_file.write(f.read) }
+          temp_html_file.close
+          temp_html_file.open
+          assert_equal(Nokogiri::HTML.parse(File.read(HTML_FILE)).xpath("//div/a").length,
+                       Nokogiri::HTML.parse(temp_html_file).xpath("//div/a").length)
+        end
+
+        def test_to_xhtml
+          assert_match("XHTML", html.to_xhtml)
+          assert_match("XHTML", html.to_xhtml(encoding: "UTF-8"))
+          assert_match("UTF-8", html.to_xhtml(encoding: "UTF-8"))
+        end
+
+        def test_no_xml_header
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+            </html>
+          EOHTML
+          assert(html.to_html.length > 0, "html length is too short")
+          assert_no_match(/^<\?xml/, html.to_html)
+        end
+
+        def test_document_has_error
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <body>
+                <div awesome="asdf>
+                  <p>inside div tag</p>
+                </div>
+                <p>outside div tag</p>
+              </body>
+            </html>
+          EOHTML
+          assert(html.errors.length > 0)
+        end
+
+        def test_relative_css
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <body>
+                <div>
+                  <p>inside div tag</p>
+                </div>
+                <p>outside div tag</p>
+              </body>
+            </html>
+          EOHTML
+          set = html.search("div").search("p")
+          assert_equal(1, set.length)
+          assert_equal("inside div tag", set.first.inner_text)
+        end
+
+        def test_multi_css
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <body>
+                <div>
+                  <p>p tag</p>
+                  <a>a tag</a>
+                </div>
+              </body>
+            </html>
+          EOHTML
+          set = html.css("p, a")
+          assert_equal(2, set.length)
+          assert_equal(["a tag", "p tag"].sort, set.map(&:content).sort)
+        end
+
+        def test_inner_text
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <body>
+                <div>
+                  <p>
+                    Hello world!
+                  </p>
+                </div>
+              </body>
+            </html>
+          EOHTML
+          node = html.xpath("//div").first
+          assert_equal("Hello world!", node.inner_text.strip)
+        end
+
+        def test_doc_type
+          html = Nokogiri::HTML(<<~EOHTML)
+            <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+            <html xmlns="http://www.w3.org/1999/xhtml">
+              <body>
+                <p>Rainbow Dash</p>
+              </body>
+            </html>
+          EOHTML
+          assert_equal("html", html.internal_subset.name)
+          assert_equal("-//W3C//DTD XHTML 1.1//EN", html.internal_subset.external_id)
+          assert_equal("http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd", html.internal_subset.system_id)
+          assert_equal(
+            "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">", html.to_s[0,
+97]
+          )
+        end
+
+        def test_content_size
+          html = Nokogiri::HTML("<div>\n</div>")
+          assert_equal(1, html.content.size)
+          assert_equal(1, html.content.split("").size)
+          assert_equal("\n", html.content)
+        end
+
+        def test_find_by_xpath
+          found = html.xpath("//div/a")
+          assert_equal(3, found.length)
+        end
+
+        def test_find_by_css
+          found = html.css("div > a")
+          assert_equal(3, found.length)
+        end
+
+        def test_find_by_css_with_square_brackets
+          found = html.css("div[@id='header'] > h1")
+          found = html.css("div[@id='header'] h1") # this blows up on commit 6fa0f6d329d9dbf1cc21c0ac72f7e627bb4c05fc
+          assert_equal(1, found.length)
+        end
+
+        def test_find_by_css_with_escaped_characters
+          found_without_escape = html.css("div[@id='abc.123']")
+          found_by_id = html.css('#abc\.123')
+          found_by_class = html.css('.special\.character')
+          assert_equal(1, found_without_escape.length)
+          assert_equal(found_by_id, found_without_escape)
+          assert_equal(found_by_class, found_without_escape)
+        end
+
+        def test_find_with_function
+          assert(html.css("div:awesome() h1", Class.new do
+                                                def awesome(divs)
+                                                  [divs.first]
+                                                end
+                                              end.new))
+        end
+
+        def test_dup_shallow
+          found = html.search("//div/a").first
+          dup = found.dup(0)
+          assert(dup)
+          assert_equal("", dup.content)
+        end
+
+        def test_search_can_handle_xpath_and_css
+          found = html.search("//div/a", "div > p")
+          length = html.xpath("//div/a").length +
+                   html.css("div > p").length
+          assert_equal(length, found.length)
+        end
+
+        def test_dup_document
+          assert(dup = html.dup)
+          assert_not_equal(dup, html)
+          assert(html.html?)
+          assert_instance_of(Nokogiri::HTML::Document, dup)
+          assert(dup.html?, "duplicate should be html")
+          assert_equal(html.to_s, dup.to_s)
+        end
+
+        def test_dup_document_shallow
+          assert(dup = html.dup(0))
+          assert_not_equal(dup, html)
+        end
+
+        def test_dup
+          found = html.search("//div/a").first
+          dup = found.dup
+          assert(dup)
+          assert_equal(found.content, dup.content)
+          assert_equal(found.document, dup.document)
+        end
+
+        # issue 1060
+        def test_node_ownership_after_dup
+          html = "<html><head></head><body><div>replace me</div></body></html>"
+          doc = Nokogiri::HTML::Document.parse(html)
+          dup = doc.dup
+          assert_same(dup, dup.at_css("div").document)
+
+          # should not raise an exception
+          dup.at_css("div").parse("<div>replaced</div>")
+        end
+
+        def test_inner_html
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <body>
+                <div>
+                  <p>
+                    Hello world!
+                  </p>
+                </div>
+              </body>
+            </html>
+          EOHTML
+          node = html.xpath("//div").first
+          assert_equal("<p>Helloworld!</p>", node.inner_html.gsub(/\s/, ""))
+        end
+
+        def test_round_trip
+          doc = Nokogiri::HTML(html.inner_html)
+          assert_equal(html.root.to_html, doc.root.to_html)
+        end
+
+        def test_fragment_contains_text_node
+          fragment = Nokogiri::HTML.fragment("fooo")
+          assert_equal(1, fragment.children.length)
+          assert_equal("fooo", fragment.inner_text)
+        end
+
+        def test_fragment_includes_two_tags
+          assert_equal(2, Nokogiri::HTML.fragment("<br/><hr/>").children.length)
+        end
+
+        def test_relative_css_finder
+          doc = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <body>
+                <div class="red">
+                  <p>
+                    inside red
+                  </p>
+                </div>
+                <div class="green">
+                  <p>
+                    inside green
+                  </p>
+                </div>
+              </body>
+            </html>
+          EOHTML
+          red_divs = doc.css("div.red")
+          assert_equal(1, red_divs.length)
+          p_tags = red_divs.first.css("p")
+          assert_equal(1, p_tags.length)
+          assert_equal("inside red", p_tags.first.text.strip)
+        end
+
+        def test_find_classes
+          doc = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <body>
+                <p class="red">RED</p>
+                <p class="awesome red">RED</p>
+                <p class="notred">GREEN</p>
+                <p class="green notred">GREEN</p>
+              </body>
+            </html>
+          EOHTML
+          list = doc.css(".red")
+          assert_equal(2, list.length)
+          assert_equal(%w{RED RED}, list.map(&:text))
+        end
+
+        def test_parse_can_take_io
+          html = nil
+          File.open(HTML_FILE, "rb") do |f|
+            html = Nokogiri::HTML(f)
+          end
+          assert(html.html?)
+          assert_equal(HTML_FILE, html.url)
+        end
+
+        def test_parse_works_with_an_object_that_responds_to_path
+          html = String.new("<html><body>hello</body></html>")
+          def html.path
+            "/i/should/be/the/document/url"
+          end
+
+          doc = Nokogiri::HTML.parse(html)
+
+          assert_equal("/i/should/be/the/document/url", doc.url)
+        end
+
+        # issue #1821, #2110
+        def test_parse_can_take_pathnames
+          assert(File.size(HTML_FILE) > 4096) # file must be big enough to trip the read callback more than once
+
+          doc = Nokogiri::HTML.parse(Pathname.new(HTML_FILE))
+
+          # an arbitrary assertion on the structure of the document
+          assert_equal(166, doc.css("a").length)
+          assert_equal(HTML_FILE, doc.url)
+        end
+
+        def test_html?
+          assert(!html.xml?)
+          assert(html.html?)
+        end
+
+        def test_serialize
+          assert(html.serialize)
+          assert(html.to_html)
+        end
+
+        def test_empty_document
+          # empty document should return "" #699
+          assert_equal("", Nokogiri::HTML.parse(nil).text)
+          assert_equal("", Nokogiri::HTML.parse("").text)
+        end
+
+        def test_capturing_nonparse_errors_during_document_clone
+          # see https://github.com/sparklemotion/nokogiri/issues/1196 for background
+          original = Nokogiri::HTML.parse("<div id='unique'></div><div id='unique'></div>")
+          original_errors = original.errors.dup
+
+          copy = original.dup
+          assert_equal(original_errors, copy.errors)
+        end
+
+        def test_capturing_nonparse_errors_during_node_copy_between_docs
+          # Errors should be emitted while parsing only, and should not change when moving nodes.
+          doc1 = Nokogiri::HTML("<html><body><diva id='unique'>one</diva></body></html>")
+          doc2 = Nokogiri::HTML("<html><body><dive id='unique'>two</dive></body></html>")
+          node1 = doc1.at_css("#unique")
+          node2 = doc2.at_css("#unique")
+          original_errors1 = doc1.errors.dup
+          original_errors2 = doc2.errors.dup
+          assert(original_errors1.any? { |e| e.to_s =~ /Tag diva invalid/ }, "it should complain about the tag name")
+          assert(original_errors2.any? { |e| e.to_s =~ /Tag dive invalid/ }, "it should complain about the tag name")
+
+          node1.add_child(node2)
+
+          assert_equal(original_errors1, doc1.errors)
+          assert_equal(original_errors2, doc2.errors)
+        end
+
+        def test_silencing_nonparse_errors_during_attribute_insertion_1262
+          # see https://github.com/sparklemotion/nokogiri/issues/1262
+          #
+          # libxml2 emits a warning when this happens; the JRuby
+          # implementation does not. so rather than capture the error in
+          # doc.errors in a platform-dependent way, I'm opting to have
+          # the error silenced.
+          #
+          # So this test doesn't look meaningful, but we want to avoid
+          # having `ID unique-issue-1262 already defined` emitted to
+          # stderr when running the test suite.
+          #
+          doc = Nokogiri::HTML::Document.new
+          Nokogiri::XML::Element.new("div", doc).set_attribute("id", "unique-issue-1262")
+          Nokogiri::XML::Element.new("div", doc).set_attribute("id", "unique-issue-1262")
+          assert_equal(0, doc.errors.length)
+        end
+
+        it "skips encoding for script tags" do
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <head>
+                <script>var isGreater = 4 > 5;</script>
+              </head>
+              <body></body>
+            </html>
+          EOHTML
+          node = html.xpath("//script").first
+          assert_equal("var isGreater = 4 > 5;", node.inner_html)
+        end
+
+        it "skips encoding for style tags" do
+          html = Nokogiri::HTML(<<~EOHTML)
+            <html>
+              <head>
+                <style>tr > div { display:block; }</style>
+              </head>
+              <body></body>
+            </html>
+          EOHTML
+          node = html.xpath("//style").first
+          assert_equal("tr > div { display:block; }", node.inner_html)
+        end
+
+        it "does not fail when converting to_html using explicit encoding" do
+          html_fragment = <<~EOHTML
+            <img width="16" height="16" src="images/icon.gif" border="0" alt="Inactive hide details for &quot;User&quot; ---19/05/2015 12:55:29---Provvediamo subito nell&#8217;integrare">
+          EOHTML
+          doc = Nokogiri::HTML(html_fragment, nil, "ISO-8859-1")
+          html = doc.to_html
+          assert html.index("src=\"images/icon.gif\"")
+          assert_equal "ISO-8859-1", html.encoding.name
+        end
+
+        def test_leaking_dtd_nodes_after_internal_subset_removal
+          # see https://github.com/sparklemotion/nokogiri/issues/1784
+          #
+          # just checking that this doesn't raise a valgrind error. we
+          # don't otherwise have any test coverage for removing DTDs.
+          #
+          100.times do |i|
+            Nokogiri::HTML::Document.new.internal_subset.remove
           end
         end
 
-        doc = Nokogiri::HTML.parse(klass.new)
-        assert_equal("foo", doc.at_css("div").content)
-      end
-
-      def test_parse_temp_file
-        temp_html_file = Tempfile.new("TEMP_HTML_FILE")
-        File.open(HTML_FILE, "rb") { |f| temp_html_file.write(f.read) }
-        temp_html_file.close
-        temp_html_file.open
-        assert_equal(Nokogiri::HTML.parse(File.read(HTML_FILE)).xpath("//div/a").length,
-          Nokogiri::HTML.parse(temp_html_file).xpath("//div/a").length)
-      end
-
-      def test_to_xhtml
-        assert_match("XHTML", html.to_xhtml)
-        assert_match("XHTML", html.to_xhtml(encoding: "UTF-8"))
-        assert_match("UTF-8", html.to_xhtml(encoding: "UTF-8"))
-      end
-
-      def test_no_xml_header
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-          </html>
-        EOHTML
-        assert(html.to_html.length > 0, "html length is too short")
-        assert_no_match(/^<\?xml/, html.to_html)
-      end
-
-      def test_document_has_error
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <body>
-              <div awesome="asdf>
-                <p>inside div tag</p>
-              </div>
-              <p>outside div tag</p>
-            </body>
-          </html>
-        EOHTML
-        assert(html.errors.length > 0)
-      end
-
-      def test_relative_css
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <body>
-              <div>
-                <p>inside div tag</p>
-              </div>
-              <p>outside div tag</p>
-            </body>
-          </html>
-        EOHTML
-        set = html.search("div").search("p")
-        assert_equal(1, set.length)
-        assert_equal("inside div tag", set.first.inner_text)
-      end
-
-      def test_multi_css
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <body>
-              <div>
-                <p>p tag</p>
-                <a>a tag</a>
-              </div>
-            </body>
-          </html>
-        EOHTML
-        set = html.css("p, a")
-        assert_equal(2, set.length)
-        assert_equal(["a tag", "p tag"].sort, set.map(&:content).sort)
-      end
-
-      def test_inner_text
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <body>
-              <div>
-                <p>
-                  Hello world!
-                </p>
-              </div>
-            </body>
-          </html>
-        EOHTML
-        node = html.xpath("//div").first
-        assert_equal("Hello world!", node.inner_text.strip)
-      end
-
-      def test_doc_type
-        html = Nokogiri::HTML(<<~EOHTML)
-          <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-          <html xmlns="http://www.w3.org/1999/xhtml">
-            <body>
-              <p>Rainbow Dash</p>
-            </body>
-          </html>
-        EOHTML
-        assert_equal("html", html.internal_subset.name)
-        assert_equal("-//W3C//DTD XHTML 1.1//EN", html.internal_subset.external_id)
-        assert_equal("http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd", html.internal_subset.system_id)
-        assert_equal("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">", html.to_s[0, 97])
-      end
-
-      def test_content_size
-        html = Nokogiri::HTML("<div>\n</div>")
-        assert_equal(1, html.content.size)
-        assert_equal(1, html.content.split("").size)
-        assert_equal("\n", html.content)
-      end
-
-      def test_find_by_xpath
-        found = html.xpath("//div/a")
-        assert_equal(3, found.length)
-      end
-
-      def test_find_by_css
-        found = html.css("div > a")
-        assert_equal(3, found.length)
-      end
-
-      def test_find_by_css_with_square_brackets
-        found = html.css("div[@id='header'] > h1")
-        found = html.css("div[@id='header'] h1") # this blows up on commit 6fa0f6d329d9dbf1cc21c0ac72f7e627bb4c05fc
-        assert_equal(1, found.length)
-      end
-
-      def test_find_by_css_with_escaped_characters
-        found_without_escape = html.css("div[@id='abc.123']")
-        found_by_id = html.css('#abc\.123')
-        found_by_class = html.css('.special\.character')
-        assert_equal(1, found_without_escape.length)
-        assert_equal(found_by_id, found_without_escape)
-        assert_equal(found_by_class, found_without_escape)
-      end
-
-      def test_find_with_function
-        assert(html.css("div:awesome() h1", Class.new do
-          def awesome(divs)
-            [divs.first]
+        describe ".parse" do
+          let(:html_strict) do
+            Nokogiri::XML::ParseOptions.new(Nokogiri::XML::ParseOptions::DEFAULT_HTML).norecover
           end
-        end.new))
-      end
 
-      def test_dup_shallow
-        found = html.search("//div/a").first
-        dup = found.dup(0)
-        assert(dup)
-        assert_equal("", dup.content)
-      end
+          it "sets the test up correctly" do
+            assert(html_strict.strict?)
+          end
 
-      def test_search_can_handle_xpath_and_css
-        found = html.search("//div/a", "div > p")
-        length = html.xpath("//div/a").length +
-                 html.css("div > p").length
-        assert_equal(length, found.length)
-      end
+          describe "read memory" do
+            let(:input) { "<html><body><div" }
 
-      def test_dup_document
-        assert(dup = html.dup)
-        assert_not_equal(dup, html)
-        assert(html.html?)
-        assert_instance_of(Nokogiri::HTML::Document, dup)
-        assert(dup.html?, "duplicate should be html")
-        assert_equal(html.to_s, dup.to_s)
-      end
+            describe "strict parsing" do
+              let(:parse_options) { html_strict }
 
-      def test_dup_document_shallow
-        assert(dup = html.dup(0))
-        assert_not_equal(dup, html)
-      end
-
-      def test_dup
-        found = html.search("//div/a").first
-        dup = found.dup
-        assert(dup)
-        assert_equal(found.content, dup.content)
-        assert_equal(found.document, dup.document)
-      end
-
-      # issue 1060
-      def test_node_ownership_after_dup
-        html = "<html><head></head><body><div>replace me</div></body></html>"
-        doc = Nokogiri::HTML::Document.parse(html)
-        dup = doc.dup
-        assert_same(dup, dup.at_css("div").document)
-
-        # should not raise an exception
-        dup.at_css("div").parse("<div>replaced</div>")
-      end
-
-      def test_inner_html
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <body>
-              <div>
-                <p>
-                  Hello world!
-                </p>
-              </div>
-            </body>
-          </html>
-        EOHTML
-        node = html.xpath("//div").first
-        assert_equal("<p>Helloworld!</p>", node.inner_html.gsub(/\s/, ""))
-      end
-
-      def test_round_trip
-        doc = Nokogiri::HTML(html.inner_html)
-        assert_equal(html.root.to_html, doc.root.to_html)
-      end
-
-      def test_fragment_contains_text_node
-        fragment = Nokogiri::HTML.fragment("fooo")
-        assert_equal(1, fragment.children.length)
-        assert_equal("fooo", fragment.inner_text)
-      end
-
-      def test_fragment_includes_two_tags
-        assert_equal(2, Nokogiri::HTML.fragment("<br/><hr/>").children.length)
-      end
-
-      def test_relative_css_finder
-        doc = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <body>
-              <div class="red">
-                <p>
-                  inside red
-                </p>
-              </div>
-              <div class="green">
-                <p>
-                  inside green
-                </p>
-              </div>
-            </body>
-          </html>
-        EOHTML
-        red_divs = doc.css("div.red")
-        assert_equal(1, red_divs.length)
-        p_tags = red_divs.first.css("p")
-        assert_equal(1, p_tags.length)
-        assert_equal("inside red", p_tags.first.text.strip)
-      end
-
-      def test_find_classes
-        doc = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <body>
-              <p class="red">RED</p>
-              <p class="awesome red">RED</p>
-              <p class="notred">GREEN</p>
-              <p class="green notred">GREEN</p>
-            </body>
-          </html>
-        EOHTML
-        list = doc.css(".red")
-        assert_equal(2, list.length)
-        assert_equal(%w{RED RED}, list.map(&:text))
-      end
-
-      def test_parse_can_take_io
-        html = nil
-        File.open(HTML_FILE, "rb") do |f|
-          html = Nokogiri::HTML(f)
-        end
-        assert(html.html?)
-        assert_equal(HTML_FILE, html.url)
-      end
-
-      def test_parse_works_with_an_object_that_responds_to_path
-        html = String.new("<html><body>hello</body></html>")
-        def html.path
-          "/i/should/be/the/document/url"
-        end
-
-        doc = Nokogiri::HTML.parse(html)
-
-        assert_equal("/i/should/be/the/document/url", doc.url)
-      end
-
-      # issue #1821, #2110
-      def test_parse_can_take_pathnames
-        assert(File.size(HTML_FILE) > 4096) # file must be big enough to trip the read callback more than once
-
-        doc = Nokogiri::HTML.parse(Pathname.new(HTML_FILE))
-
-        # an arbitrary assertion on the structure of the document
-        assert_equal(166, doc.css("a").length)
-        assert_equal(HTML_FILE, doc.url)
-      end
-
-      def test_html?
-        assert(!html.xml?)
-        assert(html.html?)
-      end
-
-      def test_serialize
-        assert(html.serialize)
-        assert(html.to_html)
-      end
-
-      def test_empty_document
-        # empty document should return "" #699
-        assert_equal("", Nokogiri::HTML.parse(nil).text)
-        assert_equal("", Nokogiri::HTML.parse("").text)
-      end
-
-      def test_capturing_nonparse_errors_during_document_clone
-        # see https://github.com/sparklemotion/nokogiri/issues/1196 for background
-        original = Nokogiri::HTML.parse("<div id='unique'></div><div id='unique'></div>")
-        original_errors = original.errors.dup
-
-        copy = original.dup
-        assert_equal(original_errors, copy.errors)
-      end
-
-      def test_capturing_nonparse_errors_during_node_copy_between_docs
-        # Errors should be emitted while parsing only, and should not change when moving nodes.
-        doc1 = Nokogiri::HTML("<html><body><diva id='unique'>one</diva></body></html>")
-        doc2 = Nokogiri::HTML("<html><body><dive id='unique'>two</dive></body></html>")
-        node1 = doc1.at_css("#unique")
-        node2 = doc2.at_css("#unique")
-        original_errors1 = doc1.errors.dup
-        original_errors2 = doc2.errors.dup
-        assert(original_errors1.any? { |e| e.to_s =~ /Tag diva invalid/ }, "it should complain about the tag name")
-        assert(original_errors2.any? { |e| e.to_s =~ /Tag dive invalid/ }, "it should complain about the tag name")
-
-        node1.add_child(node2)
-
-        assert_equal(original_errors1, doc1.errors)
-        assert_equal(original_errors2, doc2.errors)
-      end
-
-      def test_silencing_nonparse_errors_during_attribute_insertion_1262
-        # see https://github.com/sparklemotion/nokogiri/issues/1262
-        #
-        # libxml2 emits a warning when this happens; the JRuby
-        # implementation does not. so rather than capture the error in
-        # doc.errors in a platform-dependent way, I'm opting to have
-        # the error silenced.
-        #
-        # So this test doesn't look meaningful, but we want to avoid
-        # having `ID unique-issue-1262 already defined` emitted to
-        # stderr when running the test suite.
-        #
-        doc = Nokogiri::HTML::Document.new
-        Nokogiri::XML::Element.new("div", doc).set_attribute("id", "unique-issue-1262")
-        Nokogiri::XML::Element.new("div", doc).set_attribute("id", "unique-issue-1262")
-        assert_equal(0, doc.errors.length)
-      end
-
-      it "skips encoding for script tags" do
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <head>
-              <script>var isGreater = 4 > 5;</script>
-            </head>
-            <body></body>
-          </html>
-        EOHTML
-        node = html.xpath("//script").first
-        assert_equal("var isGreater = 4 > 5;", node.inner_html)
-      end
-
-      it "skips encoding for style tags" do
-        html = Nokogiri::HTML(<<~EOHTML)
-          <html>
-            <head>
-              <style>tr > div { display:block; }</style>
-            </head>
-            <body></body>
-          </html>
-        EOHTML
-        node = html.xpath("//style").first
-        assert_equal("tr > div { display:block; }", node.inner_html)
-      end
-
-      it "does not fail when converting to_html using explicit encoding" do
-        html_fragment = <<~EOHTML
-          <img width="16" height="16" src="images/icon.gif" border="0" alt="Inactive hide details for &quot;User&quot; ---19/05/2015 12:55:29---Provvediamo subito nell&#8217;integrare">
-        EOHTML
-        doc = Nokogiri::HTML(html_fragment, nil, "ISO-8859-1")
-        html = doc.to_html
-        assert html.index("src=\"images/icon.gif\"")
-        assert_equal "ISO-8859-1", html.encoding.name
-      end
-
-      def test_leaking_dtd_nodes_after_internal_subset_removal
-        # see https://github.com/sparklemotion/nokogiri/issues/1784
-        #
-        # just checking that this doesn't raise a valgrind error. we
-        # don't otherwise have any test coverage for removing DTDs.
-        #
-        100.times do |i|
-          Nokogiri::HTML::Document.new.internal_subset.remove
-        end
-      end
-
-      describe "HTML::Document.parse" do
-        let(:html_strict) do
-          Nokogiri::XML::ParseOptions.new(Nokogiri::XML::ParseOptions::DEFAULT_HTML).norecover
-        end
-
-        it "sets the test up correctly" do
-          assert(html_strict.strict?)
-        end
-
-        describe "read memory" do
-          let(:input) { "<html><body><div" }
-
-          describe "strict parsing" do
-            let(:parse_options) { html_strict }
-
-            it "raises exception on parse error" do
-              exception = assert_raises Nokogiri::SyntaxError do
-                Nokogiri::HTML.parse(input, nil, nil, parse_options)
+              it "raises exception on parse error" do
+                exception = assert_raises(Nokogiri::SyntaxError) do
+                  Nokogiri::HTML.parse(input, nil, nil, parse_options)
+                end
+                assert_match(/Parser without recover option encountered error or warning/, exception.to_s)
               end
-              assert_match(/Parser without recover option encountered error or warning/, exception.to_s)
+            end
+
+            describe "default options" do
+              it "does not raise exception on parse error" do
+                doc = Nokogiri::HTML.parse(input)
+                assert_operator(doc.errors.length, :>, 0)
+              end
             end
           end
 
-          describe "default options" do
-            it "does not raise exception on parse error" do
-              doc = Nokogiri::HTML.parse(input)
-              assert_operator(doc.errors.length, :>, 0)
+          describe "read io" do
+            let(:input) { StringIO.new("<html><body><div") }
+
+            describe "strict parsing" do
+              let(:parse_options) { html_strict }
+
+              it "raises exception on parse error" do
+                exception = assert_raises(Nokogiri::SyntaxError) do
+                  Nokogiri::HTML.parse(input, nil, "UTF-8", parse_options)
+                end
+                assert_match(/Parser without recover option encountered error or warning/, exception.to_s)
+              end
+            end
+
+            describe "default options" do
+              it "does not raise exception on parse error" do
+                doc = Nokogiri::HTML.parse(input, nil, "UTF-8")
+                assert_operator(doc.errors.length, :>, 0)
+              end
             end
           end
         end
 
-        describe "read io" do
-          let(:input) { StringIO.new("<html><body><div") }
+        describe "subclassing" do
+          let(:klass) do
+            Class.new(Nokogiri::HTML::Document) do
+              attr_accessor :initialized_with, :initialized_count
 
-          describe "strict parsing" do
-            let(:parse_options) { html_strict }
-
-            it "raises exception on parse error" do
-              exception = assert_raises Nokogiri::SyntaxError do
-                Nokogiri::HTML.parse(input, nil, "UTF-8", parse_options)
+              def initialize(*args)
+                super
+                @initialized_with = args
+                @initialized_count ||= 0
+                @initialized_count += 1
               end
-              assert_match(/Parser without recover option encountered error or warning/, exception.to_s)
             end
           end
 
-          describe "default options" do
-            it "does not raise exception on parse error" do
-              doc = Nokogiri::HTML.parse(input, nil, "UTF-8")
-              assert_operator(doc.errors.length, :>, 0)
+          describe ".new" do
+            it "returns an instance of the expected class" do
+              doc = klass.new
+              assert_instance_of(klass, doc)
+            end
+
+            it "calls #initialize exactly once" do
+              doc = klass.new
+              assert_equal(1, doc.initialized_count)
+            end
+
+            it "passes arguments to #initialize" do
+              doc = klass.new("http://www.w3.org/TR/REC-html40/loose.dtd", "-//W3C//DTD HTML 4.0 Transitional//EN")
+              assert_equal(["http://www.w3.org/TR/REC-html40/loose.dtd", "-//W3C//DTD HTML 4.0 Transitional//EN"],
+                           doc.initialized_with)
+            end
+          end
+
+          it "#dup returns the expected class" do
+            doc = klass.new.dup
+            assert_instance_of(klass, doc)
+          end
+
+          describe ".parse" do
+            it "returns an instance of the expected class" do
+              doc = klass.parse(File.read(HTML_FILE))
+              assert_instance_of(klass, doc)
+            end
+
+            it "calls #initialize exactly once" do
+              doc = klass.parse(File.read(HTML_FILE))
+              assert_equal(1, doc.initialized_count)
+            end
+
+            it "parses the doc" do
+              doc = klass.parse(File.read(HTML_FILE))
+              assert_equal(html.root.to_s, doc.root.to_s)
             end
           end
         end

--- a/test/html/test_document_fragment.rb
+++ b/test/html/test_document_fragment.rb
@@ -1,315 +1,363 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri
   module HTML
     class TestDocumentFragment < Nokogiri::TestCase
-      def setup
-        super
-        @html = Nokogiri::HTML.parse(File.read(HTML_FILE), HTML_FILE)
-      end
+      describe Nokogiri::HTML::DocumentFragment do
+        let(:html) { Nokogiri::HTML.parse(File.read(HTML_FILE), HTML_FILE) }
 
-      def test_ascii_8bit_encoding
-        s = String.new 'hello'
-        s.force_encoding ::Encoding::ASCII_8BIT
-        assert_equal "hello", Nokogiri::HTML::DocumentFragment.parse(s).to_html
-      end
-
-      def test_inspect_encoding
-        fragment = "<div>こんにちは！</div>".encode('EUC-JP')
-        f = Nokogiri::HTML::DocumentFragment.parse fragment
-        assert_equal "こんにちは！", f.content
-      end
-
-      def test_html_parse_encoding
-        fragment = "<div>こんにちは！</div>".encode 'EUC-JP'
-        f = Nokogiri::HTML.fragment fragment
-        assert_equal 'EUC-JP', f.document.encoding
-        assert_equal "こんにちは！", f.content
-      end
-
-      def test_unlink_empty_document
-        frag = Nokogiri::HTML::DocumentFragment.parse('').unlink # must_not_raise
-        assert_nil frag.parent
-      end
-
-      def test_colons_are_not_removed
-        doc = Nokogiri::HTML::DocumentFragment.parse("<span>3:30pm</span>")
-        assert_match(/3:30/, doc.to_s)
-      end
-
-      def test_parse_encoding
-        fragment = "<div>hello world</div>"
-        f = Nokogiri::HTML::DocumentFragment.parse fragment, 'ISO-8859-1'
-        assert_equal 'ISO-8859-1', f.document.encoding
-        assert_equal "hello world", f.content
-      end
-
-      def test_html_parse_with_encoding
-        fragment = "<div>hello world</div>"
-        f = Nokogiri::HTML.fragment fragment, 'ISO-8859-1'
-        assert_equal 'ISO-8859-1', f.document.encoding
-        assert_equal "hello world", f.content
-      end
-
-      def test_parse_in_context
-        assert_equal('<br>', @html.root.parse('<br />').to_s)
-      end
-
-      def test_inner_html=
-        fragment = Nokogiri::HTML.fragment '<hr />'
-
-        fragment.inner_html = "hello"
-        assert_equal 'hello', fragment.inner_html
-      end
-
-      def test_ancestors_search
-        html = %q{
-          <div>
-            <ul>
-              <li>foo</li>
-            </ul>
-          </div>
-        }
-        fragment = Nokogiri::HTML.fragment html
-        li = fragment.at('li')
-        assert li.matches?('li')
-      end
-
-      def test_fun_encoding
-        string = %Q(<body>こんにちは</body>)
-        html = Nokogiri::HTML::DocumentFragment.parse(
-          string
-        ).to_html(:encoding => 'UTF-8')
-        assert_equal string, html
-      end
-
-      def test_new
-        assert Nokogiri::HTML::DocumentFragment.new(@html)
-      end
-
-      def test_body_fragment_should_contain_body
-        fragment = Nokogiri::HTML::DocumentFragment.parse("  <body><div>foo</div></body>")
-        assert_match(/^<body>/, fragment.to_s)
-      end
-
-      def test_nonbody_fragment_should_not_contain_body
-        fragment = Nokogiri::HTML::DocumentFragment.parse("<div>foo</div>")
-        assert_match(/^<div>/, fragment.to_s)
-      end
-
-      def test_fragment_should_have_document
-        fragment = Nokogiri::HTML::DocumentFragment.new(@html)
-        assert_equal @html, fragment.document
-      end
-
-      def test_empty_fragment_should_be_searchable_by_css
-        fragment = Nokogiri::HTML.fragment("")
-        assert_equal 0, fragment.css("a").size
-      end
-
-      def test_empty_fragment_should_be_searchable
-        fragment = Nokogiri::HTML.fragment("")
-        assert_equal 0, fragment.search("//a").size
-      end
-
-      def test_name
-        fragment = Nokogiri::HTML::DocumentFragment.new(@html)
-        assert_equal '#document-fragment', fragment.name
-      end
-
-      def test_static_method
-        fragment = Nokogiri::HTML::DocumentFragment.parse("<div>a</div>")
-        assert_instance_of Nokogiri::HTML::DocumentFragment, fragment
-      end
-
-      def test_many_fragments
-        100.times { Nokogiri::HTML::DocumentFragment.new(@html) }
-      end
-
-      def test_subclass
-        klass = Class.new(Nokogiri::HTML::DocumentFragment)
-        fragment = klass.new(@html, "<div>a</div>")
-        assert_instance_of klass, fragment
-      end
-
-      def test_subclass_parse
-        klass = Class.new(Nokogiri::HTML::DocumentFragment)
-        doc = klass.parse("<div>a</div>")
-        assert_instance_of klass, doc
-      end
-
-      def test_html_fragment
-        fragment = Nokogiri::HTML.fragment("<div>a</div>")
-        assert_equal "<div>a</div>", fragment.to_s
-      end
-
-      def test_html_fragment_has_outer_text
-        doc = "a<div>b</div>c"
-        fragment = Nokogiri::HTML::Document.new.fragment(doc)
-        if Nokogiri.uses_libxml?("<= 2.6.16")
-          assert_equal "a<div>b</div><p>c</p>", fragment.to_s
-        else
-          assert_equal "a<div>b</div>c", fragment.to_s
+        def test_ascii_8bit_encoding
+          s = String.new('hello')
+          s.force_encoding(::Encoding::ASCII_8BIT)
+          assert_equal("hello", Nokogiri::HTML::DocumentFragment.parse(s).to_html)
         end
-      end
 
-      def test_html_fragment_case_insensitivity
-        doc = "<Div>b</Div>"
-        fragment = Nokogiri::HTML::Document.new.fragment(doc)
-        assert_equal "<div>b</div>", fragment.to_s
-      end
-
-      def test_html_fragment_with_leading_whitespace
-        doc = "     <div>b</div>  "
-        fragment = Nokogiri::HTML::Document.new.fragment(doc)
-        assert_match %r%     <div>b</div> *%, fragment.to_s
-      end
-
-      def test_html_fragment_with_leading_whitespace_and_newline
-        doc = "     \n<div>b</div>  "
-        fragment = Nokogiri::HTML::Document.new.fragment(doc)
-        assert_match %r%     \n<div>b</div> *%, fragment.to_s
-      end
-
-      def test_html_fragment_with_input_and_intermediate_whitespace
-        doc = "<label>Label</label><input type=\"text\"> <span>span</span>"
-        fragment = Nokogiri::HTML::Document.new.fragment(doc)
-        assert_equal "<label>Label</label><input type=\"text\"> <span>span</span>", fragment.to_s
-      end
-
-      def test_html_fragment_with_leading_text_and_newline
-        fragment = HTML::Document.new.fragment("First line\nSecond line<br>Broken line")
-        assert_equal fragment.to_s, "First line\nSecond line<br>Broken line"
-      end
-
-      def test_html_fragment_with_leading_whitespace_and_text_and_newline
-        fragment = HTML::Document.new.fragment("  First line\nSecond line<br>Broken line")
-        assert_equal "  First line\nSecond line<br>Broken line", fragment.to_s
-      end
-
-      def test_html_fragment_with_leading_entity
-        failed = "&quot;test<br/>test&quot;"
-        fragment = Nokogiri::HTML::DocumentFragment.parse(failed)
-        assert_equal '"test<br>test"', fragment.to_html
-      end
-
-      def test_to_s
-        doc = "<span>foo<br></span><span>bar</span>"
-        fragment = Nokogiri::HTML::Document.new.fragment(doc)
-        assert_equal "<span>foo<br></span><span>bar</span>", fragment.to_s
-      end
-
-      def test_to_html
-        doc = "<span>foo<br></span><span>bar</span>"
-        fragment = Nokogiri::HTML::Document.new.fragment(doc)
-        assert_equal "<span>foo<br></span><span>bar</span>", fragment.to_html
-      end
-
-      def test_to_xhtml
-        doc = "<span>foo<br></span><span>bar</span><p></p>"
-        fragment = Nokogiri::HTML::Document.new.fragment(doc)
-        if Nokogiri.jruby? || Nokogiri.uses_libxml?(">= 2.7.0")
-          assert_equal "<span>foo<br /></span><span>bar</span><p></p>", fragment.to_xhtml
-        else
-          # FIXME: why are we doing this ? this violates the spec,
-          # see http://www.w3.org/TR/xhtml1/#C_2
-          assert_equal "<span>foo<br></span><span>bar</span><p></p>", fragment.to_xhtml
+        def test_inspect_encoding
+          fragment = "<div>こんにちは！</div>".encode('EUC-JP')
+          f = Nokogiri::HTML::DocumentFragment.parse(fragment)
+          assert_equal("こんにちは！", f.content)
         end
-      end
 
-      def test_to_xml
-        doc = "<span>foo<br></span><span>bar</span>"
-        fragment = Nokogiri::HTML::Document.new.fragment(doc)
-        assert_equal "<span>foo<br/></span><span>bar</span>", fragment.to_xml
-      end
-
-      def test_fragment_script_tag_with_cdata
-        doc = HTML::Document.new
-        fragment = doc.fragment("<script>var foo = 'bar';</script>")
-        assert_equal("<script>var foo = 'bar';</script>",
-          fragment.to_s)
-      end
-
-      def test_fragment_with_comment
-        doc = HTML::Document.new
-        fragment = doc.fragment("<p>hello<!-- your ad here --></p>")
-        assert_equal("<p>hello<!-- your ad here --></p>",
-          fragment.to_s)
-      end
-
-      def test_element_children_counts
-        if Nokogiri.uses_libxml?("<= 2.9.1")
-          skip "#elements doesn't work in 2.9.1, see 1793a5a for history"
+        def test_html_parse_encoding
+          fragment = "<div>こんにちは！</div>".encode('EUC-JP')
+          f = Nokogiri::HTML.fragment(fragment)
+          assert_equal('EUC-JP', f.document.encoding)
+          assert_equal("こんにちは！", f.content)
         end
-        doc = Nokogiri::HTML::DocumentFragment.parse("   <div>  </div>\n   ")
-        assert_equal 1, doc.element_children.count
-      end
 
-      def test_malformed_fragment_is_corrected
-        fragment = HTML::DocumentFragment.parse("<div </div>")
-        assert_equal "<div></div>", fragment.to_s
-      end
+        def test_unlink_empty_document
+          frag = Nokogiri::HTML::DocumentFragment.parse('').unlink # must_not_raise
+          assert_nil(frag.parent)
+        end
 
-      def test_unclosed_script_tag
-        # see GH#315
-        fragment = HTML::DocumentFragment.parse("foo <script>bar")
-        assert_equal "foo <script>bar</script>", fragment.to_html
-      end
+        def test_colons_are_not_removed
+          doc = Nokogiri::HTML::DocumentFragment.parse("<span>3:30pm</span>")
+          assert_match(/3:30/, doc.to_s)
+        end
 
-      def test_error_propagation_on_fragment_parse
-        frag = Nokogiri::HTML::DocumentFragment.parse "<hello>oh, hello there.</hello>"
-        assert frag.errors.any?{|err| err.to_s =~ /Tag hello invalid/}, "errors should be copied to the fragment"
-      end
+        def test_parse_encoding
+          fragment = "<div>hello world</div>"
+          f = Nokogiri::HTML::DocumentFragment.parse(fragment, 'ISO-8859-1')
+          assert_equal('ISO-8859-1', f.document.encoding)
+          assert_equal("hello world", f.content)
+        end
 
-      def test_error_propagation_on_fragment_parse_in_node_context
-        doc = Nokogiri::HTML::Document.parse "<html><body><div></div></body></html>"
-        context_node = doc.at_css "div"
-        frag = Nokogiri::HTML::DocumentFragment.new doc, "<hello>oh, hello there.</hello>", context_node
-        assert frag.errors.any?{|err| err.to_s =~ /Tag hello invalid/}, "errors should be on the context node's document"
-      end
+        def test_html_parse_with_encoding
+          fragment = "<div>hello world</div>"
+          f = Nokogiri::HTML.fragment(fragment, 'ISO-8859-1')
+          assert_equal('ISO-8859-1', f.document.encoding)
+          assert_equal("hello world", f.content)
+        end
 
-      def test_error_propagation_on_fragment_parse_in_node_context_should_not_include_preexisting_errors
-        doc = Nokogiri::HTML::Document.parse "<html><body><div></div><jimmy></jimmy></body></html>"
-        assert doc.errors.any?{|err| err.to_s =~ /jimmy/}, "assert on setup"
+        def test_parse_in_context
+          assert_equal('<br>', html.root.parse('<br />').to_s)
+        end
 
-        context_node = doc.at_css "div"
-        frag = Nokogiri::HTML::DocumentFragment.new doc, "<hello>oh, hello there.</hello>", context_node
-        assert frag.errors.any?{|err| err.to_s =~ /Tag hello invalid/}, "errors should be on the context node's document"
-        assert frag.errors.none?{|err| err.to_s =~ /jimmy/}, "errors should not include pre-existing document errors"
-      end
+        def test_inner_html=
+          fragment = Nokogiri::HTML.fragment('<hr />')
 
-      def test_capturing_nonparse_errors_during_fragment_clone
-        # see https://github.com/sparklemotion/nokogiri/issues/1196 for background
-        original = Nokogiri::HTML.fragment("<div id='unique'></div><div id='unique'></div>")
-        original_errors = original.errors.dup
+          fragment.inner_html = "hello"
+          assert_equal('hello', fragment.inner_html)
+        end
 
-        copy = original.dup
-        assert_equal original_errors, copy.errors
-      end
+        def test_ancestors_search
+          html = <<~EOF
+            <div>
+              <ul>
+                <li>foo</li>
+              </ul>
+            </div>
+          EOF
+          fragment = Nokogiri::HTML.fragment(html)
+          li = fragment.at('li')
+          assert(li.matches?('li'))
+        end
 
-      def test_capturing_nonparse_errors_during_node_copy_between_fragments
-        # Errors should be emitted while parsing only, and should not change when moving nodes.
-        frag1 = Nokogiri::HTML.fragment("<diva id='unique'>one</diva>")
-        frag2 = Nokogiri::HTML.fragment("<dive id='unique'>two</dive>")
-        node1 = frag1.at_css("#unique")
-        node2 = frag2.at_css("#unique")
-        original_errors1 = frag1.errors.dup
-        original_errors2 = frag2.errors.dup
-        assert original_errors1.any?{|e| e.to_s =~ /Tag diva invalid/ }, "it should complain about the tag name"
-        assert original_errors2.any?{|e| e.to_s =~ /Tag dive invalid/ }, "it should complain about the tag name"
+        def test_fun_encoding
+          string = %(<body>こんにちは</body>)
+          html = Nokogiri::HTML::DocumentFragment.parse(
+            string
+          ).to_html(encoding: 'UTF-8')
+          assert_equal(string, html)
+        end
 
-        node1.add_child node2
+        def test_new
+          assert(Nokogiri::HTML::DocumentFragment.new(html))
+        end
 
-        assert_equal original_errors1, frag1.errors
-        assert_equal original_errors2, frag2.errors
-      end
+        def test_body_fragment_should_contain_body
+          fragment = Nokogiri::HTML::DocumentFragment.parse("  <body><div>foo</div></body>")
+          assert_match(/^<body>/, fragment.to_s)
+        end
 
-      def test_dup_should_create_an_html_document_fragment
-        # https://github.com/sparklemotion/nokogiri/issues/1846
-        original = Nokogiri::HTML::DocumentFragment.parse("<div><p>hello</p></div>")
-        duplicate = original.dup
-        assert_instance_of Nokogiri::HTML::DocumentFragment, duplicate
+        def test_nonbody_fragment_should_not_contain_body
+          fragment = Nokogiri::HTML::DocumentFragment.parse("<div>foo</div>")
+          assert_match(/^<div>/, fragment.to_s)
+        end
+
+        def test_fragment_should_have_document
+          fragment = Nokogiri::HTML::DocumentFragment.new(html)
+          assert_equal(html, fragment.document)
+        end
+
+        def test_empty_fragment_should_be_searchable_by_css
+          fragment = Nokogiri::HTML.fragment("")
+          assert_equal(0, fragment.css("a").size)
+        end
+
+        def test_empty_fragment_should_be_searchable
+          fragment = Nokogiri::HTML.fragment("")
+          assert_equal(0, fragment.search("//a").size)
+        end
+
+        def test_name
+          fragment = Nokogiri::HTML::DocumentFragment.new(html)
+          assert_equal('#document-fragment', fragment.name)
+        end
+
+        def test_static_method
+          fragment = Nokogiri::HTML::DocumentFragment.parse("<div>a</div>")
+          assert_instance_of(Nokogiri::HTML::DocumentFragment, fragment)
+        end
+
+        def test_many_fragments
+          100.times { Nokogiri::HTML::DocumentFragment.new(html) }
+        end
+
+        def test_html_fragment
+          fragment = Nokogiri::HTML.fragment("<div>a</div>")
+          assert_equal("<div>a</div>", fragment.to_s)
+        end
+
+        def test_html_fragment_has_outer_text
+          doc = "a<div>b</div>c"
+          fragment = Nokogiri::HTML::Document.new.fragment(doc)
+          if Nokogiri.uses_libxml?("<= 2.6.16")
+            assert_equal("a<div>b</div><p>c</p>", fragment.to_s)
+          else
+            assert_equal("a<div>b</div>c", fragment.to_s)
+          end
+        end
+
+        def test_html_fragment_case_insensitivity
+          doc = "<Div>b</Div>"
+          fragment = Nokogiri::HTML::Document.new.fragment(doc)
+          assert_equal("<div>b</div>", fragment.to_s)
+        end
+
+        def test_html_fragment_with_leading_whitespace
+          doc = "     <div>b</div>  "
+          fragment = Nokogiri::HTML::Document.new.fragment(doc)
+          assert_match(%r%     <div>b</div> *%, fragment.to_s)
+        end
+
+        def test_html_fragment_with_leading_whitespace_and_newline
+          doc = "     \n<div>b</div>  "
+          fragment = Nokogiri::HTML::Document.new.fragment(doc)
+          assert_match(%r%     \n<div>b</div> *%, fragment.to_s)
+        end
+
+        def test_html_fragment_with_input_and_intermediate_whitespace
+          doc = "<label>Label</label><input type=\"text\"> <span>span</span>"
+          fragment = Nokogiri::HTML::Document.new.fragment(doc)
+          assert_equal("<label>Label</label><input type=\"text\"> <span>span</span>", fragment.to_s)
+        end
+
+        def test_html_fragment_with_leading_text_and_newline
+          fragment = HTML::Document.new.fragment("First line\nSecond line<br>Broken line")
+          assert_equal(fragment.to_s, "First line\nSecond line<br>Broken line")
+        end
+
+        def test_html_fragment_with_leading_whitespace_and_text_and_newline
+          fragment = HTML::Document.new.fragment("  First line\nSecond line<br>Broken line")
+          assert_equal("  First line\nSecond line<br>Broken line", fragment.to_s)
+        end
+
+        def test_html_fragment_with_leading_entity
+          failed = "&quot;test<br/>test&quot;"
+          fragment = Nokogiri::HTML::DocumentFragment.parse(failed)
+          assert_equal('"test<br>test"', fragment.to_html)
+        end
+
+        def test_to_s
+          doc = "<span>foo<br></span><span>bar</span>"
+          fragment = Nokogiri::HTML::Document.new.fragment(doc)
+          assert_equal("<span>foo<br></span><span>bar</span>", fragment.to_s)
+        end
+
+        def test_to_html
+          doc = "<span>foo<br></span><span>bar</span>"
+          fragment = Nokogiri::HTML::Document.new.fragment(doc)
+          assert_equal("<span>foo<br></span><span>bar</span>", fragment.to_html)
+        end
+
+        def test_to_xhtml
+          doc = "<span>foo<br></span><span>bar</span><p></p>"
+          fragment = Nokogiri::HTML::Document.new.fragment(doc)
+          if Nokogiri.jruby? || Nokogiri.uses_libxml?(">= 2.7.0")
+            assert_equal("<span>foo<br /></span><span>bar</span><p></p>", fragment.to_xhtml)
+          else
+            # FIXME: why are we doing this ? this violates the spec,
+            # see http://www.w3.org/TR/xhtml1/#C_2
+            assert_equal("<span>foo<br></span><span>bar</span><p></p>", fragment.to_xhtml)
+          end
+        end
+
+        def test_to_xml
+          doc = "<span>foo<br></span><span>bar</span>"
+          fragment = Nokogiri::HTML::Document.new.fragment(doc)
+          assert_equal("<span>foo<br/></span><span>bar</span>", fragment.to_xml)
+        end
+
+        def test_fragment_script_tag_with_cdata
+          doc = HTML::Document.new
+          fragment = doc.fragment("<script>var foo = 'bar';</script>")
+          assert_equal("<script>var foo = 'bar';</script>",
+                       fragment.to_s)
+        end
+
+        def test_fragment_with_comment
+          doc = HTML::Document.new
+          fragment = doc.fragment("<p>hello<!-- your ad here --></p>")
+          assert_equal("<p>hello<!-- your ad here --></p>",
+                       fragment.to_s)
+        end
+
+        def test_element_children_counts
+          if Nokogiri.uses_libxml?("<= 2.9.1")
+            skip("#elements doesn't work in 2.9.1, see 1793a5a for history")
+          end
+          doc = Nokogiri::HTML::DocumentFragment.parse("   <div>  </div>\n   ")
+          assert_equal(1, doc.element_children.count)
+        end
+
+        def test_malformed_fragment_is_corrected
+          fragment = HTML::DocumentFragment.parse("<div </div>")
+          assert_equal("<div></div>", fragment.to_s)
+        end
+
+        def test_unclosed_script_tag
+          # see GH#315
+          fragment = HTML::DocumentFragment.parse("foo <script>bar")
+          assert_equal("foo <script>bar</script>", fragment.to_html)
+        end
+
+        def test_error_propagation_on_fragment_parse
+          frag = Nokogiri::HTML::DocumentFragment.parse("<hello>oh, hello there.</hello>")
+          assert(frag.errors.any? { |err| err.to_s =~ /Tag hello invalid/ }, "errors should be copied to the fragment")
+        end
+
+        def test_error_propagation_on_fragment_parse_in_node_context
+          doc = Nokogiri::HTML::Document.parse("<html><body><div></div></body></html>")
+          context_node = doc.at_css("div")
+          frag = Nokogiri::HTML::DocumentFragment.new(doc, "<hello>oh, hello there.</hello>", context_node)
+          assert(frag.errors.any? do |err|
+                   err.to_s =~ /Tag hello invalid/
+                 end, "errors should be on the context node's document")
+        end
+
+        def test_error_propagation_on_fragment_parse_in_node_context_should_not_include_preexisting_errors
+          doc = Nokogiri::HTML::Document.parse("<html><body><div></div><jimmy></jimmy></body></html>")
+          assert(doc.errors.any? { |err| err.to_s =~ /jimmy/ }, "assert on setup")
+
+          context_node = doc.at_css("div")
+          frag = Nokogiri::HTML::DocumentFragment.new(doc, "<hello>oh, hello there.</hello>", context_node)
+          assert(frag.errors.any? do |err|
+                   err.to_s =~ /Tag hello invalid/
+                 end, "errors should be on the context node's document")
+          assert(frag.errors.none? do |err|
+                   err.to_s =~ /jimmy/
+                 end, "errors should not include pre-existing document errors")
+        end
+
+        def test_capturing_nonparse_errors_during_fragment_clone
+          # see https://github.com/sparklemotion/nokogiri/issues/1196 for background
+          original = Nokogiri::HTML.fragment("<div id='unique'></div><div id='unique'></div>")
+          original_errors = original.errors.dup
+
+          copy = original.dup
+          assert_equal(original_errors, copy.errors)
+        end
+
+        def test_capturing_nonparse_errors_during_node_copy_between_fragments
+          # Errors should be emitted while parsing only, and should not change when moving nodes.
+          frag1 = Nokogiri::HTML.fragment("<diva id='unique'>one</diva>")
+          frag2 = Nokogiri::HTML.fragment("<dive id='unique'>two</dive>")
+          node1 = frag1.at_css("#unique")
+          node2 = frag2.at_css("#unique")
+          original_errors1 = frag1.errors.dup
+          original_errors2 = frag2.errors.dup
+          assert(original_errors1.any? { |e| e.to_s =~ /Tag diva invalid/ }, "it should complain about the tag name")
+          assert(original_errors2.any? { |e| e.to_s =~ /Tag dive invalid/ }, "it should complain about the tag name")
+
+          node1.add_child(node2)
+
+          assert_equal(original_errors1, frag1.errors)
+          assert_equal(original_errors2, frag2.errors)
+        end
+
+        def test_dup_should_create_an_html_document_fragment
+          # https://github.com/sparklemotion/nokogiri/issues/1846
+          original = Nokogiri::HTML::DocumentFragment.parse("<div><p>hello</p></div>")
+          duplicate = original.dup
+          assert_instance_of(Nokogiri::HTML::DocumentFragment, duplicate)
+        end
+
+        describe "subclassing" do
+          let(:klass) do
+            Class.new(Nokogiri::HTML::DocumentFragment) do
+              attr_accessor :initialized_with, :initialized_count
+
+              def initialize(*args)
+                super
+                @initialized_with = args
+                @initialized_count ||= 0
+                @initialized_count += 1
+              end
+            end
+          end
+
+          describe ".new" do
+            it "returns an instance of the right class" do
+              fragment = klass.new(html, "<div>a</div>")
+              assert_instance_of(klass, fragment)
+            end
+
+            it "calls #initialize exactly once" do
+              fragment = klass.new(html, "<div>a</div>")
+              assert_equal(1, fragment.initialized_count)
+            end
+
+            it "passes args to #initialize" do
+              fragment = klass.new(html, "<div>a</div>")
+              assert_equal([html, "<div>a</div>"], fragment.initialized_with)
+            end
+          end
+
+          it "#dup returns the expected class" do
+            doc = klass.new(html, "<div>a</div>").dup
+            assert_instance_of(klass, doc)
+          end
+
+          describe ".parse" do
+            it "returns an instance of the right class" do
+              fragment = klass.parse("<div>a</div>")
+              assert_instance_of(klass, fragment)
+            end
+
+            it "calls #initialize exactly once" do
+              fragment = klass.parse("<div>a</div>")
+              assert_equal(1, fragment.initialized_count)
+            end
+
+            it "passes the fragment" do
+              fragment = klass.parse("<div>a</div>")
+              assert_equal(Nokogiri::HTML::DocumentFragment.parse("<div>a</div>").to_s, fragment.to_s)
+            end
+          end
+        end
       end
     end
   end

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 require "uri"
@@ -5,758 +6,727 @@ require "uri"
 module Nokogiri
   module XML
     class TestDocument < Nokogiri::TestCase
-      URI = if URI.const_defined?(:DEFAULT_PARSER)
-              ::URI::DEFAULT_PARSER
-            else
-              ::URI
+      describe Nokogiri::XML::Document do
+        URI = if URI.const_defined?(:DEFAULT_PARSER)
+          ::URI::DEFAULT_PARSER
+        else
+          ::URI
+        end
+
+        let(:xml) { Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) }
+
+        def test_dtd_with_empty_internal_subset
+          doc = Nokogiri::XML(<<~eoxml)
+            <?xml version="1.0"?>
+            <!DOCTYPE people >
+            <people>
+            </people>
+          eoxml
+          assert(doc.root)
+        end
+
+        # issue #1005
+        def test_strict_parsing_empty_doc_should_raise_exception
+          ["", " "].each do |empty_string|
+            assert_raises(SyntaxError, "empty string '#{empty_string}' should raise a SyntaxError") do
+              Nokogiri::XML(empty_string) { |c| c.strict }
+            end
+            assert_raises(SyntaxError, "StringIO of '#{empty_string}' should raise a SyntaxError") do
+              Nokogiri::XML(StringIO.new(empty_string)) { |c| c.strict }
+            end
+          end
+        end
+
+        # issue #838
+        def test_document_with_invalid_prolog
+          doc = Nokogiri::XML("<? ?>")
+          assert_empty(doc.content)
+        end
+
+        # issue #837
+        def test_document_with_refentity
+          doc = Nokogiri::XML("&amp;")
+          assert_equal("", doc.content)
+        end
+
+        # issue 1060
+        def test_node_ownership_after_dup
+          html = "<html><head></head><body><div>replace me</div></body></html>"
+          doc = Nokogiri::XML::Document.parse(html)
+          dup = doc.dup
+          assert_same(dup, dup.at_css("div").document)
+
+          # should not raise an exception
+          dup.at_css("div").parse("<div>replaced</div>")
+        end
+
+        # issue #835
+        def test_manually_adding_reference_entities
+          d = Nokogiri::XML::Document.new
+          root = Nokogiri::XML::Element.new("bar", d)
+          txt = Nokogiri::XML::Text.new("foo", d)
+          ent = Nokogiri::XML::EntityReference.new(d, "#8217")
+          root << txt
+          root << ent
+          d << root
+          assert_match(/&#8217;/, d.to_html)
+        end
+
+        def test_document_with_initial_space
+          doc = Nokogiri::XML(" <?xml version='1.0' encoding='utf-8' ?><first \>")
+          assert_equal(2, doc.children.size)
+        end
+
+        def test_root_set_to_nil
+          xml.root = nil
+          assert_nil(xml.root)
+        end
+
+        def test_million_laugh_attach
+          doc = Nokogiri::XML(<<~EOF)
+            <?xml version="1.0"?>
+            <!DOCTYPE lolz [
+            <!ENTITY lol "lol">
+            <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+            <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+            <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+            <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+            <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+            <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+            <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+            <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+            ]>
+            <lolz>&lol9;</lolz>
+          EOF
+          assert_not_nil(doc)
+        end
+
+        def test_million_laugh_attach_2
+          doc = Nokogiri::XML(<<~EOF)
+            <?xml version="1.0" encoding="UTF-8"?>
+             <!DOCTYPE member [
+               <!ENTITY a "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+               <!ENTITY b "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+               <!ENTITY c "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">
+               <!ENTITY d "&e;&e;&e;&e;&e;&e;&e;&e;&e;&e;">
+               <!ENTITY e "&f;&f;&f;&f;&f;&f;&f;&f;&f;&f;">
+               <!ENTITY f "&g;&g;&g;&g;&g;&g;&g;&g;&g;&g;">
+               <!ENTITY g "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+             ]>
+             <member>
+             &a;
+             </member>
+          EOF
+          assert_not_nil(doc)
+        end
+
+        def test_ignore_unknown_namespace
+          doc = Nokogiri::XML(<<~eoxml)
+            <xml>
+              <unknown:foo xmlns='http://hello.com/' />
+              <bar />
+            </xml>
+          eoxml
+          if Nokogiri.jruby?
+            refute(doc.xpath("//foo").first.namespace) # assert that the namespace is nil
+          end
+          refute_empty(doc.xpath("//bar"), "bar wasn't found in the document") # bar should be part of the doc
+        end
+
+        def test_collect_namespaces
+          doc = Nokogiri::XML(<<~eoxml)
+            <xml>
+              <foo xmlns='hello'>
+                <bar xmlns:foo='world' />
+              </foo>
+            </xml>
+          eoxml
+          assert_equal({ "xmlns" => "hello", "xmlns:foo" => "world" },
+                       doc.collect_namespaces)
+        end
+
+        def test_subclass_initialize_modify # testing a segv
+          Class.new(Nokogiri::XML::Document) do
+            def initialize
+              super
+              body_node = Nokogiri::XML::Node.new("body", self)
+              body_node.content = "stuff"
+              self.root = body_node
+            end
+          end.new
+        end
+
+        def test_create_text_node
+          txt = xml.create_text_node("foo")
+          assert_instance_of(Nokogiri::XML::Text, txt)
+          assert_equal("foo", txt.text)
+          assert_equal(xml, txt.document)
+        end
+
+        def test_create_text_node_with_block
+          xml.create_text_node("foo") do |txt|
+            assert_instance_of(Nokogiri::XML::Text, txt)
+            assert_equal("foo", txt.text)
+            assert_equal(xml, txt.document)
+          end
+        end
+
+        def test_create_element
+          elm = xml.create_element("foo")
+          assert_instance_of(Nokogiri::XML::Element, elm)
+          assert_equal("foo", elm.name)
+          assert_equal(xml, elm.document)
+        end
+
+        def test_create_element_with_block
+          xml.create_element("foo") do |elm|
+            assert_instance_of(Nokogiri::XML::Element, elm)
+            assert_equal("foo", elm.name)
+            assert_equal(xml, elm.document)
+          end
+        end
+
+        def test_create_element_with_attributes
+          elm = xml.create_element("foo", a: "1")
+          assert_instance_of(Nokogiri::XML::Element, elm)
+          assert_instance_of(Nokogiri::XML::Attr, elm.attributes["a"])
+          assert_equal("1", elm["a"])
+        end
+
+        def test_create_element_with_namespace
+          elm = xml.create_element("foo", 'xmlns:foo': "http://tenderlovemaking.com")
+          assert_equal("http://tenderlovemaking.com", elm.namespaces["xmlns:foo"])
+        end
+
+        def test_create_element_with_hyphenated_namespace
+          elm = xml.create_element("foo", 'xmlns:SOAP-ENC': "http://tenderlovemaking.com")
+          assert_equal("http://tenderlovemaking.com", elm.namespaces["xmlns:SOAP-ENC"])
+        end
+
+        def test_create_element_with_content
+          elm = xml.create_element("foo", "needs more xml/violence")
+          assert_equal("needs more xml/violence", elm.content)
+        end
+
+        def test_create_cdata
+          cdata = xml.create_cdata("abc")
+          assert_instance_of(Nokogiri::XML::CDATA, cdata)
+          assert_equal("abc", cdata.content)
+        end
+
+        def test_create_cdata_with_block
+          xml.create_cdata("abc") do |cdata|
+            assert_instance_of(Nokogiri::XML::CDATA, cdata)
+            assert_equal("abc", cdata.content)
+          end
+        end
+
+        def test_create_comment
+          comment = xml.create_comment("abc")
+          assert_instance_of(Nokogiri::XML::Comment, comment)
+          assert_equal("abc", comment.content)
+        end
+
+        def test_create_comment_with_block
+          xml.create_comment("abc") do |comment|
+            assert_instance_of(Nokogiri::XML::Comment, comment)
+            assert_equal("abc", comment.content)
+          end
+        end
+
+        def test_pp
+          out = StringIO.new(String.new)
+          ::PP.pp(xml, out)
+          assert_operator(out.string.length, :>, 0)
+        end
+
+        def test_create_internal_subset_on_existing_subset
+          assert_not_nil(xml.internal_subset)
+          assert_raises(RuntimeError) do
+            xml.create_internal_subset("staff", nil, "staff.dtd")
+          end
+        end
+
+        def test_create_internal_subset
+          xml = Nokogiri::XML("<root />")
+          assert_nil(xml.internal_subset)
+
+          xml.create_internal_subset("name", nil, "staff.dtd")
+          ss = xml.internal_subset
+          assert_equal("name", ss.name)
+          assert_nil(ss.external_id)
+          assert_equal("staff.dtd", ss.system_id)
+        end
+
+        def test_external_subset
+          assert_nil(xml.external_subset)
+          xml = Dir.chdir(ASSETS_DIR) do
+            Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) do |cfg|
+              cfg.dtdload
+            end
+          end
+          assert(xml.external_subset)
+        end
+
+        def test_create_external_subset_fails_with_existing_subset
+          assert_nil(xml.external_subset)
+          xml = Dir.chdir(ASSETS_DIR) do
+            Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) do |cfg|
+              cfg.dtdload
+            end
+          end
+          assert(xml.external_subset)
+
+          assert_raises(RuntimeError) do
+            xml.create_external_subset("staff", nil, "staff.dtd")
+          end
+        end
+
+        def test_create_external_subset
+          dtd = xml.create_external_subset("staff", nil, "staff.dtd")
+          assert_nil(dtd.external_id)
+          assert_equal("staff.dtd", dtd.system_id)
+          assert_equal("staff", dtd.name)
+          assert_equal(dtd, xml.external_subset)
+        end
+
+        def test_version
+          assert_equal("1.0", xml.version)
+        end
+
+        def test_add_namespace
+          assert_raise(NoMethodError) do
+            xml.add_namespace("foo", "bar")
+          end
+        end
+
+        def test_attributes
+          assert_raise(NoMethodError) do
+            xml.attributes
+          end
+        end
+
+        def test_namespace
+          assert_raise(NoMethodError) do
+            xml.namespace
+          end
+        end
+
+        def test_namespace_definitions
+          assert_raise(NoMethodError) do
+            xml.namespace_definitions
+          end
+        end
+
+        def test_line
+          assert_raise(NoMethodError) do
+            xml.line
+          end
+        end
+
+        def test_empty_node_converted_to_html_is_not_self_closing
+          doc = Nokogiri::XML("<a></a>")
+          assert_equal("<a></a>", doc.inner_html)
+        end
+
+        def test_fragment
+          fragment = xml.fragment
+          assert_equal(0, fragment.children.length)
+        end
+
+        def test_add_child_fragment_with_single_node
+          doc = Nokogiri::XML::Document.new
+          fragment = doc.fragment("<hello />")
+          doc.add_child(fragment)
+          assert_equal("/hello", doc.at("//hello").path)
+          assert_equal("hello", doc.root.name)
+        end
+
+        def test_add_child_fragment_with_multiple_nodes
+          doc = Nokogiri::XML::Document.new
+          fragment = doc.fragment("<hello /><goodbye />")
+          assert_raises(RuntimeError) do
+            doc.add_child(fragment)
+          end
+        end
+
+        def test_add_child_with_multiple_roots
+          assert_raises(RuntimeError) do
+            xml << Node.new("foo", xml)
+          end
+        end
+
+        def test_add_child_with_string
+          doc = Nokogiri::XML::Document.new
+          doc.add_child("<div>quack!</div>")
+          assert_equal(1, doc.root.children.length)
+          assert_equal("quack!", doc.root.children.first.content)
+        end
+
+        def test_prepend
+          doc = Nokogiri::XML("<root>")
+
+          node_set = doc.root.prepend_child("<branch/>")
+          assert_equal(%w[branch], node_set.map(&:name))
+
+          branch = doc.at("//branch")
+
+          leaves = %w[leaf1 leaf2 leaf3]
+          leaves.each do |name|
+            branch.prepend_child("<%s/>" % name)
+          end
+          assert_equal(leaves.length, branch.children.length)
+          assert_equal(leaves.reverse, branch.children.map(&:name))
+        end
+
+        def test_prepend_child_fragment_with_single_node
+          doc = Nokogiri::XML::Document.new
+          fragment = doc.fragment("<hello />")
+          doc.prepend_child(fragment)
+          assert_equal("/hello", doc.at("//hello").path)
+          assert_equal("hello", doc.root.name)
+        end
+
+        def test_prepend_child_fragment_with_multiple_nodes
+          doc = Nokogiri::XML::Document.new
+          fragment = doc.fragment("<hello /><goodbye />")
+          assert_raises(RuntimeError) do
+            doc.prepend_child(fragment)
+          end
+        end
+
+        def test_prepend_child_with_multiple_roots
+          assert_raises(RuntimeError) do
+            xml.prepend_child(Node.new("foo", xml))
+          end
+        end
+
+        def test_prepend_child_with_string
+          doc = Nokogiri::XML::Document.new
+          doc.prepend_child("<div>quack!</div>")
+          assert_equal(1, doc.root.children.length)
+          assert_equal("quack!", doc.root.children.first.content)
+        end
+
+        def test_move_root_to_document_with_no_root
+          sender = Nokogiri::XML("<root>foo</root>")
+          newdoc = Nokogiri::XML::Document.new
+          newdoc.root = sender.root
+        end
+
+        def test_move_root_with_existing_root_gets_gcd
+          doc = Nokogiri::XML("<root>test</root>")
+          doc2 = Nokogiri::XML("<root>#{'x' * 5000000}</root>")
+          doc2.root = doc.root
+        end
+
+        def test_validate
+          if Nokogiri.uses_libxml?
+            assert_equal(45, xml.validate.length)
+          else
+            xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) { |cfg| cfg.dtdvalid }
+            assert_equal(40, xml.validate.length)
+          end
+        end
+
+        def test_validate_no_internal_subset
+          doc = Nokogiri::XML("<test/>")
+          assert_nil(doc.validate)
+        end
+
+        def test_clone
+          assert(xml.clone)
+        end
+
+        def test_document_should_not_have_default_ns
+          doc = Nokogiri::XML::Document.new
+
+          assert_raises(NoMethodError) do
+            doc.default_namespace = "http://innernet.com/"
+          end
+
+          assert_raises(NoMethodError) do
+            doc.add_namespace_definition("foo", "bar")
+          end
+        end
+
+        def test_parse_handles_nil_gracefully
+          @doc = Nokogiri::XML::Document.parse(nil)
+          assert_instance_of(Nokogiri::XML::Document, @doc)
+        end
+
+        def test_parse_takes_block
+          options = nil
+          Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) do |cfg|
+            options = cfg
+          end
+          assert(options)
+        end
+
+        def test_parse_yields_parse_options
+          options = nil
+          Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) do |cfg|
+            options = cfg
+            options.nonet.nowarning.dtdattr
+          end
+          assert(options.nonet?)
+          assert(options.nowarning?)
+          assert(options.dtdattr?)
+        end
+
+        def test_XML_takes_block
+          options = nil
+          Nokogiri::XML(File.read(XML_FILE), XML_FILE) do |cfg|
+            options = cfg
+            options.nonet.nowarning.dtdattr
+          end
+          assert(options.nonet?)
+          assert(options.nowarning?)
+          assert(options.dtdattr?)
+        end
+
+        def test_document_parse_method
+          xml = Nokogiri::XML::Document.parse(File.read(XML_FILE))
+          # lame hack uses root to avoid comparing DOCTYPE tags which can appear out of order.
+          # I should really finish lorax and use that here.
+          assert_equal(xml.root.to_s, xml.root.to_s)
+        end
+
+        def test_encoding=
+          xml.encoding = "UTF-8"
+          assert_match("UTF-8", xml.to_xml)
+
+          xml.encoding = "EUC-JP"
+          assert_match("EUC-JP", xml.to_xml)
+        end
+
+        def test_namespace_should_not_exist
+          assert_raises(NoMethodError) do
+            xml.namespace
+          end
+        end
+
+        def test_non_existant_function
+          # WTF.  I don't know why this is different between MRI and Jruby
+          # They should be the same...  Either way, raising an exception
+          # is the correct thing to do.
+          exception = RuntimeError
+
+          if !Nokogiri.uses_libxml? || (Nokogiri.uses_libxml? && Nokogiri::VERSION_INFO["libxml"]["platform"] == "jruby")
+            exception = Nokogiri::XML::XPath::SyntaxError
+          end
+
+          assert_raises(exception) do
+            xml.xpath("//name[foo()]")
+          end
+        end
+
+        def test_xpath_syntax_error
+          assert_raises(Nokogiri::XML::XPath::SyntaxError) do
+            xml.xpath('\\')
+          end
+        end
+
+        def test_ancestors
+          assert_equal(0, xml.ancestors.length)
+        end
+
+        def test_root_node_parent_is_document
+          parent = xml.root.parent
+          assert_equal(xml, parent)
+          assert_instance_of(Nokogiri::XML::Document, parent)
+        end
+
+        def test_xmlns_is_automatically_registered
+          doc = Nokogiri::XML(<<~eoxml)
+            <root xmlns="http://tenderlovemaking.com/">
+              <foo>
+                bar
+              </foo>
+            </root>
+          eoxml
+          assert_equal(1, doc.css("xmlns|foo").length)
+          assert_equal(1, doc.css("foo").length)
+          assert_equal(0, doc.css("|foo").length)
+          assert_equal(1, doc.xpath("//xmlns:foo").length)
+          assert_equal(1, doc.search("xmlns|foo").length)
+          assert_equal(1, doc.search("//xmlns:foo").length)
+          assert(doc.at("xmlns|foo"))
+          assert(doc.at("//xmlns:foo"))
+          assert(doc.at("foo"))
+        end
+
+        def test_xmlns_is_registered_for_nodesets
+          doc = Nokogiri::XML(<<~eoxml)
+            <root xmlns="http://tenderlovemaking.com/">
+              <foo>
+                <bar>
+                  baz
+                </bar>
+              </foo>
+            </root>
+          eoxml
+          assert_equal(1, doc.css("xmlns|foo").css("xmlns|bar").length)
+          assert_equal(1, doc.css("foo").css("bar").length)
+          assert_equal(1, doc.xpath("//xmlns:foo").xpath("./xmlns:bar").length)
+          assert_equal(1, doc.search("xmlns|foo").search("xmlns|bar").length)
+          assert_equal(1, doc.search("//xmlns:foo").search("./xmlns:bar").length)
+        end
+
+        def test_to_xml_with_indent
+          doc = Nokogiri::XML("<root><foo><bar/></foo></root>")
+          doc = Nokogiri::XML(doc.to_xml(indent: 5))
+
+          assert_indent(5, doc)
+        end
+
+        def test_write_xml_to_with_indent
+          io = StringIO.new
+          doc = Nokogiri::XML("<root><foo><bar/></foo></root>")
+          doc.write_xml_to(io, indent: 5)
+          io.rewind
+          doc = Nokogiri::XML(io.read)
+          assert_indent(5, doc)
+        end
+
+        unless Nokogiri.uses_libxml?("~> 2.6.0")
+          def test_encoding
+            xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE, "UTF-8")
+            assert_equal("UTF-8", xml.encoding)
+          end
+        end
+
+        def test_memory_explosion_on_invalid_xml
+          doc = Nokogiri::XML("<<<")
+          refute_nil(doc)
+          refute_empty(doc.errors)
+        end
+
+        def test_memory_explosion_on_wrong_formatted_element_following_the_root_element
+          doc = Nokogiri::XML("<a/><\n")
+          refute_nil(doc)
+          refute_empty(doc.errors)
+        end
+
+        def test_document_has_errors
+          doc = Nokogiri::XML(<<~eoxml)
+            <foo><bar></foo>
+          eoxml
+          assert(doc.errors.length > 0)
+          doc.errors.each do |error|
+            assert_match(error.message, error.inspect)
+            assert_match(error.message, error.to_s)
+          end
+        end
+
+        def test_strict_document_throws_syntax_error
+          assert_raises(Nokogiri::XML::SyntaxError) do
+            Nokogiri::XML("<foo><bar></foo>", nil, nil, 0)
+          end
+
+          assert_raises(Nokogiri::XML::SyntaxError) do
+            Nokogiri::XML("<foo><bar></foo>") do |cfg|
+              cfg.strict
+            end
+          end
+
+          assert_raises(Nokogiri::XML::SyntaxError) do
+            Nokogiri::XML(StringIO.new("<foo><bar></foo>")) do |cfg|
+              cfg.strict
+            end
+          end
+        end
+
+        def test_XML_function
+          xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE)
+          assert(xml.xml?)
+        end
+
+        def test_url
+          assert(xml.url)
+          assert_equal(XML_FILE, xml.url)
+        end
+
+        def test_document_parent
+          xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE)
+          assert_raises(NoMethodError) do
+            xml.parent
+          end
+        end
+
+        def test_document_name
+          xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE)
+          assert_equal("document", xml.name)
+        end
+
+        def test_parse_can_take_io
+          xml = nil
+          File.open(XML_FILE, "rb") do |f|
+            xml = Nokogiri::XML(f)
+          end
+          assert(xml.xml?)
+          assert_equal(XML_FILE, xml.url)
+          set = xml.search("//employee")
+          assert(set.length > 0)
+        end
+
+        def test_parsing_empty_io
+          doc = Nokogiri::XML.parse(StringIO.new(""))
+          refute_nil(doc)
+        end
+
+        def test_parse_works_with_an_object_that_responds_to_read
+          klass = Class.new do
+            def initialize
+              @contents = StringIO.new("<div>foo</div>")
             end
 
-      def setup
-        super
-        @xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE)
-      end
-
-      def test_dtd_with_empty_internal_subset
-        doc = Nokogiri::XML <<-eoxml
-<?xml version="1.0"?>
-<!DOCTYPE people >
-<people>
-</people>
-        eoxml
-        assert doc.root
-      end
-
-      # issue #1005
-      def test_strict_parsing_empty_doc_should_raise_exception
-        ["", " "].each do |empty_string|
-          assert_raises(SyntaxError, "empty string '#{empty_string}' should raise a SyntaxError") do
-            Nokogiri::XML(empty_string) { |c| c.strict }
-          end
-          assert_raises(SyntaxError, "StringIO of '#{empty_string}' should raise a SyntaxError") do
-            Nokogiri::XML(StringIO.new(empty_string)) { |c| c.strict }
-          end
-        end
-      end
-
-      # issue #838
-      def test_document_with_invalid_prolog
-        doc = Nokogiri::XML "<? ?>"
-        assert_empty doc.content
-      end
-
-      # issue #837
-      def test_document_with_refentity
-        doc = Nokogiri::XML "&amp;"
-        assert_equal "", doc.content
-      end
-
-      # issue 1060
-      def test_node_ownership_after_dup
-        html = "<html><head></head><body><div>replace me</div></body></html>"
-        doc = Nokogiri::XML::Document.parse(html)
-        dup = doc.dup
-        assert_same dup, dup.at_css("div").document
-
-        # should not raise an exception
-        dup.at_css("div").parse("<div>replaced</div>")
-      end
-
-      # issue #835
-      def test_manually_adding_reference_entities
-        d = Nokogiri::XML::Document.new
-        root = Nokogiri::XML::Element.new("bar", d)
-        txt = Nokogiri::XML::Text.new("foo", d)
-        ent = Nokogiri::XML::EntityReference.new(d, "#8217")
-        root << txt
-        root << ent
-        d << root
-        assert_match(/&#8217;/, d.to_html)
-      end
-
-      def test_document_with_initial_space
-        doc = Nokogiri::XML(" <?xml version='1.0' encoding='utf-8' ?><first \>")
-        assert_equal 2, doc.children.size
-      end
-
-      def test_root_set_to_nil
-        @xml.root = nil
-        assert_nil @xml.root
-      end
-
-      def test_million_laugh_attach
-        doc = Nokogiri::XML '<?xml version="1.0"?>
-<!DOCTYPE lolz [
-<!ENTITY lol "lol">
-<!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
-<!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
-<!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
-<!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
-<!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
-<!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
-<!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
-<!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
-]>
-<lolz>&lol9;</lolz>'
-        assert_not_nil doc
-      end
-
-      def test_million_laugh_attach_2
-        doc = Nokogiri::XML '<?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE member [
-   <!ENTITY a "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
-   <!ENTITY b "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
-   <!ENTITY c "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">
-   <!ENTITY d "&e;&e;&e;&e;&e;&e;&e;&e;&e;&e;">
-   <!ENTITY e "&f;&f;&f;&f;&f;&f;&f;&f;&f;&f;">
-   <!ENTITY f "&g;&g;&g;&g;&g;&g;&g;&g;&g;&g;">
-   <!ENTITY g "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
- ]>
- <member>
- &a;
- </member>'
-        assert_not_nil doc
-      end
-
-      def test_ignore_unknown_namespace
-        doc = Nokogiri::XML(<<-eoxml)
-        <xml>
-          <unknown:foo xmlns='http://hello.com/' />
-          <bar />
-        </xml>
-        eoxml
-        if Nokogiri.jruby?
-          refute doc.xpath("//foo").first.namespace # assert that the namespace is nil
-        end
-        refute_empty doc.xpath("//bar"), "bar wasn't found in the document" # bar should be part of the doc
-      end
-
-      def test_collect_namespaces
-        doc = Nokogiri::XML(<<-eoxml)
-        <xml>
-          <foo xmlns='hello'>
-            <bar xmlns:foo='world' />
-          </foo>
-        </xml>
-        eoxml
-        assert_equal({ "xmlns" => "hello", "xmlns:foo" => "world" },
-                     doc.collect_namespaces)
-      end
-
-      def test_subclass_initialize_modify # testing a segv
-        Class.new(Nokogiri::XML::Document) {
-          def initialize
-            super
-            body_node = Nokogiri::XML::Node.new "body", self
-            body_node.content = "stuff"
-            self.root = body_node
-          end
-        }.new
-      end
-
-      def test_create_text_node
-        txt = @xml.create_text_node "foo"
-        assert_instance_of Nokogiri::XML::Text, txt
-        assert_equal "foo", txt.text
-        assert_equal @xml, txt.document
-      end
-
-      def test_create_text_node_with_block
-        @xml.create_text_node "foo" do |txt|
-          assert_instance_of Nokogiri::XML::Text, txt
-          assert_equal "foo", txt.text
-          assert_equal @xml, txt.document
-        end
-      end
-
-      def test_create_element
-        elm = @xml.create_element("foo")
-        assert_instance_of Nokogiri::XML::Element, elm
-        assert_equal "foo", elm.name
-        assert_equal @xml, elm.document
-      end
-
-      def test_create_element_with_block
-        @xml.create_element("foo") do |elm|
-          assert_instance_of Nokogiri::XML::Element, elm
-          assert_equal "foo", elm.name
-          assert_equal @xml, elm.document
-        end
-      end
-
-      def test_create_element_with_attributes
-        elm = @xml.create_element("foo", :a => "1")
-        assert_instance_of Nokogiri::XML::Element, elm
-        assert_instance_of Nokogiri::XML::Attr, elm.attributes["a"]
-        assert_equal "1", elm["a"]
-      end
-
-      def test_create_element_with_namespace
-        elm = @xml.create_element("foo", :'xmlns:foo' => "http://tenderlovemaking.com")
-        assert_equal "http://tenderlovemaking.com", elm.namespaces["xmlns:foo"]
-      end
-
-      def test_create_element_with_hyphenated_namespace
-        elm = @xml.create_element("foo", :'xmlns:SOAP-ENC' => "http://tenderlovemaking.com")
-        assert_equal "http://tenderlovemaking.com", elm.namespaces["xmlns:SOAP-ENC"]
-      end
-
-      def test_create_element_with_content
-        elm = @xml.create_element("foo", "needs more xml/violence")
-        assert_equal "needs more xml/violence", elm.content
-      end
-
-      def test_create_cdata
-        cdata = @xml.create_cdata("abc")
-        assert_instance_of Nokogiri::XML::CDATA, cdata
-        assert_equal "abc", cdata.content
-      end
-
-      def test_create_cdata_with_block
-        @xml.create_cdata("abc") do |cdata|
-          assert_instance_of Nokogiri::XML::CDATA, cdata
-          assert_equal "abc", cdata.content
-        end
-      end
-
-      def test_create_comment
-        comment = @xml.create_comment("abc")
-        assert_instance_of Nokogiri::XML::Comment, comment
-        assert_equal "abc", comment.content
-      end
-
-      def test_create_comment_with_block
-        @xml.create_comment("abc") do |comment|
-          assert_instance_of Nokogiri::XML::Comment, comment
-          assert_equal "abc", comment.content
-        end
-      end
-
-      def test_pp
-        out = StringIO.new(String.new)
-        ::PP.pp @xml, out
-        assert_operator out.string.length, :>, 0
-      end
-
-      def test_create_internal_subset_on_existing_subset
-        assert_not_nil @xml.internal_subset
-        assert_raises(RuntimeError) do
-          @xml.create_internal_subset("staff", nil, "staff.dtd")
-        end
-      end
-
-      def test_create_internal_subset
-        xml = Nokogiri::XML("<root />")
-        assert_nil xml.internal_subset
-
-        xml.create_internal_subset("name", nil, "staff.dtd")
-        ss = xml.internal_subset
-        assert_equal "name", ss.name
-        assert_nil ss.external_id
-        assert_equal "staff.dtd", ss.system_id
-      end
-
-      def test_external_subset
-        assert_nil @xml.external_subset
-        Dir.chdir(ASSETS_DIR) do
-          @xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) { |cfg|
-            cfg.dtdload
-          }
-        end
-        assert @xml.external_subset
-      end
-
-      def test_create_external_subset_fails_with_existing_subset
-        assert_nil @xml.external_subset
-        Dir.chdir(ASSETS_DIR) do
-          @xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) { |cfg|
-            cfg.dtdload
-          }
-        end
-        assert @xml.external_subset
-
-        assert_raises(RuntimeError) do
-          @xml.create_external_subset("staff", nil, "staff.dtd")
-        end
-      end
-
-      def test_create_external_subset
-        dtd = @xml.create_external_subset("staff", nil, "staff.dtd")
-        assert_nil dtd.external_id
-        assert_equal "staff.dtd", dtd.system_id
-        assert_equal "staff", dtd.name
-        assert_equal dtd, @xml.external_subset
-      end
-
-      def test_version
-        assert_equal "1.0", @xml.version
-      end
-
-      def test_add_namespace
-        assert_raise NoMethodError do
-          @xml.add_namespace("foo", "bar")
-        end
-      end
-
-      def test_attributes
-        assert_raise NoMethodError do
-          @xml.attributes
-        end
-      end
-
-      def test_namespace
-        assert_raise NoMethodError do
-          @xml.namespace
-        end
-      end
-
-      def test_namespace_definitions
-        assert_raise NoMethodError do
-          @xml.namespace_definitions
-        end
-      end
-
-      def test_line
-        assert_raise NoMethodError do
-          @xml.line
-        end
-      end
-
-      def test_empty_node_converted_to_html_is_not_self_closing
-        doc = Nokogiri::XML("<a></a>")
-        assert_equal "<a></a>", doc.inner_html
-      end
-
-      def test_fragment
-        fragment = @xml.fragment
-        assert_equal 0, fragment.children.length
-      end
-
-      def test_add_child_fragment_with_single_node
-        doc = Nokogiri::XML::Document.new
-        fragment = doc.fragment("<hello />")
-        doc.add_child fragment
-        assert_equal "/hello", doc.at("//hello").path
-        assert_equal "hello", doc.root.name
-      end
-
-      def test_add_child_fragment_with_multiple_nodes
-        doc = Nokogiri::XML::Document.new
-        fragment = doc.fragment("<hello /><goodbye />")
-        assert_raises(RuntimeError) do
-          doc.add_child fragment
-        end
-      end
-
-      def test_add_child_with_multiple_roots
-        assert_raises(RuntimeError) do
-          @xml << Node.new("foo", @xml)
-        end
-      end
-
-      def test_add_child_with_string
-        doc = Nokogiri::XML::Document.new
-        doc.add_child "<div>quack!</div>"
-        assert_equal 1, doc.root.children.length
-        assert_equal "quack!", doc.root.children.first.content
-      end
-
-      def test_prepend
-        doc = Nokogiri::XML("<root>")
-
-        node_set = doc.root.prepend_child "<branch/>"
-        assert_equal %w[branch], node_set.map(&:name)
-
-        branch = doc.at("//branch")
-
-        leaves = %w[leaf1 leaf2 leaf3]
-        leaves.each { |name|
-          branch.prepend_child("<%s/>" % name)
-        }
-        assert_equal leaves.length, branch.children.length
-        assert_equal leaves.reverse, branch.children.map(&:name)
-      end
-
-      def test_prepend_child_fragment_with_single_node
-        doc = Nokogiri::XML::Document.new
-        fragment = doc.fragment("<hello />")
-        doc.prepend_child fragment
-        assert_equal "/hello", doc.at("//hello").path
-        assert_equal "hello", doc.root.name
-      end
-
-      def test_prepend_child_fragment_with_multiple_nodes
-        doc = Nokogiri::XML::Document.new
-        fragment = doc.fragment("<hello /><goodbye />")
-        assert_raises(RuntimeError) do
-          doc.prepend_child fragment
-        end
-      end
-
-      def test_prepend_child_with_multiple_roots
-        assert_raises(RuntimeError) do
-          @xml.prepend_child Node.new("foo", @xml)
-        end
-      end
-
-      def test_prepend_child_with_string
-        doc = Nokogiri::XML::Document.new
-        doc.prepend_child "<div>quack!</div>"
-        assert_equal 1, doc.root.children.length
-        assert_equal "quack!", doc.root.children.first.content
-      end
-
-      def test_move_root_to_document_with_no_root
-        sender = Nokogiri::XML("<root>foo</root>")
-        newdoc = Nokogiri::XML::Document.new
-        newdoc.root = sender.root
-      end
-
-      def test_move_root_with_existing_root_gets_gcd
-        doc = Nokogiri::XML("<root>test</root>")
-        doc2 = Nokogiri::XML("<root>#{"x" * 5000000}</root>")
-        doc2.root = doc.root
-      end
-
-      def test_validate
-        if Nokogiri.uses_libxml?
-          assert_equal 45, @xml.validate.length
-        else
-          xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) { |cfg| cfg.dtdvalid }
-          assert_equal 40, xml.validate.length
-        end
-      end
-
-      def test_validate_no_internal_subset
-        doc = Nokogiri::XML("<test/>")
-        assert_nil doc.validate
-      end
-
-      def test_clone
-        assert @xml.clone
-      end
-
-      def test_document_should_not_have_default_ns
-        doc = Nokogiri::XML::Document.new
-
-        assert_raises NoMethodError do
-          doc.default_namespace = "http://innernet.com/"
-        end
-
-        assert_raises NoMethodError do
-          doc.add_namespace_definition("foo", "bar")
-        end
-      end
-
-      def test_parse_handles_nil_gracefully
-        @doc = Nokogiri::XML::Document.parse(nil)
-        assert_instance_of Nokogiri::XML::Document, @doc
-      end
-
-      def test_parse_takes_block
-        options = nil
-        Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) do |cfg|
-          options = cfg
-        end
-        assert options
-      end
-
-      def test_parse_yields_parse_options
-        options = nil
-        Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) do |cfg|
-          options = cfg
-          options.nonet.nowarning.dtdattr
-        end
-        assert options.nonet?
-        assert options.nowarning?
-        assert options.dtdattr?
-      end
-
-      def test_XML_takes_block
-        options = nil
-        Nokogiri::XML(File.read(XML_FILE), XML_FILE) do |cfg|
-          options = cfg
-          options.nonet.nowarning.dtdattr
-        end
-        assert options.nonet?
-        assert options.nowarning?
-        assert options.dtdattr?
-      end
-
-      def test_subclass
-        klass = Class.new(Nokogiri::XML::Document)
-        doc = klass.new
-        assert_instance_of klass, doc
-      end
-
-      def test_subclass_initialize
-        klass = Class.new(Nokogiri::XML::Document) do
-          attr_accessor :initialized_with
-
-          def initialize(*args)
-            @initialized_with = args
-          end
-        end
-        doc = klass.new("1.0", 1)
-        assert_equal ["1.0", 1], doc.initialized_with
-      end
-
-      def test_subclass_dup
-        klass = Class.new(Nokogiri::XML::Document)
-        doc = klass.new.dup
-        assert_instance_of klass, doc
-      end
-
-      def test_subclass_parse
-        klass = Class.new(Nokogiri::XML::Document)
-        doc = klass.parse(File.read(XML_FILE))
-        # lame hack uses root to avoid comparing DOCTYPE tags which can appear out of order.
-        # I should really finish lorax and use that here.
-        assert_equal @xml.root.to_s, doc.root.to_s
-        assert_instance_of klass, doc
-      end
-
-      def test_document_parse_method
-        xml = Nokogiri::XML::Document.parse(File.read(XML_FILE))
-        # lame hack uses root to avoid comparing DOCTYPE tags which can appear out of order.
-        # I should really finish lorax and use that here.
-        assert_equal @xml.root.to_s, xml.root.to_s
-      end
-
-      def test_encoding=
-        @xml.encoding = "UTF-8"
-        assert_match "UTF-8", @xml.to_xml
-
-        @xml.encoding = "EUC-JP"
-        assert_match "EUC-JP", @xml.to_xml
-      end
-
-      def test_namespace_should_not_exist
-        assert_raises(NoMethodError) {
-          @xml.namespace
-        }
-      end
-
-      def test_non_existant_function
-        # WTF.  I don't know why this is different between MRI and Jruby
-        # They should be the same...  Either way, raising an exception
-        # is the correct thing to do.
-        exception = RuntimeError
-
-        if !Nokogiri.uses_libxml? || (Nokogiri.uses_libxml? && Nokogiri::VERSION_INFO["libxml"]["platform"] == "jruby")
-          exception = Nokogiri::XML::XPath::SyntaxError
-        end
-
-        assert_raises(exception) {
-          @xml.xpath("//name[foo()]")
-        }
-      end
-
-      def test_xpath_syntax_error
-        assert_raises(Nokogiri::XML::XPath::SyntaxError) do
-          @xml.xpath('\\')
-        end
-      end
-
-      def test_ancestors
-        assert_equal 0, @xml.ancestors.length
-      end
-
-      def test_root_node_parent_is_document
-        parent = @xml.root.parent
-        assert_equal @xml, parent
-        assert_instance_of Nokogiri::XML::Document, parent
-      end
-
-      def test_xmlns_is_automatically_registered
-        doc = Nokogiri::XML(<<-eoxml)
-          <root xmlns="http://tenderlovemaking.com/">
-            <foo>
-              bar
-            </foo>
-          </root>
-        eoxml
-        assert_equal 1, doc.css("xmlns|foo").length
-        assert_equal 1, doc.css("foo").length
-        assert_equal 0, doc.css("|foo").length
-        assert_equal 1, doc.xpath("//xmlns:foo").length
-        assert_equal 1, doc.search("xmlns|foo").length
-        assert_equal 1, doc.search("//xmlns:foo").length
-        assert doc.at("xmlns|foo")
-        assert doc.at("//xmlns:foo")
-        assert doc.at("foo")
-      end
-
-      def test_xmlns_is_registered_for_nodesets
-        doc = Nokogiri::XML(<<-eoxml)
-          <root xmlns="http://tenderlovemaking.com/">
-            <foo>
-              <bar>
-                baz
-              </bar>
-            </foo>
-          </root>
-        eoxml
-        assert_equal 1, doc.css("xmlns|foo").css("xmlns|bar").length
-        assert_equal 1, doc.css("foo").css("bar").length
-        assert_equal 1, doc.xpath("//xmlns:foo").xpath("./xmlns:bar").length
-        assert_equal 1, doc.search("xmlns|foo").search("xmlns|bar").length
-        assert_equal 1, doc.search("//xmlns:foo").search("./xmlns:bar").length
-      end
-
-      def test_to_xml_with_indent
-        doc = Nokogiri::XML("<root><foo><bar/></foo></root>")
-        doc = Nokogiri::XML(doc.to_xml(:indent => 5))
-
-        assert_indent 5, doc
-      end
-
-      def test_write_xml_to_with_indent
-        io = StringIO.new
-        doc = Nokogiri::XML("<root><foo><bar/></foo></root>")
-        doc.write_xml_to io, :indent => 5
-        io.rewind
-        doc = Nokogiri::XML(io.read)
-        assert_indent 5, doc
-      end
-
-      if ! Nokogiri.uses_libxml?("~> 2.6.0")
-        def test_encoding
-          xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE, "UTF-8")
-          assert_equal "UTF-8", xml.encoding
-        end
-      end
-
-      def test_memory_explosion_on_invalid_xml
-        doc = Nokogiri::XML("<<<")
-        refute_nil doc
-        refute_empty doc.errors
-      end
-
-      def test_memory_explosion_on_wrong_formatted_element_following_the_root_element
-        doc = Nokogiri::XML("<a/><\n")
-        refute_nil doc
-        refute_empty doc.errors
-      end
-
-      def test_document_has_errors
-        doc = Nokogiri::XML(<<-eoxml)
-          <foo><bar></foo>
-        eoxml
-        assert doc.errors.length > 0
-        doc.errors.each do |error|
-          assert_match error.message, error.inspect
-          assert_match error.message, error.to_s
-        end
-      end
-
-      def test_strict_document_throws_syntax_error
-        assert_raises(Nokogiri::XML::SyntaxError) {
-          Nokogiri::XML("<foo><bar></foo>", nil, nil, 0)
-        }
-
-        assert_raises(Nokogiri::XML::SyntaxError) {
-          Nokogiri::XML("<foo><bar></foo>") { |cfg|
-            cfg.strict
-          }
-        }
-
-        assert_raises(Nokogiri::XML::SyntaxError) {
-          Nokogiri::XML(StringIO.new("<foo><bar></foo>")) { |cfg|
-            cfg.strict
-          }
-        }
-      end
-
-      def test_XML_function
-        xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE)
-        assert xml.xml?
-      end
-
-      def test_url
-        assert @xml.url
-        assert_equal XML_FILE, @xml.url
-      end
-
-      def test_document_parent
-        xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE)
-        assert_raises(NoMethodError) {
-          xml.parent
-        }
-      end
-
-      def test_document_name
-        xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE)
-        assert_equal "document", xml.name
-      end
-
-      def test_parse_can_take_io
-        xml = nil
-        File.open(XML_FILE, "rb") { |f|
-          xml = Nokogiri::XML(f)
-        }
-        assert xml.xml?
-        assert_equal XML_FILE, xml.url
-        set = xml.search("//employee")
-        assert set.length > 0
-      end
-
-      def test_parsing_empty_io
-        doc = Nokogiri::XML.parse(StringIO.new(""))
-        refute_nil doc
-      end
-
-      def test_parse_works_with_an_object_that_responds_to_read
-        klass = Class.new do
-          def initialize
-            @contents = StringIO.new("<div>foo</div>")
+            def read(*args)
+              @contents.read(*args)
+            end
           end
 
-          def read(*args)
-            @contents.read(*args)
+          doc = Nokogiri::XML.parse(klass.new)
+          assert_equal("foo", doc.at_css("div").content)
+        end
+
+        def test_parse_works_with_an_object_that_responds_to_path
+          xml = String.new("<root><sub>hello</sub></root>")
+          def xml.path
+            "/i/should/be/the/document/url"
           end
+
+          doc = Nokogiri::XML.parse(xml)
+
+          assert_equal("/i/should/be/the/document/url", doc.url)
         end
 
-        doc = Nokogiri::XML.parse klass.new
-        assert_equal "foo", doc.at_css("div").content
-      end
+        # issue #1821, #2110
+        def test_parse_can_take_pathnames
+          assert(File.size(XML_ATOM_FILE) > 4096) # file must be big enough to trip the read callback more than once
 
-      def test_parse_works_with_an_object_that_responds_to_path
-        xml = String.new("<root><sub>hello</sub></root>")
-        def xml.path
-          "/i/should/be/the/document/url"
+          doc = Nokogiri::XML.parse(Pathname.new(XML_ATOM_FILE))
+
+          # an arbitrary assertion on the structure of the document
+          assert_equal(20, doc.xpath("/xmlns:feed/xmlns:entry/xmlns:author",
+                                     "xmlns" => "http://www.w3.org/2005/Atom").length)
+          assert_equal(XML_ATOM_FILE, doc.url)
         end
 
-        doc = Nokogiri::XML.parse(xml)
+        def test_search_on_empty_documents
+          doc = Nokogiri::XML::Document.new
+          ns = doc.search("//foo")
+          assert_equal(0, ns.length)
 
-        assert_equal "/i/should/be/the/document/url", doc.url
-      end
+          ns = doc.css("foo")
+          assert_equal(0, ns.length)
 
-      # issue #1821, #2110
-      def test_parse_can_take_pathnames
-        assert(File.size(XML_ATOM_FILE) > 4096) # file must be big enough to trip the read callback more than once
+          ns = doc.xpath("//foo")
+          assert_equal(0, ns.length)
+        end
 
-        doc = Nokogiri::XML.parse(Pathname.new(XML_ATOM_FILE))
-
-        # an arbitrary assertion on the structure of the document
-        assert_equal 20, doc.xpath("/xmlns:feed/xmlns:entry/xmlns:author",
-                                   "xmlns" => "http://www.w3.org/2005/Atom").length
-        assert_equal XML_ATOM_FILE, doc.url
-      end
-
-      def test_search_on_empty_documents
-        doc = Nokogiri::XML::Document.new
-        ns = doc.search("//foo")
-        assert_equal 0, ns.length
-
-        ns = doc.css("foo")
-        assert_equal 0, ns.length
-
-        ns = doc.xpath("//foo")
-        assert_equal 0, ns.length
-      end
-
-      def test_document_search_with_multiple_queries
-        xml = '<document>
+        def test_document_search_with_multiple_queries
+          xml = '<document>
                  <thing>
                    <div class="title">important thing</div>
                  </thing>
@@ -767,305 +737,360 @@ module Nokogiri
                    <p class="blah">more stuff</div>
                  </thing>
                </document>'
-        document = Nokogiri::XML(xml)
-        assert_kind_of Nokogiri::XML::Document, document
+          document = Nokogiri::XML(xml)
+          assert_kind_of(Nokogiri::XML::Document, document)
 
-        assert_equal 3, document.xpath(".//div", ".//p").length
-        assert_equal 3, document.css(".title", ".content", "p").length
-        assert_equal 3, document.search(".//div", "p.blah").length
-      end
-
-      def test_bad_xpath_raises_syntax_error
-        assert_raises(XML::XPath::SyntaxError) {
-          @xml.xpath('\\')
-        }
-      end
-
-      def test_find_with_namespace
-        doc = Nokogiri::XML.parse(<<-eoxml)
-        <x xmlns:tenderlove='http://tenderlovemaking.com/'>
-          <tenderlove:foo awesome='true'>snuggles!</tenderlove:foo>
-        </x>
-        eoxml
-
-        ctx = Nokogiri::XML::XPathContext.new(doc)
-        ctx.register_ns "tenderlove", "http://tenderlovemaking.com/"
-        set = ctx.evaluate("//tenderlove:foo")
-        assert_equal 1, set.length
-        assert_equal "foo", set.first.name
-
-        # It looks like only the URI is important:
-        ctx = Nokogiri::XML::XPathContext.new(doc)
-        ctx.register_ns "america", "http://tenderlovemaking.com/"
-        set = ctx.evaluate("//america:foo")
-        assert_equal 1, set.length
-        assert_equal "foo", set.first.name
-
-        # Its so important that a missing slash will cause it to return nothing
-        ctx = Nokogiri::XML::XPathContext.new(doc)
-        ctx.register_ns "america", "http://tenderlovemaking.com"
-        set = ctx.evaluate("//america:foo")
-        assert_equal 0, set.length
-      end
-
-      def test_xml?
-        assert @xml.xml?
-      end
-
-      def test_document
-        assert @xml.document
-      end
-
-      def test_singleton_methods
-        assert node_set = @xml.search("//name")
-        assert node_set.length > 0
-        node = node_set.first
-        def node.test
-          "test"
-        end
-        assert node_set = @xml.search("//name")
-        assert_equal "test", node_set.first.test
-      end
-
-      def test_multiple_search
-        assert node_set = @xml.search("//employee", "//name")
-        employees = @xml.search("//employee")
-        names = @xml.search("//name")
-        assert_equal(employees.length + names.length, node_set.length)
-      end
-
-      def test_node_set_index
-        assert node_set = @xml.search("//employee")
-
-        assert_equal(5, node_set.length)
-        assert node_set[4]
-        assert_nil node_set[5]
-      end
-
-      def test_search
-        assert node_set = @xml.search("//employee")
-
-        assert_equal(5, node_set.length)
-
-        node_set.each do |node|
-          assert_equal("employee", node.name)
-        end
-      end
-
-      def test_dump
-        assert @xml.serialize
-        assert @xml.to_xml
-      end
-
-      def test_dup
-        dup = @xml.dup
-        assert_instance_of Nokogiri::XML::Document, dup
-        assert dup.xml?, "duplicate should be xml"
-      end
-
-      def test_new
-        doc = nil
-        doc = Nokogiri::XML::Document.new
-        assert doc
-        assert doc.xml?
-        assert_nil doc.root
-      end
-
-      def test_set_root
-        doc = nil
-        doc = Nokogiri::XML::Document.new
-        assert doc
-        assert doc.xml?
-        assert_nil doc.root
-        node = Nokogiri::XML::Node.new("b", doc) { |n|
-          n.content = "hello world"
-        }
-        assert_equal("hello world", node.content)
-        doc.root = node
-        assert_equal(node, doc.root)
-      end
-
-      def test_remove_namespaces
-        doc = Nokogiri::XML <<-EOX
-          <root xmlns:a="http://a.flavorjon.es/" xmlns:b="http://b.flavorjon.es/">
-            <a:foo>hello from a</a:foo>
-            <b:foo>hello from b</b:foo>
-            <container xmlns:c="http://c.flavorjon.es/">
-              <c:foo c:attr='attr-value'>hello from c</c:foo>
-            </container>
-          </root>
-        EOX
-
-        namespaces = doc.root.namespaces
-
-        # assert on setup
-        assert_equal 2, doc.root.namespaces.length
-        assert_equal 3, doc.at_xpath("//container").namespaces.length
-        assert_equal 0, doc.xpath("//foo").length
-        assert_equal 1, doc.xpath("//a:foo").length
-        assert_equal 1, doc.xpath("//a:foo").length
-        assert_equal 1, doc.xpath("//x:foo", "x" => "http://c.flavorjon.es/").length
-        assert_match %r{foo c:attr}, doc.to_xml
-        doc.at_xpath("//x:foo", "x" => "http://c.flavorjon.es/").tap do |node|
-          assert_nil node["attr"]
-          assert_equal "attr-value", node["c:attr"]
-          assert_nil node.attribute_with_ns("attr", nil)
-          assert_equal "attr-value", node.attribute_with_ns("attr", "http://c.flavorjon.es/").value
-          assert_equal "attr-value", node.attributes["attr"].value
+          assert_equal(3, document.xpath(".//div", ".//p").length)
+          assert_equal(3, document.css(".title", ".content", "p").length)
+          assert_equal(3, document.search(".//div", "p.blah").length)
         end
 
-        doc.remove_namespaces!
-
-        assert_equal 0, doc.root.namespaces.length
-        assert_equal 0, doc.at_xpath("//container").namespaces.length
-        assert_equal 3, doc.xpath("//foo").length
-        assert_equal 0, doc.xpath("//a:foo", namespaces).length
-        assert_equal 0, doc.xpath("//a:foo", namespaces).length
-        assert_equal 0, doc.xpath("//x:foo", "x" => "http://c.flavorjon.es/").length
-        assert_match %r{foo attr}, doc.to_xml
-        doc.at_xpath("//container/foo").tap do |node|
-          assert_equal "attr-value", node["attr"]
-          assert_nil node["c:attr"]
-          assert_equal "attr-value", node.attribute_with_ns("attr", nil).value
-          assert_nil node.attribute_with_ns("attr", "http://c.flavorjon.es/")
-          assert_equal "attr-value", node.attributes["attr"].value # doesn't change!
-        end
-      end
-
-      # issue #785
-      def test_attribute_decoration
-        decorator = Module.new do
-          def test_method
+        def test_bad_xpath_raises_syntax_error
+          assert_raises(XML::XPath::SyntaxError) do
+            xml.xpath('\\')
           end
         end
 
-        util_decorate(@xml, decorator)
+        def test_find_with_namespace
+          doc = Nokogiri::XML.parse(<<~eoxml)
+            <x xmlns:tenderlove='http://tenderlovemaking.com/'>
+              <tenderlove:foo awesome='true'>snuggles!</tenderlove:foo>
+            </x>
+          eoxml
 
-        assert @xml.search("//@street").first.respond_to?(:test_method)
-      end
+          ctx = Nokogiri::XML::XPathContext.new(doc)
+          ctx.register_ns("tenderlove", "http://tenderlovemaking.com/")
+          set = ctx.evaluate("//tenderlove:foo")
+          assert_equal(1, set.length)
+          assert_equal("foo", set.first.name)
 
-      def test_subset_is_decorated
-        x = Module.new do
-          def awesome!
+          # It looks like only the URI is important:
+          ctx = Nokogiri::XML::XPathContext.new(doc)
+          ctx.register_ns("america", "http://tenderlovemaking.com/")
+          set = ctx.evaluate("//america:foo")
+          assert_equal(1, set.length)
+          assert_equal("foo", set.first.name)
+
+          # Its so important that a missing slash will cause it to return nothing
+          ctx = Nokogiri::XML::XPathContext.new(doc)
+          ctx.register_ns("america", "http://tenderlovemaking.com")
+          set = ctx.evaluate("//america:foo")
+          assert_equal(0, set.length)
+        end
+
+        def test_xml?
+          assert(xml.xml?)
+        end
+
+        def test_document
+          assert(xml.document)
+        end
+
+        def test_singleton_methods
+          assert(node_set = xml.search("//name"))
+          assert(node_set.length > 0)
+          node = node_set.first
+          def node.test
+            "test"
+          end
+          assert(node_set = xml.search("//name"))
+          assert_equal("test", node_set.first.test)
+        end
+
+        def test_multiple_search
+          assert(node_set = xml.search("//employee", "//name"))
+          employees = xml.search("//employee")
+          names = xml.search("//name")
+          assert_equal(employees.length + names.length, node_set.length)
+        end
+
+        def test_node_set_index
+          assert(node_set = xml.search("//employee"))
+
+          assert_equal(5, node_set.length)
+          assert(node_set[4])
+          assert_nil(node_set[5])
+        end
+
+        def test_search
+          assert(node_set = xml.search("//employee"))
+
+          assert_equal(5, node_set.length)
+
+          node_set.each do |node|
+            assert_equal("employee", node.name)
           end
         end
-        util_decorate(@xml, x)
 
-        assert @xml.respond_to?(:awesome!)
-        assert node_set = @xml.search("//staff")
-        assert node_set.respond_to?(:awesome!)
-        assert subset = node_set.search(".//employee")
-        assert subset.respond_to?(:awesome!)
-        assert sub_subset = node_set.search(".//name")
-        assert sub_subset.respond_to?(:awesome!)
-      end
+        def test_dump
+          assert(xml.serialize)
+          assert(xml.to_xml)
+        end
 
-      def test_decorator_is_applied
-        x = Module.new do
-          def awesome!
+        def test_dup
+          dup = xml.dup
+          assert_instance_of(Nokogiri::XML::Document, dup)
+          assert(dup.xml?, "duplicate should be xml")
+        end
+
+        def test_new
+          doc = nil
+          doc = Nokogiri::XML::Document.new
+          assert(doc)
+          assert(doc.xml?)
+          assert_nil(doc.root)
+        end
+
+        def test_set_root
+          doc = nil
+          doc = Nokogiri::XML::Document.new
+          assert(doc)
+          assert(doc.xml?)
+          assert_nil(doc.root)
+          node = Nokogiri::XML::Node.new("b", doc) do |n|
+            n.content = "hello world"
+          end
+          assert_equal("hello world", node.content)
+          doc.root = node
+          assert_equal(node, doc.root)
+        end
+
+        def test_remove_namespaces
+          doc = Nokogiri::XML(<<~EOX)
+            <root xmlns:a="http://a.flavorjon.es/" xmlns:b="http://b.flavorjon.es/">
+              <a:foo>hello from a</a:foo>
+              <b:foo>hello from b</b:foo>
+              <container xmlns:c="http://c.flavorjon.es/">
+                <c:foo c:attr='attr-value'>hello from c</c:foo>
+              </container>
+            </root>
+          EOX
+
+          namespaces = doc.root.namespaces
+
+          # assert on setup
+          assert_equal(2, doc.root.namespaces.length)
+          assert_equal(3, doc.at_xpath("//container").namespaces.length)
+          assert_equal(0, doc.xpath("//foo").length)
+          assert_equal(1, doc.xpath("//a:foo").length)
+          assert_equal(1, doc.xpath("//a:foo").length)
+          assert_equal(1, doc.xpath("//x:foo", "x" => "http://c.flavorjon.es/").length)
+          assert_match(/foo c:attr/, doc.to_xml)
+          doc.at_xpath("//x:foo", "x" => "http://c.flavorjon.es/").tap do |node|
+            assert_nil(node["attr"])
+            assert_equal("attr-value", node["c:attr"])
+            assert_nil(node.attribute_with_ns("attr", nil))
+            assert_equal("attr-value", node.attribute_with_ns("attr", "http://c.flavorjon.es/").value)
+            assert_equal("attr-value", node.attributes["attr"].value)
+          end
+
+          doc.remove_namespaces!
+
+          assert_equal(0, doc.root.namespaces.length)
+          assert_equal(0, doc.at_xpath("//container").namespaces.length)
+          assert_equal(3, doc.xpath("//foo").length)
+          assert_equal(0, doc.xpath("//a:foo", namespaces).length)
+          assert_equal(0, doc.xpath("//a:foo", namespaces).length)
+          assert_equal(0, doc.xpath("//x:foo", "x" => "http://c.flavorjon.es/").length)
+          assert_match(/foo attr/, doc.to_xml)
+          doc.at_xpath("//container/foo").tap do |node|
+            assert_equal("attr-value", node["attr"])
+            assert_nil(node["c:attr"])
+            assert_equal("attr-value", node.attribute_with_ns("attr", nil).value)
+            assert_nil(node.attribute_with_ns("attr", "http://c.flavorjon.es/"))
+            assert_equal("attr-value", node.attributes["attr"].value) # doesn't change!
           end
         end
-        util_decorate(@xml, x)
 
-        assert @xml.respond_to?(:awesome!)
-        assert node_set = @xml.search("//employee")
-        assert node_set.respond_to?(:awesome!)
-        node_set.each do |node|
-          assert node.respond_to?(:awesome!), node.class
-        end
-        assert @xml.root.respond_to?(:awesome!)
-        assert @xml.children.respond_to?(:awesome!)
-      end
+        # issue #785
+        def test_attribute_decoration
+          decorator = Module.new do
+            def test_method
+            end
+          end
 
-      if Nokogiri.jruby?
-        def wrap_java_document
-          require "java"
-          factory = javax.xml.parsers.DocumentBuilderFactory.newInstance
-          builder = factory.newDocumentBuilder
-          document = builder.newDocument
-          root = document.createElement("foo")
-          document.appendChild(root)
-          Nokogiri::XML::Document.wrap(document)
-        end
-      end
+          util_decorate(xml, decorator)
 
-      def test_java_integration
-        skip("CRuby doesn't have the Document#wrap method") unless Nokogiri.jruby?
-        noko_doc = wrap_java_document
-        assert_equal "foo", noko_doc.root.name
-
-        noko_doc = Nokogiri::XML(<<eoxml)
-<foo xmlns='hello'>
-  <bar xmlns:foo='world' />
-</foo>
-eoxml
-        dom = noko_doc.to_java
-        assert dom.kind_of? org.w3c.dom.Document
-        assert_equal "foo", dom.getDocumentElement().getTagName()
-      end
-
-      def test_add_child
-        skip("CRuby doesn't have the Document#wrap method") unless Nokogiri.jruby?
-        doc = wrap_java_document
-        doc.root.add_child "<bar />"
-      end
-
-      def test_can_be_closed
-        f = File.open XML_FILE
-        Nokogiri::XML f
-        f.close
-      end
-
-      describe "XML::Document.parse" do
-        # establish baseline behavior for HTML document behavior in
-        # https://github.com/sparklemotion/nokogiri/issues/2130
-        # (see similar tests in test/html/test_document.rb)
-        let(:xml_strict) do
-          Nokogiri::XML::ParseOptions.new(Nokogiri::XML::ParseOptions::DEFAULT_XML).norecover
+          assert(xml.search("//@street").first.respond_to?(:test_method))
         end
 
-        it "sets the test up correctly" do
-          assert(xml_strict.strict?)
+        def test_subset_is_decorated
+          x = Module.new do
+            def awesome!
+            end
+          end
+          util_decorate(xml, x)
+
+          assert(xml.respond_to?(:awesome!))
+          assert(node_set = xml.search("//staff"))
+          assert(node_set.respond_to?(:awesome!))
+          assert(subset = node_set.search(".//employee"))
+          assert(subset.respond_to?(:awesome!))
+          assert(sub_subset = node_set.search(".//name"))
+          assert(sub_subset.respond_to?(:awesome!))
         end
 
-        describe "read memory" do
-          let(:input) { "<html><body><div" }
+        def test_decorator_is_applied
+          x = Module.new do
+            def awesome!
+            end
+          end
+          util_decorate(xml, x)
 
-          describe "strict parsing" do
-            let(:parse_options) { xml_strict }
+          assert(xml.respond_to?(:awesome!))
+          assert(node_set = xml.search("//employee"))
+          assert(node_set.respond_to?(:awesome!))
+          node_set.each do |node|
+            assert(node.respond_to?(:awesome!), node.class)
+          end
+          assert(xml.root.respond_to?(:awesome!))
+          assert(xml.children.respond_to?(:awesome!))
+        end
 
-            it "raises exception on parse error" do
-              assert_raises Nokogiri::SyntaxError do
-                Nokogiri::XML.parse(input, nil, nil, parse_options)
+        if Nokogiri.jruby?
+          def wrap_java_document
+            require "java"
+            factory = javax.xml.parsers.DocumentBuilderFactory.newInstance
+            builder = factory.newDocumentBuilder
+            document = builder.newDocument
+            root = document.createElement("foo")
+            document.appendChild(root)
+            Nokogiri::XML::Document.wrap(document)
+          end
+        end
+
+        def test_java_integration
+          skip("CRuby doesn't have the Document#wrap method") unless Nokogiri.jruby?
+          noko_doc = wrap_java_document
+          assert_equal("foo", noko_doc.root.name)
+
+          noko_doc = Nokogiri::XML(<<~eoxml)
+            <foo xmlns='hello'>
+              <bar xmlns:foo='world' />
+            </foo>
+          eoxml
+          dom = noko_doc.to_java
+          assert(dom.is_a?(org.w3c.dom.Document))
+          assert_equal("foo", dom.getDocumentElement.getTagName)
+        end
+
+        def test_add_child
+          skip("CRuby doesn't have the Document#wrap method") unless Nokogiri.jruby?
+          doc = wrap_java_document
+          doc.root.add_child("<bar />")
+        end
+
+        def test_can_be_closed
+          f = File.open(XML_FILE)
+          Nokogiri::XML(f)
+          f.close
+        end
+
+        describe "XML::Document.parse" do
+          # establish baseline behavior for HTML document behavior in
+          # https://github.com/sparklemotion/nokogiri/issues/2130
+          # (see similar tests in test/html/test_document.rb)
+          let(:xml_strict) do
+            Nokogiri::XML::ParseOptions.new(Nokogiri::XML::ParseOptions::DEFAULT_XML).norecover
+          end
+
+          it "sets the test up correctly" do
+            assert(xml_strict.strict?)
+          end
+
+          describe "read memory" do
+            let(:input) { "<html><body><div" }
+
+            describe "strict parsing" do
+              let(:parse_options) { xml_strict }
+
+              it "raises exception on parse error" do
+                assert_raises Nokogiri::SyntaxError do
+                  Nokogiri::XML.parse(input, nil, nil, parse_options)
+                end
+              end
+            end
+
+            describe "default options" do
+              it "does not raise exception on parse error" do
+                doc = Nokogiri::XML.parse(input)
+                assert_operator(doc.errors.length, :>, 0)
               end
             end
           end
 
-          describe "default options" do
-            it "does not raise exception on parse error" do
-              doc = Nokogiri::XML.parse(input)
-              assert_operator(doc.errors.length, :>, 0)
+          describe "read io" do
+            let(:input) { StringIO.new("<html><body><div") }
+
+            describe "strict parsing" do
+              let(:parse_options) { xml_strict }
+
+              it "raises exception on parse error" do
+                assert_raises Nokogiri::SyntaxError do
+                  Nokogiri::XML.parse(input, nil, nil, parse_options)
+                end
+              end
+            end
+
+            describe "default options" do
+              it "does not raise exception on parse error" do
+                doc = Nokogiri::XML.parse(input)
+                assert_operator(doc.errors.length, :>, 0)
+              end
             end
           end
         end
 
-        describe "read io" do
-          let(:input) { StringIO.new("<html><body><div") }
+        describe "subclassing" do
+          let(:klass) do
+            Class.new(Nokogiri::XML::Document) do
+              attr_accessor :initialized_with, :initialized_count
 
-          describe "strict parsing" do
-            let(:parse_options) { xml_strict }
-
-            it "raises exception on parse error" do
-              assert_raises Nokogiri::SyntaxError do
-                Nokogiri::XML.parse(input, nil, nil, parse_options)
+              def initialize(*args)
+                super
+                @initialized_with = args
+                @initialized_count ||= 0
+                @initialized_count += 1
               end
             end
           end
 
-          describe "default options" do
-            it "does not raise exception on parse error" do
-              doc = Nokogiri::XML.parse(input)
-              assert_operator(doc.errors.length, :>, 0)
+          describe ".new" do
+            it "returns an instance of the expected class" do
+              doc = klass.new
+              assert_instance_of(klass, doc)
+            end
+
+            it "calls #initialize exactly once" do
+              doc = klass.new
+              assert_equal(1, doc.initialized_count)
+            end
+
+            it "passes arguments to #initialize" do
+              doc = klass.new("1.0", 1)
+              assert_equal ["1.0", 1], doc.initialized_with
+            end
+          end
+
+          it "#dup returns the expected class" do
+            doc = klass.new.dup
+            assert_instance_of(klass, doc)
+          end
+
+          describe ".parse" do
+            it "returns an instance of the expected class" do
+              doc = klass.parse(File.read(XML_FILE))
+              assert_instance_of(klass, doc)
+            end
+
+            it "calls #initialize exactly once" do
+              doc = klass.parse(File.read(XML_FILE))
+              assert_equal(1, doc.initialized_count)
+            end
+
+            it "parses the doc" do
+              doc = klass.parse(File.read(XML_FILE))
+              assert_equal xml.root.to_s, doc.root.to_s
             end
           end
         end

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -1,176 +1,163 @@
+# frozen_string_literal: true
 require "helper"
 
 module Nokogiri
   module XML
     class TestDocumentFragment < Nokogiri::TestCase
-      def setup
-        super
-        @xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE)
-      end
+      describe Nokogiri::XML::DocumentFragment do
+        let(:xml) { Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) }
 
-      def test_replace_text_node
-        html = "foo"
-        doc = Nokogiri::XML::DocumentFragment.parse(html)
-        doc.children[0].replace "bar"
-        assert_equal 'bar', doc.children[0].content
-      end
-
-      def test_fragment_is_relative
-        doc      = Nokogiri::XML('<root><a xmlns="blah" /></root>')
-        ctx      = doc.root.child
-        fragment = Nokogiri::XML::DocumentFragment.new(doc, '<hello />', ctx)
-        hello    = fragment.child
-
-        assert_equal 'hello', hello.name
-        assert_equal doc.root.child.namespace, hello.namespace
-      end
-
-      def test_node_fragment_is_relative
-        doc      = Nokogiri::XML('<root><a xmlns="blah" /></root>')
-        assert doc.root.child
-        fragment = doc.root.child.fragment('<hello />')
-        hello    = fragment.child
-
-        assert_equal 'hello', hello.name
-        assert_equal doc.root.child.namespace, hello.namespace
-      end
-
-      def test_new
-        assert Nokogiri::XML::DocumentFragment.new(@xml)
-      end
-
-      def test_fragment_should_have_document
-        fragment = Nokogiri::XML::DocumentFragment.new(@xml)
-        assert_equal @xml, fragment.document
-      end
-
-      def test_name
-        fragment = Nokogiri::XML::DocumentFragment.new(@xml)
-        assert_equal '#document-fragment', fragment.name
-      end
-
-      def test_static_method
-        fragment = Nokogiri::XML::DocumentFragment.parse("<div>a</div>")
-        assert_instance_of Nokogiri::XML::DocumentFragment, fragment
-      end
-
-      def test_static_method_with_namespaces
-        # follows different path in FragmentHandler#start_element which blew up after 597195ff
-        fragment = Nokogiri::XML::DocumentFragment.parse("<o:div>a</o:div>")
-        assert_instance_of Nokogiri::XML::DocumentFragment, fragment
-      end
-
-      def test_many_fragments
-        100.times { Nokogiri::XML::DocumentFragment.new(@xml) }
-      end
-
-      def test_subclass
-        klass = Class.new(Nokogiri::XML::DocumentFragment)
-        fragment = klass.new(@xml, "<div>a</div>")
-        assert_instance_of klass, fragment
-      end
-
-      def test_subclass_parse
-        klass = Class.new(Nokogiri::XML::DocumentFragment)
-        doc = klass.parse("<div>a</div>")
-        assert_instance_of klass, doc
-      end
-
-      def test_unparented_text_node_parse
-        fragment = Nokogiri::XML::DocumentFragment.parse("foo")
-        fragment.children.after("<bar/>")
-      end
-
-      def test_xml_fragment
-        fragment = Nokogiri::XML.fragment("<div>a</div>")
-        assert_equal "<div>a</div>", fragment.to_s
-      end
-
-      def test_xml_fragment_has_multiple_toplevel_children
-        doc = "<div>b</div><div>e</div>"
-        fragment = Nokogiri::XML::Document.new.fragment(doc)
-        assert_equal "<div>b</div><div>e</div>", fragment.to_s
-      end
-
-      def test_xml_fragment_has_outer_text
-        # this test is descriptive, not prescriptive.
-        doc = "a<div>b</div>"
-        fragment = Nokogiri::XML::Document.new.fragment(doc)
-        assert_equal "a<div>b</div>", fragment.to_s
-
-        doc = "<div>b</div>c"
-        fragment = Nokogiri::XML::Document.new.fragment(doc)
-        assert_equal "<div>b</div>c", fragment.to_s
-      end
-
-      def test_xml_fragment_case_sensitivity
-        doc = "<crazyDiv>b</crazyDiv>"
-        fragment = Nokogiri::XML::Document.new.fragment(doc)
-        assert_equal "<crazyDiv>b</crazyDiv>", fragment.to_s
-      end
-
-      def test_xml_fragment_with_leading_whitespace
-        doc = "     <div>b</div>  "
-        fragment = Nokogiri::XML::Document.new.fragment(doc)
-        assert_equal "     <div>b</div>  ", fragment.to_s
-      end
-
-      def test_xml_fragment_with_leading_whitespace_and_newline
-        doc = "     \n<div>b</div>  "
-        fragment = Nokogiri::XML::Document.new.fragment(doc)
-        assert_equal "     \n<div>b</div>  ", fragment.to_s
-      end
-
-      def test_fragment_children_search
-        fragment = Nokogiri::XML::Document.new.fragment(
-          '<div><p id="content">hi</p></div>'
-        )
-        expected = fragment.children.xpath('.//p')
-        assert_equal 1, expected.length
-
-        css          = fragment.children.css('p')
-        search_css   = fragment.children.search('p')
-        search_xpath = fragment.children.search('.//p')
-        assert_equal expected, css
-        assert_equal expected, search_css
-        assert_equal expected, search_xpath
-      end
-
-      def test_fragment_css_search_with_whitespace_and_node_removal
-        # The same xml without leading whitespace in front of the first line
-        # does not expose the error. Putting both nodes on the same line
-        # instead also fixes the crash.
-        fragment = Nokogiri::XML::DocumentFragment.parse <<-EOXML
-          <p id="content">hi</p> x <!--y--> <p>another paragraph</p>
-        EOXML
-        children = fragment.css('p')
-        assert_equal 2, children.length
-        # removing the last node instead does not yield the error. Probably the
-        # node removal leaves around two consecutive text nodes which make the
-        # css search crash?
-        children.first.remove
-        assert_equal 1, fragment.xpath('.//p | self::p').length
-        assert_equal 1, fragment.css('p').length
-      end
-
-      def test_fragment_search_three_ways
-        frag = Nokogiri::XML::Document.new.fragment '<p id="content">foo</p><p id="content">bar</p>'
-        expected = frag.xpath('./*[@id = "content"]')
-        assert_equal 2, expected.length
-
-        [
-          [:css, '#content'],
-          [:search, '#content'],
-          [:search, './*[@id = \'content\']'],
-        ].each do |method, query|
-          result = frag.send(method, query)
-          assert_equal(expected, result,
-            "fragment search with :#{method} using '#{query}' expected '#{expected}' got '#{result}'")
+        def test_replace_text_node
+          html = "foo"
+          doc = Nokogiri::XML::DocumentFragment.parse(html)
+          doc.children[0].replace("bar")
+          assert_equal('bar', doc.children[0].content)
         end
-      end
 
-      def test_fragment_search_with_multiple_queries
-        xml = '<thing>
+        def test_fragment_is_relative
+          doc      = Nokogiri::XML('<root><a xmlns="blah" /></root>')
+          ctx      = doc.root.child
+          fragment = Nokogiri::XML::DocumentFragment.new(doc, '<hello />', ctx)
+          hello    = fragment.child
+
+          assert_equal('hello', hello.name)
+          assert_equal(doc.root.child.namespace, hello.namespace)
+        end
+
+        def test_node_fragment_is_relative
+          doc = Nokogiri::XML('<root><a xmlns="blah" /></root>')
+          assert(doc.root.child)
+          fragment = doc.root.child.fragment('<hello />')
+          hello    = fragment.child
+
+          assert_equal('hello', hello.name)
+          assert_equal(doc.root.child.namespace, hello.namespace)
+        end
+
+        def test_new
+          assert(Nokogiri::XML::DocumentFragment.new(xml))
+        end
+
+        def test_fragment_should_have_document
+          fragment = Nokogiri::XML::DocumentFragment.new(xml)
+          assert_equal(xml, fragment.document)
+        end
+
+        def test_name
+          fragment = Nokogiri::XML::DocumentFragment.new(xml)
+          assert_equal('#document-fragment', fragment.name)
+        end
+
+        def test_static_method
+          fragment = Nokogiri::XML::DocumentFragment.parse("<div>a</div>")
+          assert_instance_of(Nokogiri::XML::DocumentFragment, fragment)
+        end
+
+        def test_static_method_with_namespaces
+          # follows different path in FragmentHandler#start_element which blew up after 597195ff
+          fragment = Nokogiri::XML::DocumentFragment.parse("<o:div>a</o:div>")
+          assert_instance_of(Nokogiri::XML::DocumentFragment, fragment)
+        end
+
+        def test_many_fragments
+          100.times { Nokogiri::XML::DocumentFragment.new(xml) }
+        end
+
+        def test_unparented_text_node_parse
+          fragment = Nokogiri::XML::DocumentFragment.parse("foo")
+          fragment.children.after("<bar/>")
+        end
+
+        def test_xml_fragment
+          fragment = Nokogiri::XML.fragment("<div>a</div>")
+          assert_equal("<div>a</div>", fragment.to_s)
+        end
+
+        def test_xml_fragment_has_multiple_toplevel_children
+          doc = "<div>b</div><div>e</div>"
+          fragment = Nokogiri::XML::Document.new.fragment(doc)
+          assert_equal("<div>b</div><div>e</div>", fragment.to_s)
+        end
+
+        def test_xml_fragment_has_outer_text
+          # this test is descriptive, not prescriptive.
+          doc = "a<div>b</div>"
+          fragment = Nokogiri::XML::Document.new.fragment(doc)
+          assert_equal("a<div>b</div>", fragment.to_s)
+
+          doc = "<div>b</div>c"
+          fragment = Nokogiri::XML::Document.new.fragment(doc)
+          assert_equal("<div>b</div>c", fragment.to_s)
+        end
+
+        def test_xml_fragment_case_sensitivity
+          doc = "<crazyDiv>b</crazyDiv>"
+          fragment = Nokogiri::XML::Document.new.fragment(doc)
+          assert_equal("<crazyDiv>b</crazyDiv>", fragment.to_s)
+        end
+
+        def test_xml_fragment_with_leading_whitespace
+          doc = "     <div>b</div>  "
+          fragment = Nokogiri::XML::Document.new.fragment(doc)
+          assert_equal("     <div>b</div>  ", fragment.to_s)
+        end
+
+        def test_xml_fragment_with_leading_whitespace_and_newline
+          doc = "     \n<div>b</div>  "
+          fragment = Nokogiri::XML::Document.new.fragment(doc)
+          assert_equal("     \n<div>b</div>  ", fragment.to_s)
+        end
+
+        def test_fragment_children_search
+          fragment = Nokogiri::XML::Document.new.fragment(
+            '<div><p id="content">hi</p></div>'
+          )
+          expected = fragment.children.xpath('.//p')
+          assert_equal(1, expected.length)
+
+          css          = fragment.children.css('p')
+          search_css   = fragment.children.search('p')
+          search_xpath = fragment.children.search('.//p')
+          assert_equal(expected, css)
+          assert_equal(expected, search_css)
+          assert_equal(expected, search_xpath)
+        end
+
+        def test_fragment_css_search_with_whitespace_and_node_removal
+          # The same xml without leading whitespace in front of the first line
+          # does not expose the error. Putting both nodes on the same line
+          # instead also fixes the crash.
+          fragment = Nokogiri::XML::DocumentFragment.parse(<<~EOXML)
+            <p id="content">hi</p> x <!--y--> <p>another paragraph</p>
+          EOXML
+          children = fragment.css('p')
+          assert_equal(2, children.length)
+          # removing the last node instead does not yield the error. Probably the
+          # node removal leaves around two consecutive text nodes which make the
+          # css search crash?
+          children.first.remove
+          assert_equal(1, fragment.xpath('.//p | self::p').length)
+          assert_equal(1, fragment.css('p').length)
+        end
+
+        def test_fragment_search_three_ways
+          frag = Nokogiri::XML::Document.new.fragment('<p id="content">foo</p><p id="content">bar</p>')
+          expected = frag.xpath('./*[@id = "content"]')
+          assert_equal(2, expected.length)
+
+          [
+            [:css, '#content'],
+            [:search, '#content'],
+            [:search, './*[@id = \'content\']'],
+          ].each do |method, query|
+            result = frag.send(method, query)
+            assert_equal(expected, result,
+                         "fragment search with :#{method} using '#{query}' expected '#{expected}' got '#{result}'")
+          end
+        end
+
+        def test_fragment_search_with_multiple_queries
+          xml = '<thing>
                  <div class="title">important thing</div>
                </thing>
                <thing>
@@ -179,148 +166,202 @@ module Nokogiri
                <thing>
                  <p class="blah">more stuff</div>
                </thing>'
-        fragment = Nokogiri::XML.fragment(xml)
-        assert_kind_of Nokogiri::XML::DocumentFragment, fragment
+          fragment = Nokogiri::XML.fragment(xml)
+          assert_kind_of(Nokogiri::XML::DocumentFragment, fragment)
 
-        assert_equal 3, fragment.xpath('.//div', './/p').length
-        assert_equal 3, fragment.css('.title', '.content', 'p').length
-        assert_equal 3, fragment.search('.//div', 'p.blah').length
-      end
+          assert_equal(3, fragment.xpath('.//div', './/p').length)
+          assert_equal(3, fragment.css('.title', '.content', 'p').length)
+          assert_equal(3, fragment.search('.//div', 'p.blah').length)
+        end
 
-      def test_fragment_without_a_namespace_does_not_get_a_namespace
-        doc = Nokogiri::XML <<-EOX
-          <root xmlns="http://tenderlovemaking.com/" xmlns:foo="http://flavorjon.es/" xmlns:bar="http://google.com/">
-            <foo:existing></foo:existing>
-          </root>
-        EOX
-        frag = doc.fragment "<newnode></newnode>"
-        assert_nil frag.namespace
-      end
+        def test_fragment_without_a_namespace_does_not_get_a_namespace
+          doc = Nokogiri::XML(<<~EOX)
+            <root xmlns="http://tenderlovemaking.com/" xmlns:foo="http://flavorjon.es/" xmlns:bar="http://google.com/">
+              <foo:existing></foo:existing>
+            </root>
+          EOX
+          frag = doc.fragment("<newnode></newnode>")
+          assert_nil(frag.namespace)
+        end
 
-      def test_fragment_namespace_resolves_against_document_root
-        doc = Nokogiri::XML <<-EOX
-          <root xmlns:foo="http://flavorjon.es/" xmlns:bar="http://google.com/">
-            <foo:existing></foo:existing>
-          </root>
-        EOX
-        ns = doc.root.namespace_definitions.detect { |x| x.prefix == "bar" }
+        def test_fragment_namespace_resolves_against_document_root
+          doc = Nokogiri::XML(<<~EOX)
+            <root xmlns:foo="http://flavorjon.es/" xmlns:bar="http://google.com/">
+              <foo:existing></foo:existing>
+            </root>
+          EOX
+          ns = doc.root.namespace_definitions.detect { |x| x.prefix == "bar" }
 
-        frag = doc.fragment "<bar:newnode></bar:newnode>"
-        assert frag.children.first.namespace
-        assert_equal ns, frag.children.first.namespace
-      end
+          frag = doc.fragment("<bar:newnode></bar:newnode>")
+          assert(frag.children.first.namespace)
+          assert_equal(ns, frag.children.first.namespace)
+        end
 
-      def test_fragment_invalid_namespace_is_silently_ignored
-        doc = Nokogiri::XML <<-EOX
-          <root xmlns:foo="http://flavorjon.es/" xmlns:bar="http://google.com/">
-            <foo:existing></foo:existing>
-          </root>
-        EOX
-        frag = doc.fragment "<baz:newnode></baz:newnode>"
-        assert_nil frag.children.first.namespace
-      end
+        def test_fragment_invalid_namespace_is_silently_ignored
+          doc = Nokogiri::XML(<<~EOX)
+            <root xmlns:foo="http://flavorjon.es/" xmlns:bar="http://google.com/">
+              <foo:existing></foo:existing>
+            </root>
+          EOX
+          frag = doc.fragment("<baz:newnode></baz:newnode>")
+          assert_nil(frag.children.first.namespace)
+        end
 
-      def test_decorator_is_applied
-        x = Module.new do
-          def awesome!
+        def test_decorator_is_applied
+          x = Module.new do
+            def awesome!
+            end
+          end
+          util_decorate(xml, x)
+          fragment = Nokogiri::XML::DocumentFragment.new(xml, "<div>a</div><div>b</div>")
+
+          assert(node_set = fragment.css('div'))
+          assert(node_set.respond_to?(:awesome!))
+          node_set.each do |node|
+            assert(node.respond_to?(:awesome!), node.class)
+          end
+          assert(fragment.children.respond_to?(:awesome!), fragment.children.class)
+        end
+
+        def test_decorator_is_applied_to_empty_set
+          x = Module.new do
+            def awesome!
+            end
+          end
+          util_decorate(xml, x)
+          fragment = Nokogiri::XML::DocumentFragment.new(xml, "")
+          assert(fragment.children.respond_to?(:awesome!), fragment.children.class)
+        end
+
+        def test_add_node_to_doc_fragment_segfault
+          frag = Nokogiri::XML::DocumentFragment.new(xml, '<p>hello world</p>')
+          Nokogiri::XML::Comment.new(frag, 'moo')
+        end
+
+        def test_issue_1077_parsing_of_frozen_strings
+          input = <<~EOS
+            <?xml version="1.0" encoding="utf-8"?>
+            <library>
+              <book title="I like turtles"/>
+            </library>
+          EOS
+          input.freeze
+
+          Nokogiri::XML::DocumentFragment.parse(input) # assert_nothing_raised
+        end
+
+        if Nokogiri.uses_libxml?
+          def test_dup_should_exist_in_a_new_document
+            # https://github.com/sparklemotion/nokogiri/issues/1063
+            original = Nokogiri::XML::DocumentFragment.parse("<div><p>hello</p></div>")
+            duplicate = original.dup
+            assert_not_equal(original.document, duplicate.document)
           end
         end
-        util_decorate(@xml, x)
-        fragment = Nokogiri::XML::DocumentFragment.new(@xml, "<div>a</div><div>b</div>")
 
-        assert node_set = fragment.css('div')
-        assert node_set.respond_to?(:awesome!)
-        node_set.each do |node|
-          assert node.respond_to?(:awesome!), node.class
-        end
-        assert fragment.children.respond_to?(:awesome!), fragment.children.class
-      end
-
-      def test_decorator_is_applied_to_empty_set
-        x = Module.new do
-          def awesome!
-          end
-        end
-        util_decorate(@xml, x)
-        fragment = Nokogiri::XML::DocumentFragment.new(@xml, "")
-        assert fragment.children.respond_to?(:awesome!), fragment.children.class
-      end
-
-      def test_add_node_to_doc_fragment_segfault
-        frag = Nokogiri::XML::DocumentFragment.new(@xml, '<p>hello world</p>')
-        Nokogiri::XML::Comment.new(frag,'moo')
-      end
-
-      def test_issue_1077_parsing_of_frozen_strings
-        input = <<-EOS
-<?xml version="1.0" encoding="utf-8"?>
-<library>
-  <book title="I like turtles"/>
-</library>
-EOS
-        input.freeze
-
-        Nokogiri::XML::DocumentFragment.parse(input) # assert_nothing_raised
-      end
-
-      if Nokogiri.uses_libxml?
-        def test_dup_should_exist_in_a_new_document
-          # https://github.com/sparklemotion/nokogiri/issues/1063
+        def test_dup_should_create_an_xml_document_fragment
+          # https://github.com/sparklemotion/nokogiri/issues/1846
           original = Nokogiri::XML::DocumentFragment.parse("<div><p>hello</p></div>")
           duplicate = original.dup
-          assert_not_equal original.document, duplicate.document
+          assert_instance_of(Nokogiri::XML::DocumentFragment, duplicate)
         end
-      end
 
-      def test_dup_should_create_an_xml_document_fragment
-        # https://github.com/sparklemotion/nokogiri/issues/1846
-        original = Nokogiri::XML::DocumentFragment.parse("<div><p>hello</p></div>")
-        duplicate = original.dup
-        assert_instance_of Nokogiri::XML::DocumentFragment, duplicate
-      end
+        def test_dup_creates_tree_with_identical_structure
+          original = Nokogiri::XML::DocumentFragment.parse("<div><p>hello</p></div>")
+          duplicate = original.dup
+          assert_equal(original.to_html, duplicate.to_html)
+        end
 
-      def test_dup_creates_tree_with_identical_structure
-        original = Nokogiri::XML::DocumentFragment.parse("<div><p>hello</p></div>")
-        duplicate = original.dup
-        assert_equal original.to_html, duplicate.to_html
-      end
+        def test_dup_creates_mutable_tree
+          original = Nokogiri::XML::DocumentFragment.parse("<div><p>hello</p></div>")
+          duplicate = original.dup
+          duplicate.at_css("div").add_child("<b>hello there</b>")
+          assert_nil(original.at_css("b"))
+          assert_not_nil(duplicate.at_css("b"))
+        end
 
-      def test_dup_creates_mutable_tree
-        original = Nokogiri::XML::DocumentFragment.parse("<div><p>hello</p></div>")
-        duplicate = original.dup
-        duplicate.at_css("div").add_child("<b>hello there</b>")
-        assert_nil original.at_css("b")
-        assert_not_nil duplicate.at_css("b")
-      end
-
-      if Nokogiri.uses_libxml?
-        def test_for_libxml_in_context_fragment_parsing_bug_workaround
-          10.times do
-            begin
+        if Nokogiri.uses_libxml?
+          def test_for_libxml_in_context_fragment_parsing_bug_workaround
+            10.times do
               fragment = Nokogiri::XML.fragment("<div></div>")
               parent = fragment.children.first
               child = parent.parse("<h1></h1>").first
-              parent.add_child child
+              parent.add_child(child)
+
+              GC.start
             end
-            GC.start
+          end
+
+          def test_for_libxml_in_context_memory_badness_when_encountering_encoding_errors
+            # see issue #643 for background
+            # this test exists solely to raise an error during valgrind test runs.
+            html = <<~EOHTML
+              <html>
+                <head>
+                  <meta http-equiv="Content-Type" content="text/html; charset=shizzle" />
+                </head>
+                <body>
+                  <div>Foo</div>
+                </body>
+              </html>
+            EOHTML
+            doc = Nokogiri::HTML(html)
+            doc.at_css("div").replace("Bar")
           end
         end
 
-        def test_for_libxml_in_context_memory_badness_when_encountering_encoding_errors
-          # see issue #643 for background
-          # this test exists solely to raise an error during valgrind test runs.
-          html = <<-EOHTML
-<html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=shizzle" />
-  </head>
-  <body>
-    <div>Foo</div>
-  </body>
-</html>
-EOHTML
-          doc = Nokogiri::HTML html
-          doc.at_css("div").replace("Bar")
+        describe "subclassing" do
+          let(:klass) do
+            Class.new(Nokogiri::XML::DocumentFragment) do
+              attr_accessor :initialized_with, :initialized_count
+
+              def initialize(*args)
+                super
+                @initialized_with = args
+                @initialized_count ||= 0
+                @initialized_count += 1
+              end
+            end
+          end
+
+          describe ".new" do
+            it "returns an instance of the right class" do
+              fragment = klass.new(xml, "<div>a</div>")
+              assert_instance_of(klass, fragment)
+            end
+
+            it "calls #initialize exactly once" do
+              fragment = klass.new(xml, "<div>a</div>")
+              assert_equal(1, fragment.initialized_count)
+            end
+
+            it "passes args to #initialize" do
+              fragment = klass.new(xml, "<div>a</div>")
+              assert_equal([xml, "<div>a</div>"], fragment.initialized_with)
+            end
+          end
+
+          it "#dup returns the expected class" do
+            doc = klass.new(xml, "<div>a</div>").dup
+            assert_instance_of(klass, doc)
+          end
+
+          describe ".parse" do
+            it "returns an instance of the right class" do
+              fragment = klass.parse("<div>a</div>")
+              assert_instance_of(klass, fragment)
+            end
+
+            it "calls #initialize exactly once" do
+              fragment = klass.parse("<div>a</div>")
+              assert_equal(1, fragment.initialized_count)
+            end
+
+            it "passes the fragment" do
+              fragment = klass.parse("<div>a</div>")
+              assert_equal(Nokogiri::XML::DocumentFragment.parse("<div>a</div>").to_s, fragment.to_s)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Originally this PR was started to address errors in Loofah's test suite on JRuby (see flavorjones/loofah#88) related to Nokogiri object decorators not being applied correctly. The root cause of these errors was that `{XML,HTML}Document#initialize` was not being called in the JRuby implementation. Surprising! And breaks the subclassing behavior that Loofah relies on.

As I erected tests in Nokogiri's suite to make this failure obvious, I uncovered the fact that in CRuby, `Document#initialize` was actually being called twice from the `.parse` method. Even more surprising! But doesn't obviously break anything.

This PR addresses both of these issues, with the result that `Document#initialize` is called exactly once on all platforms.


**Have you included adequate test coverage?**

Yes! Thorough testing is introduced around subclassing `XML::Document`, `HTML::Document`, `XML::DocumentFragment`, and `HTML::DocumentFragment` constructor calls `.new` and `.parse`.


**Does this change affect the behavior of either the C or the Java implementations?**

Yes, but as noted above the changed behavior is now correct and consistent across the platforms.