### PR TITLE
Restore Nokogiri_wrap_xml_document

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -588,6 +588,13 @@ VALUE nokogiri_xml_document_wrap_with_init_args(VALUE klass, xmlDocPtr doc, int 
 }
 
 
+/* deprecated. use nokogiri_xml_document_wrap() instead. */
+VALUE Nokogiri_wrap_xml_document(VALUE klass, xmlDocPtr doc)
+{
+  /* TODO: deprecate this method in v2.0 */
+  return nokogiri_xml_document_wrap_with_init_args(klass, doc, 0, NULL);
+}
+
 VALUE nokogiri_xml_document_wrap(VALUE klass, xmlDocPtr doc)
 {
   return nokogiri_xml_document_wrap_with_init_args(klass, doc, 0, NULL);

--- a/ext/nokogiri/xml_document.h
+++ b/ext/nokogiri/xml_document.h
@@ -21,4 +21,8 @@ VALUE nokogiri_xml_document_wrap(VALUE klass, xmlDocPtr doc);
 #define DOC_NODE_CACHE(x) (((nokogiriTuplePtr)(x->_private))->node_cache)
 
 extern VALUE cNokogiriXmlDocument ;
+
+/* deprecated. use nokogiri_xml_document_wrap() instead. */
+VALUE Nokogiri_wrap_xml_document(VALUE klass, xmlDocPtr doc);
+
 #endif


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See test failures when trying to install Nokogumbo against `main`:

- https://ci.nokogiri.org/teams/nokogiri-core/pipelines/nokogiri/jobs/cruby-gem-test/builds/76#L5ffe2a36:251

This restores this method as an accessible symbol after 8587972 renamed it.

**Have you included adequate test coverage?**

Yes! Tests introduced in d02f723 demonstrated the problem that's being fixed in this changeset.

**Does this change affect the behavior of either the C or the Java implementations?**

No behavioral changes.
