### PR TITLE
Allow overriding env var with --use-system-libraries=false and default to --disable-static on TruffleRuby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * Reduce the number of object allocations needed when parsing an HTML::DocumentFragment. [[#2087](https://github.com/sparklemotion/nokogiri/issues/2087)] (Thanks, [@ashmaroli](https://github.com/ashmaroli)!)
 * [JRuby] Update the algorithm used to calculate `Node#line` to be wrong less-often. The underlying parser, Xerces, does not track line numbers, and so we've always used a hacky solution for this method. [[#1223](https://github.com/sparklemotion/nokogiri/issues/1223)]
 * Introduce `--enable-system-libraries` and `--disable-system-libraries` flags to `extconf.rb`. These flags provide the same functionality as `--use-system-libraries` and the `NOKOGIRI_USE_SYSTEM_LIBRARIES` environment variable, but are more idiomatic. [[#2193](https://github.com/sparklemotion/nokogiri/issues/2193)] (Thanks, [@eregon](https://github.com/eregon)!)
+* [TruffleRuby] `--disable-static` is used by default on TruffleRuby, when `--disable-system-libraries` is set, which is more flexible and compiles faster, see [#2191](https://github.com/sparklemotion/nokogiri/issues/2191#issuecomment-780724627). [[#2193](https://github.com/sparklemotion/nokogiri/issues/2193)] (Thanks, [@eregon](https://github.com/eregon)!)
 
 
 ## 1.11.1 / 2021-01-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 * Reduce the number of object allocations needed when parsing an HTML::DocumentFragment. [[#2087](https://github.com/sparklemotion/nokogiri/issues/2087)] (Thanks, [@ashmaroli](https://github.com/ashmaroli)!)
 * [JRuby] Update the algorithm used to calculate `Node#line` to be wrong less-often. The underlying parser, Xerces, does not track line numbers, and so we've always used a hacky solution for this method. [[#1223](https://github.com/sparklemotion/nokogiri/issues/1223)]
+* Introduce `--enable-system-libraries` and `--disable-system-libraries` flags to `extconf.rb`. These flags provide the same functionality as `--use-system-libraries` and the `NOKOGIRI_USE_SYSTEM_LIBRARIES` environment variable, but are more idiomatic. [[#2193](https://github.com/sparklemotion/nokogiri/issues/2193)] (Thanks, [@eregon](https://github.com/eregon)!)
 
 
 ## 1.11.1 / 2021-01-06

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -149,6 +149,18 @@ HELP
 #
 #  utility functions
 #
+def config_clean?
+  enable_config('clean', true)
+end
+
+def config_static?
+  enable_config("static", true)
+end
+
+def config_cross_build?
+  enable_config("cross-build")
+end
+
 def config_system_libraries?
   enable_config("system-libraries", ENV.key?("NOKOGIRI_USE_SYSTEM_LIBRARIES")) do |_, default|
     arg_config('--use-system-libraries', default)
@@ -524,7 +536,7 @@ def do_clean
       FileUtils.rm_rf(dir, verbose: true)
     end
 
-    if enable_config('static')
+    if config_static?
       # ports installation can be safely removed if statically linked.
       FileUtils.rm_rf(root + 'ports', verbose: true)
     else
@@ -618,10 +630,10 @@ if config_system_libraries?
 else
   message "Building nokogiri using packaged libraries.\n"
 
-  static_p = enable_config("static", true)
+  static_p = config_static?
   message "Static linking is #{static_p ? 'enabled' : 'disabled'}.\n"
 
-  cross_build_p = enable_config("cross-build")
+  cross_build_p = config_cross_build?
   message "Cross build is #{cross_build_p ? 'enabled' : 'disabled'}.\n"
 
   require 'yaml'
@@ -876,7 +888,7 @@ end
 
 create_makefile('nokogiri/nokogiri')
 
-if enable_config('clean', true)
+if config_clean?
   # Do not clean if run in a development work tree.
   File.open('Makefile', 'at') do |mk|
     mk.print(<<~EOF)

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -29,7 +29,7 @@ NOKOGIRI_HELP_MESSAGE = <<~HELP
           Use system libraries instead of building and using the packaged libraries
 
       --disable-clean
-          Do not clean out intermediate files after successful build
+          Do not clean out intermediate files after successful build.
 
       --prevent-strip
           Take steps to prevent stripping the symbol table and debugging info from the shared
@@ -41,79 +41,79 @@ NOKOGIRI_HELP_MESSAGE = <<~HELP
       General:
 
         --with-opt-dir=DIRECTORY
-            Look for headers and libraries in DIRECTORY
+            Look for headers and libraries in DIRECTORY.
 
         --with-opt-lib=DIRECTORY
-            Look for libraries in DIRECTORY
+            Look for libraries in DIRECTORY.
 
         --with-opt-include=DIRECTORY
-            Look for headers in DIRECTORY
+            Look for headers in DIRECTORY.
 
 
       Related to zlib:
 
         --with-zlib-dir=DIRECTORY
-            Look for zlib headers and library in DIRECTORY
+            Look for zlib headers and library in DIRECTORY.
 
         --with-zlib-lib=DIRECTORY
-            Look for zlib library in DIRECTORY
+            Look for zlib library in DIRECTORY.
 
         --with-zlib-include=DIRECTORY
-            Look for zlib headers in DIRECTORY
+            Look for zlib headers in DIRECTORY.
 
 
       Related to iconv:
 
         --with-iconv-dir=DIRECTORY
-            Look for iconv headers and library in DIRECTORY
+            Look for iconv headers and library in DIRECTORY.
 
         --with-iconv-lib=DIRECTORY
-            Look for iconv library in DIRECTORY
+            Look for iconv library in DIRECTORY.
 
         --with-iconv-include=DIRECTORY
-            Look for iconv headers in DIRECTORY
+            Look for iconv headers in DIRECTORY.
 
 
       Related to libxml2:
 
         --with-xml2-dir=DIRECTORY
-            Look for xml2 headers and library in DIRECTORY
+            Look for xml2 headers and library in DIRECTORY.
 
         --with-xml2-lib=DIRECTORY
-            Look for xml2 library in DIRECTORY
+            Look for xml2 library in DIRECTORY.
 
         --with-xml2-include=DIRECTORY
-            Look for xml2 headers in DIRECTORY
+            Look for xml2 headers in DIRECTORY.
 
 
       Related to libxslt:
 
         --with-xslt-dir=DIRECTORY
-            Look for xslt headers and library in DIRECTORY
+            Look for xslt headers and library in DIRECTORY.
 
         --with-xslt-lib=DIRECTORY
-            Look for xslt library in DIRECTORY
+            Look for xslt library in DIRECTORY.
 
         --with-xslt-include=DIRECTORY
-            Look for xslt headers in DIRECTORY
+            Look for xslt headers in DIRECTORY.
 
 
       Related to libexslt:
 
         --with-exslt-dir=DIRECTORY
-            Look for exslt headers and library in DIRECTORY
+            Look for exslt headers and library in DIRECTORY.
 
         --with-exslt-lib=DIRECTORY
-            Look for exslt library in DIRECTORY
+            Look for exslt library in DIRECTORY.
 
         --with-exslt-include=DIRECTORY
-            Look for exslt headers in DIRECTORY
+            Look for exslt headers in DIRECTORY.
 
 
     Flags only used when building and using the packaged libraries:
 
       --disable-static
-          Do not statically link packaged libraries, instead use shared libraries
+          Do not statically link packaged libraries, instead use shared libraries.
 
       --enable-cross-build
           Enable cross-build mode. (You probably do not want to set this manually.)

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -154,7 +154,8 @@ def config_clean?
 end
 
 def config_static?
-  enable_config("static", true)
+  default_static = !truffle?
+  enable_config("static", default_static)
 end
 
 def config_cross_build?
@@ -189,6 +190,10 @@ end
 
 def nix?
   !(windows? || solaris? || darwin?)
+end
+
+def truffle?
+  ::RUBY_ENGINE == 'truffleruby'
 end
 
 def concat_flags(*args)


### PR DESCRIPTION
See https://github.com/sparklemotion/nokogiri/issues/2191