### PR TITLE
ci: specify 30-x64 now that Appveyor supports it

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize]
     branches:
       - '*'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,11 @@ environment:
       INSTALL_PACKAGES: "mingw-w64-x86_64-libxslt"
       EXTCONF_PARAMS: "--use-system-libraries"
 
+    - ruby_version: 30-x64
+    - ruby_version: 30-x64
+      INSTALL_PACKAGES: "mingw-w64-x86_64-libxslt"
+      EXTCONF_PARAMS: "--use-system-libraries"
+
     - ruby_version: 27-x64
     - ruby_version: 27-x64
       INSTALL_PACKAGES: "mingw-w64-x86_64-libxslt"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

`appveyor.yml` specifies "head-x64" but "30-x64" is now recognized (https://www.appveyor.com/docs/windows-images-software/#ruby).
