### PR TITLE
small chores / improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,4 +14,4 @@ indent_size = 2
 
 [**.java]
 indent_style = space
-indent_size = 4
+indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * `Nokogiri.XSLT` parses the stylesheet using `ParseOptions::DEFAULT_XSLT`, which should make some edge-case XSL transformations match libxslt's default behavior. [[#1940](https://github.com/sparklemotion/nokogiri/issues/1940)]
 
 
+### Improved
+
+* [MRI] Speed up (slightly) the compile time of packaged libraries `libiconv`, `libxml2`, and `libxslt` by using autoconf's `--disable-dependency-tracking` option.
+
+
 ## 1.11.3 / 2021-04-07
 
 ### Fixed

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -714,6 +714,7 @@ cross_build_p) do |recipe|
         cflags = concat_flags(ENV["CFLAGS"], "-O2", "-U_FORTIFY_SOURCE", "-g")
 
         recipe.configure_options += [
+          "--disable-dependency-tracking",
           "CPPFLAGS=-Wall",
           "CFLAGS=#{cflags}",
           "CXXFLAGS=#{cflags}",
@@ -769,6 +770,7 @@ cross_build_p) do |recipe|
     end
 
     recipe.configure_options += [
+      "--disable-dependency-tracking",
       "--without-python",
       "--without-readline",
       "--with-c14n",
@@ -791,6 +793,7 @@ cross_build_p) do |recipe|
     end
 
     recipe.configure_options += [
+      "--disable-dependency-tracking",
       "--without-python",
       "--without-crypto",
       "--with-debug",

--- a/rakelib/format.rake
+++ b/rakelib/format.rake
@@ -37,11 +37,11 @@ namespace "format" do
   end
 
   def astyle_c_files
-    FileList.new("ext/nokogiri/*.[ch]")
+    FileList.new("ext/**/*.[ch]")
   end
 
   def astyle_java_files
-    FileList.new("ext/java/nokogiri/**/*.java")
+    FileList.new("ext/**/*.java")
   end
 
   desc "Format Nokogiri's C code"

--- a/rakelib/format.rake
+++ b/rakelib/format.rake
@@ -3,7 +3,7 @@
 namespace "format" do
   def assert_astyle
     require "mkmf"
-    find_executable("astyle") || raise("Could not find command 'astyle'")
+    find_executable0("astyle") || raise("Could not find command 'astyle'")
   end
 
   def astyle_args
@@ -60,7 +60,6 @@ namespace "format" do
 
   CLEAN.add(astyle_c_files.map { |f| "#{f}.orig" })
   CLEAN.add(astyle_java_files.map { |f| "#{f}.orig" })
-  CLEAN.add("mkmf.log") # because of find_executable
 end
 
 task "format" => ["format:c", "format:java"]


### PR DESCRIPTION
**What problem is this PR intended to solve?**

- Speed up the one-time automake-based builds of libiconv, libxml2, and libxslt using the `--disable-dependency-tracking` option.
- Update `.editorconfig` for Java files to match the `astyle` formatting choices made in `rakelib/format.rake`
- Formatting uses `MakeMakefile.find_executable0` to discover `astyle` (instead of `.find_executable`) in order to avoid creating and cleaning up a stray `mkmf.log` file.


**Have you included adequate test coverage?**

The functional change, disabling dependency tracking, has plenty of test coverage already.


**Does this change affect the behavior of either the C or the Java implementations?**

No functional changes.