### PR TITLE
ci: check how fast/slow valgrind is on GA

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,24 @@
+# this is a work in progress!
+
+name: valgrind
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: flavorjones/nokogiri-test:mri-3.0
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        bundle install --local || bundle install
+        bundle exec rake compile -- --enable-system-libraries
+        bundle exec rake test:valgrind TESTOPTS=-v


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Let's experiment with a `rake test:valgrind` run on Github Actions. This action is taking ~1.5h on my Concourse instance on GCP lately, and I'm not sure why (it used to only take ~30 minutes).

Related to #2207 