### PR TITLE
test: adjust tests to pass on system libxml2 >= 2.9.11, and work around windows dll unloading issue

### DIFF
--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -137,6 +137,7 @@ module Nokogiri
             else
               libxml["source"] = "system"
             end
+            libxml["memory_management"] = Nokogiri::LIBXML_MEMORY_MANAGEMENT
             libxml["iconv_enabled"] = libxml2_has_iconv?
             libxml["compiled"] = compiled_libxml_version.to_s
             libxml["loaded"] = loaded_libxml_version.to_s

--- a/test/html/test_comments.rb
+++ b/test/html/test_comments.rb
@@ -113,8 +113,7 @@ module Nokogiri
         let(:subject) { doc.at_css("div#under-test") }
         let(:inner_div) { doc.at_css("div#do-i-exist") }
 
-        if Nokogiri.uses_libxml? && Nokogiri::VersionInfo.instance.libxml2_using_packaged?
-          # see patches/libxml2/0006-htmlParseComment-treat-as-if-it-closed-the-comment.patch
+        if Nokogiri::VersionInfo.instance.libxml2_using_packaged? || (Nokogiri::VersionInfo.instance.libxml2_using_system? && Nokogiri.uses_libxml?(">=2.9.11"))
           it "behaves as if the comment is normally closed" do # COMPLIANT
             assert_equal 3, subject.children.length
             assert subject.children[0].comment?
@@ -128,9 +127,7 @@ module Nokogiri
           end
         end
 
-        if Nokogiri.jruby? || Nokogiri::VersionInfo.instance.libxml2_using_system?
-          # this behavior may change to the above in libxml v2.9.11 depending on whether
-          # https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/82 is merged
+        if Nokogiri.jruby? || (Nokogiri::VersionInfo.instance.libxml2_using_system? && Nokogiri.uses_libxml?("<2.9.11"))
           it "behaves as if the comment encompasses the inner div" do # NON-COMPLIANT
             assert_equal 1, subject.children.length
             assert subject.children.first.comment?


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Adjust tests to pass on system libxml2 >= 2.9.11, because the comment parsing improvement was merged upstream. See https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/82 for context (and the recently removed `htmlParseComment` patch). This will allow us to run tests regularly against upstream master.

Also, work around the libxml2 issue described in #2241 by having libxml2 use its default memory management on windows when system libraries are being used. Note that this also introduces a new value into `Nokogiri::VERSION_INFO`, which is "libxml → memory_management", and the value will be either "ruby" or "default".
