### PR TITLE
Remove the default allocator function from Document

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -663,6 +663,8 @@ noko_init_xml_document()
    */
   cNokogiriXmlDocument = rb_define_class_under(mNokogiriXml, "Document", cNokogiriXmlNode);
 
+  rb_undef_alloc_func(cNokogiriXmlDocument);
+
   rb_define_singleton_method(cNokogiriXmlDocument, "read_memory", read_memory, 4);
   rb_define_singleton_method(cNokogiriXmlDocument, "read_io", read_io, 4);
   rb_define_singleton_method(cNokogiriXmlDocument, "new", new, -1);

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -15,6 +15,12 @@ module Nokogiri
 
         let(:xml) { Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) }
 
+        def test_allocation_is_not_allowed
+          assert_raises(TypeError) do
+            Nokogiri::XML::Document.allocate
+          end
+        end
+
         def test_dtd_with_empty_internal_subset
           doc = Nokogiri::XML(<<~eoxml)
             <?xml version="1.0"?>


### PR DESCRIPTION
We expect that XML documents will be of type T_DATA as they are backed
by a C extension.  It was possible for people to call `allocate` on
Document and end up with a T_OBJECT.  This commit removes the default
allocator so the only way to get a document object is via the
constructors we've defined.
