### PR TITLE
namespace behavior change when reparenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Many thanks to Sam Ruby, Steve Checkoway, and Craig Barnes for creating and main
 ### Fixed
 
 * [CRuby] Namespaced attributes are handled properly when their parent node is reparented into another document. Previously, the namespace may have gotten dropped. [[#2228](https://github.com/sparklemotion/nokogiri/issues/2228)]
+* [CRuby] Reparented nodes no longer inherit their parent's namespace. Previously, a node without a namespace was forced to adopt its parent's namespace. [[#1712](https://github.com/sparklemotion/nokogiri/issues/1712)]
 
 
 ### Improved

--- a/test/xml/test_builder.rb
+++ b/test/xml/test_builder.rb
@@ -107,6 +107,26 @@ module Nokogiri
         assert_equal "one", b.doc.at("hello", "xmlns" => "one").namespace.href
       end
 
+      def test_builder_namespace_children_do_not_inherit
+        # see https://github.com/sparklemotion/nokogiri/issues/1712
+        result = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
+          xml['soapenv'].Envelope('xmlns:soapenv' => 'http://schemas.xmlsoap.org/soap/envelope/', 'xmlns:emer' => 'http://dashcs.com/api/v1/emergency') do
+            xml['soapenv'].Header
+            xml['soapenv'].Body do
+              xml['emer'].validateLocation do
+                # these should not have a namespace
+                xml.location do
+                  xml.address 'Some place over the rainbow'
+                end
+              end
+            end
+          end
+        end
+        assert(result.doc.at_xpath("//emer:validateLocation", {"emer" => "http://dashcs.com/api/v1/emergency"}),
+                                   "expected validateLocation node to have a namespace")
+        assert(result.doc.at_xpath("//location"), "expected location node to not have a namespace")
+      end
+
       def test_specify_namespace
         b = Nokogiri::XML::Builder.new { |xml|
           xml.root("xmlns:foo" => "bar") do

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -334,7 +334,7 @@ module Nokogiri
           assert_equal(0, namespace_definitions.length)
         end
 
-        def test_namespace_goes_to_children
+        def test_default_namespace_goes_to_children
           fruits = Nokogiri::XML(<<~eoxml)
             <Fruit xmlns='www.fruits.org'>
             </Fruit>
@@ -345,6 +345,22 @@ module Nokogiri
           fruits.root << apple
           assert(fruits.at('//fruit:Orange', { 'fruit' => 'www.fruits.org' }))
           assert(fruits.at('//fruit:Apple', { 'fruit' => 'www.fruits.org' }))
+        end
+
+        def test_parent_namespace_is_not_inherited
+          fruits = Nokogiri::XML(<<-eoxml)
+            <fruit xmlns:fruit="http://fruits.org">
+              <fruit:apple />
+            </fruit>
+          eoxml
+
+          apple = fruits.at_xpath('//fruit:apple', {"fruit" => "http://fruits.org"})
+          assert(apple)
+
+          orange = Nokogiri::XML::Node.new('orange', fruits)
+          apple.add_child(orange)
+
+          assert_equal(orange, fruits.at_xpath('//orange'))
         end
 
         def test_description


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Add tests for the behavior change introduced by 1f483f0.

That behavior change fixes #1712


**Have you included adequate test coverage?**

Yarp.


**Does this change affect the behavior of either the C or the Java implementations?**

The Java implementation already exhibited this behavior; and 1f483f0 brought the two implementations in line with each other.