### PR TITLE
T_DATA classes should undef the allocator, or define a custom allocator

### DIFF
--- a/ext/nokogiri/html_element_description.c
+++ b/ext/nokogiri/html_element_description.c
@@ -274,6 +274,8 @@ noko_init_html_element_description()
 {
   cNokogiriHtmlElementDescription = rb_define_class_under(mNokogiriHtml, "ElementDescription", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriHtmlElementDescription);
+
   rb_define_singleton_method(cNokogiriHtmlElementDescription, "[]", get_description, 1);
 
   rb_define_method(cNokogiriHtmlElementDescription, "name", name, 0);

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -102,6 +102,7 @@ NOKOPUBVAR VALUE mNokogiriXmlSax ;
 NOKOPUBVAR VALUE mNokogiriXmlXpath ;
 NOKOPUBVAR VALUE mNokogiriXslt ;
 
+NOKOPUBVAR VALUE cNokogiriEncodingHandler;
 NOKOPUBVAR VALUE cNokogiriSyntaxError;
 NOKOPUBVAR VALUE cNokogiriXmlAttr;
 NOKOPUBVAR VALUE cNokogiriXmlAttributeDecl;

--- a/ext/nokogiri/xml_element_content.c
+++ b/ext/nokogiri/xml_element_content.c
@@ -116,6 +116,8 @@ noko_init_xml_element_content()
 {
   cNokogiriXmlElementContent = rb_define_class_under(mNokogiriXml, "ElementContent", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriXmlElementContent);
+
   rb_define_method(cNokogiriXmlElementContent, "name", get_name, 0);
   rb_define_method(cNokogiriXmlElementContent, "type", get_type, 0);
   rb_define_method(cNokogiriXmlElementContent, "occur", get_occur, 0);

--- a/ext/nokogiri/xml_encoding_handler.c
+++ b/ext/nokogiri/xml_encoding_handler.c
@@ -1,5 +1,8 @@
 #include <nokogiri.h>
 
+VALUE cNokogiriEncodingHandler;
+
+
 /*
  * call-seq: Nokogiri::EncodingHandler.[](name)
  *
@@ -75,11 +78,11 @@ name(VALUE self)
 void
 noko_init_xml_encoding_handler()
 {
-  VALUE klass = rb_define_class_under(mNokogiri, "EncodingHandler", rb_cObject);
+  cNokogiriEncodingHandler = rb_define_class_under(mNokogiri, "EncodingHandler", rb_cObject);
 
-  rb_define_singleton_method(klass, "[]", get, 1);
-  rb_define_singleton_method(klass, "delete", delete, 1);
-  rb_define_singleton_method(klass, "alias", alias, 2);
-  rb_define_singleton_method(klass, "clear_aliases!", clear_aliases, 0);
-  rb_define_method(klass, "name", name, 0);
+  rb_define_singleton_method(cNokogiriEncodingHandler, "[]", get, 1);
+  rb_define_singleton_method(cNokogiriEncodingHandler, "delete", delete, 1);
+  rb_define_singleton_method(cNokogiriEncodingHandler, "alias", alias, 2);
+  rb_define_singleton_method(cNokogiriEncodingHandler, "clear_aliases!", clear_aliases, 0);
+  rb_define_method(cNokogiriEncodingHandler, "name", name, 0);
 }

--- a/ext/nokogiri/xml_encoding_handler.c
+++ b/ext/nokogiri/xml_encoding_handler.c
@@ -80,6 +80,8 @@ noko_init_xml_encoding_handler()
 {
   cNokogiriEncodingHandler = rb_define_class_under(mNokogiri, "EncodingHandler", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriEncodingHandler);
+
   rb_define_singleton_method(cNokogiriEncodingHandler, "[]", get, 1);
   rb_define_singleton_method(cNokogiriEncodingHandler, "delete", delete, 1);
   rb_define_singleton_method(cNokogiriEncodingHandler, "alias", alias, 2);

--- a/ext/nokogiri/xml_namespace.c
+++ b/ext/nokogiri/xml_namespace.c
@@ -113,6 +113,8 @@ noko_init_xml_namespace()
 {
   cNokogiriXmlNamespace = rb_define_class_under(mNokogiriXml, "Namespace", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriXmlNamespace);
+
   rb_define_method(cNokogiriXmlNamespace, "prefix", prefix, 0);
   rb_define_method(cNokogiriXmlNamespace, "href", href, 0);
 }

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1760,6 +1760,8 @@ noko_init_xml_node()
 {
   cNokogiriXmlNode = rb_define_class_under(mNokogiriXml, "Node", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriXmlNode);
+
   rb_define_singleton_method(cNokogiriXmlNode, "new", rb_xml_node_new, -1);
 
   rb_define_method(cNokogiriXmlNode, "add_namespace_definition", add_namespace_definition, 2);

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -662,6 +662,8 @@ noko_init_xml_reader()
    */
   cNokogiriXmlReader = rb_define_class_under(mNokogiriXml, "Reader", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriXmlReader);
+
   rb_define_singleton_method(cNokogiriXmlReader, "from_memory", from_memory, -1);
   rb_define_singleton_method(cNokogiriXmlReader, "from_io", from_io, -1);
 

--- a/ext/nokogiri/xml_sax_parser_context.c
+++ b/ext/nokogiri/xml_sax_parser_context.c
@@ -265,6 +265,8 @@ noko_init_xml_sax_parser_context()
 {
   cNokogiriXmlSaxParserContext = rb_define_class_under(mNokogiriXmlSax, "ParserContext", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriXmlSaxParserContext);
+
   rb_define_singleton_method(cNokogiriXmlSaxParserContext, "io", parse_io, 2);
   rb_define_singleton_method(cNokogiriXmlSaxParserContext, "memory", parse_memory, 1);
   rb_define_singleton_method(cNokogiriXmlSaxParserContext, "file", parse_file, 1);

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -274,6 +274,8 @@ noko_init_xml_schema()
 {
   cNokogiriXmlSchema = rb_define_class_under(mNokogiriXml, "Schema", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriXmlSchema);
+
   rb_define_singleton_method(cNokogiriXmlSchema, "read_memory", read_memory, -1);
   rb_define_singleton_method(cNokogiriXmlSchema, "from_document", from_document, -1);
 

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -373,6 +373,8 @@ noko_init_xml_xpath_context(void)
    */
   cNokogiriXmlXpathContext = rb_define_class_under(mNokogiriXml, "XPathContext", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriXmlXpathContext);
+
   rb_define_singleton_method(cNokogiriXmlXpathContext, "new", new, 1);
 
   rb_define_method(cNokogiriXmlXpathContext, "evaluate", evaluate, -1);

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -257,6 +257,8 @@ noko_init_xslt_stylesheet()
 
   cNokogiriXsltStylesheet = rb_define_class_under(mNokogiriXslt, "Stylesheet", rb_cObject);
 
+  rb_undef_alloc_func(cNokogiriXsltStylesheet);
+
   rb_define_singleton_method(cNokogiriXsltStylesheet, "parse_stylesheet_doc", parse_stylesheet_doc, 1);
   rb_define_method(cNokogiriXsltStylesheet, "serialize", serialize, 1);
   rb_define_method(cNokogiriXsltStylesheet, "transform", transform, -1);


### PR DESCRIPTION
**What problem is this PR intended to solve?**

As specified in [`extensions.rdoc` on Ruby trunk](https://github.com/ruby/ruby/blob/master/doc/extension.rdoc), T_DATA classes should undefine (or redefine) the allocator function.

I test-drove these change by temporarily introducing this into `nokogiri.h`:

```c
static void
noko_check_allocator(VALUE klass)
{
  rb_alloc_func_t current_allocator = rb_get_alloc_func(klass);
  rb_alloc_func_t parent_allocator = rb_get_alloc_func(rb_cObject);
  if (current_allocator == parent_allocator) {
    VALUE class_name = rb_class_name(klass);
    fprintf(stderr, "MIKE: %s has the default allocator\n",
            StringValueCStr(class_name));
  }
}

static VALUE
noko_check_wrap(VALUE klass, RUBY_DATA_FUNC dmark, RUBY_DATA_FUNC dfree, void *sval)
{
  noko_check_allocator(klass);
  return rb_data_object_wrap(
    (klass),
    (sval),
    (dmark),
    (dfree));
}

static VALUE
noko_check_make(VALUE klass, RUBY_DATA_FUNC dmark, RUBY_DATA_FUNC dfree, void **sval, size_t size)
{
  noko_check_allocator(klass);
  return rb_data_object_make(
    (klass),
    (dmark),
    (dfree),
    ((void **)(sval)),
    size);
}

#undef Data_Wrap_Struct
#define Data_Wrap_Struct(klass, mark, free, sval) noko_check_wrap(klass, mark, free, sval)

#undef Data_Make_Struct
#define Data_Make_Struct(klass, type, mark, free, sval) noko_check_make(klass, mark, free, &sval, sizeof(type))
```

**Have you included adequate test coverage?**

:thinking: I've discussed with @tenderlove a bit about how to have better failing tests for this expectation of C extensions, and may submit something upstream to Ruby to do so. In the meantime, the above C snippet would be necessary to test for regressions.

**Does this change affect the behavior of either the C or the Java implementations?**

There should be no behavioral change.
