### PR TITLE
fix: `DocumentFragment#path` with libxml > 2.9.10

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1290,17 +1290,25 @@ get_name(VALUE self)
  * Returns the path associated with this Node
  */
 static VALUE
-path(VALUE self)
+noko_xml_node_path(VALUE rb_node)
 {
-  xmlNodePtr node;
-  xmlChar *path ;
+  xmlNodePtr c_node;
+  xmlChar *c_path ;
   VALUE rval;
 
-  Data_Get_Struct(self, xmlNode, node);
+  Data_Get_Struct(rb_node, xmlNode, c_node);
 
-  path = xmlGetNodePath(node);
-  rval = NOKOGIRI_STR_NEW2(path);
-  xmlFree(path);
+  c_path = xmlGetNodePath(c_node);
+  if (c_path == NULL) {
+    // see https://github.com/sparklemotion/nokogiri/issues/2250
+    // this behavior is clearly undesirable, but is what libxml <= 2.9.10 returned, and so we
+    // do this for now to preserve the behavior across libxml2 versions.
+    rval = NOKOGIRI_STR_NEW2("?");
+  } else {
+    rval = NOKOGIRI_STR_NEW2(c_path);
+    xmlFree(c_path);
+  }
+
   return rval ;
 }
 
@@ -1779,7 +1787,7 @@ noko_init_xml_node()
   rb_define_method(cNokogiriXmlNode, "next_element", next_element, 0);
   rb_define_method(cNokogiriXmlNode, "previous_element", previous_element, 0);
   rb_define_method(cNokogiriXmlNode, "node_type", node_type, 0);
-  rb_define_method(cNokogiriXmlNode, "path", path, 0);
+  rb_define_method(cNokogiriXmlNode, "path", noko_xml_node_path, 0);
   rb_define_method(cNokogiriXmlNode, "key?", key_eh, 1);
   rb_define_method(cNokogiriXmlNode, "namespaced_key?", namespaced_key_eh, 2);
   rb_define_method(cNokogiriXmlNode, "blank?", blank_eh, 0);

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -518,7 +518,7 @@ module Nokogiri
 
         def test_xpath_syntax_error
           assert_raises(Nokogiri::XML::XPath::SyntaxError) do
-            xml.xpath('\\')
+            xml.xpath("\\")
           end
         end
 
@@ -704,7 +704,7 @@ module Nokogiri
 
           # an arbitrary assertion on the structure of the document
           assert_equal(20, doc.xpath("/xmlns:feed/xmlns:entry/xmlns:author",
-                                     "xmlns" => "http://www.w3.org/2005/Atom").length)
+            "xmlns" => "http://www.w3.org/2005/Atom").length)
           assert_equal(XML_ATOM_FILE, doc.url)
         end
 
@@ -742,7 +742,7 @@ module Nokogiri
 
         def test_bad_xpath_raises_syntax_error
           assert_raises(XML::XPath::SyntaxError) do
-            xml.xpath('\\')
+            xml.xpath("\\")
           end
         end
 
@@ -957,16 +957,16 @@ module Nokogiri
                 rb_doc = Nokogiri::XML::Document.wrap(java_doc)
                 assert_equal(0, rb_doc.root.children.length)
 
-                java_doc.getFirstChild().appendChild(java_doc.createElement("bar"))
+                java_doc.getFirstChild.appendChild(java_doc.createElement("bar"))
                 assert_equal(1, rb_doc.root.children.length)
               end
 
               it "shares the same data structure as shown when modified via Nokogiri" do
                 rb_doc = Nokogiri::XML::Document.wrap(java_doc)
-                assert_equal(0, java_doc.getFirstChild().getChildNodes().getLength())
+                assert_equal(0, java_doc.getFirstChild.getChildNodes.getLength)
 
                 rb_doc.root.add_child("<bar />")
-                assert_equal(1, java_doc.getFirstChild().getChildNodes().getLength())
+                assert_equal(1, java_doc.getFirstChild.getChildNodes.getLength)
               end
             else
               it "does not have the method" do
@@ -984,22 +984,22 @@ module Nokogiri
               it "returns the underlying java object" do
                 java_doc = rb_doc.to_java
                 assert_kind_of(org.w3c.dom.Document, java_doc)
-                assert_equal("foo", java_doc.getDocumentElement().getTagName())
+                assert_equal("foo", java_doc.getDocumentElement.getTagName)
               end
 
               it "shares the same data structure as shown when modified via Nokogiri" do
                 java_doc = rb_doc.to_java
-                assert_equal(1, java_doc.getFirstChild().getChildNodes().getLength())
+                assert_equal(1, java_doc.getFirstChild.getChildNodes.getLength)
 
                 rb_doc.root.add_child("<baz />")
-                assert_equal(2, java_doc.getFirstChild().getChildNodes().getLength())
+                assert_equal(2, java_doc.getFirstChild.getChildNodes.getLength)
               end
 
               it "shares the same data structure as shown when modified via Java interop" do
                 java_doc = rb_doc.to_java
                 assert_equal(1, rb_doc.root.children.length)
 
-                java_doc.getFirstChild().appendChild(java_doc.createElement("baz"))
+                java_doc.getFirstChild.appendChild(java_doc.createElement("baz"))
                 assert_equal(2, rb_doc.root.children.length)
               end
             else
@@ -1145,9 +1145,9 @@ module Nokogiri
           end
 
           it "doesn't leak the replaced node" do
-            skip("only run if NOKOGIRI_GC is set") unless ENV['NOKOGIRI_GC']
+            skip("only run if NOKOGIRI_GC is set") unless ENV["NOKOGIRI_GC"]
             doc = Nokogiri::XML("<root>test</root>")
-            doc2 = Nokogiri::XML("<root>#{'x' * 5000000}</root>")
+            doc2 = Nokogiri::XML("<root>#{"x" * 5000000}</root>")
             doc2.root = doc.root
           end
 
@@ -1164,7 +1164,7 @@ module Nokogiri
             e = assert_raises(ArgumentError) do
               doc.root = node_set
             end
-            assert_equal("expected Nokogiri::XML::Node but received Nokogiri::XML::NodeSet", e.message);
+            assert_equal("expected Nokogiri::XML::Node but received Nokogiri::XML::NodeSet", e.message)
           end
         end
       end

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -1167,6 +1167,18 @@ module Nokogiri
             assert_equal("expected Nokogiri::XML::Node but received Nokogiri::XML::NodeSet", e.message)
           end
         end
+
+        describe "#path" do
+          it "should return '/'" do
+            xml = <<~EOF
+              <root></root>
+            EOF
+
+            doc = Nokogiri::XML::Document.parse(xml)
+            assert_equal("/", doc.path)
+            assert_equal(doc, doc.at_xpath(doc.path)) # make sure we can round-trip
+          end
+        end
       end
     end
   end

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -363,6 +363,25 @@ module Nokogiri
             end
           end
         end
+
+        describe "#path" do
+          it "should return '?'" do
+            # see https://github.com/sparklemotion/nokogiri/issues/2250
+            # this behavior is clearly undesirable, but is what libxml <= 2.9.10 returned, and so we
+            # do this for now to preserve the behavior across libxml2 versions.
+            xml = <<~EOF
+              <root1></root1>
+              <root2></root2>
+            EOF
+
+            frag = Nokogiri::XML::DocumentFragment.parse(xml)
+            assert_equal "?", frag.path
+
+            # # TODO: we should circle back and fix both the `#path` behavior and the `#xpath`
+            # # behavior so we can round-trip and get the DocumentFragment back again.
+            # assert_equal(frag, frag.at_xpath(doc.path)) # make sure we can round-trip
+          end
+        end
       end
     end
   end

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -11,26 +11,26 @@ module Nokogiri
           html = "foo"
           doc = Nokogiri::XML::DocumentFragment.parse(html)
           doc.children[0].replace("bar")
-          assert_equal('bar', doc.children[0].content)
+          assert_equal("bar", doc.children[0].content)
         end
 
         def test_fragment_is_relative
           doc      = Nokogiri::XML('<root><a xmlns="blah" /></root>')
           ctx      = doc.root.child
-          fragment = Nokogiri::XML::DocumentFragment.new(doc, '<hello />', ctx)
+          fragment = Nokogiri::XML::DocumentFragment.new(doc, "<hello />", ctx)
           hello    = fragment.child
 
-          assert_equal('hello', hello.name)
+          assert_equal("hello", hello.name)
           assert_equal(doc.root.child.namespace, hello.namespace)
         end
 
         def test_node_fragment_is_relative
           doc = Nokogiri::XML('<root><a xmlns="blah" /></root>')
           assert(doc.root.child)
-          fragment = doc.root.child.fragment('<hello />')
+          fragment = doc.root.child.fragment("<hello />")
           hello    = fragment.child
 
-          assert_equal('hello', hello.name)
+          assert_equal("hello", hello.name)
           assert_equal(doc.root.child.namespace, hello.namespace)
         end
 
@@ -45,7 +45,7 @@ module Nokogiri
 
         def test_name
           fragment = Nokogiri::XML::DocumentFragment.new(xml)
-          assert_equal('#document-fragment', fragment.name)
+          assert_equal("#document-fragment", fragment.name)
         end
 
         def test_static_method
@@ -112,12 +112,12 @@ module Nokogiri
           fragment = Nokogiri::XML::Document.new.fragment(
             '<div><p id="content">hi</p></div>'
           )
-          expected = fragment.children.xpath('.//p')
+          expected = fragment.children.xpath(".//p")
           assert_equal(1, expected.length)
 
-          css          = fragment.children.css('p')
-          search_css   = fragment.children.search('p')
-          search_xpath = fragment.children.search('.//p')
+          css          = fragment.children.css("p")
+          search_css   = fragment.children.search("p")
+          search_xpath = fragment.children.search(".//p")
           assert_equal(expected, css)
           assert_equal(expected, search_css)
           assert_equal(expected, search_xpath)
@@ -130,14 +130,14 @@ module Nokogiri
           fragment = Nokogiri::XML::DocumentFragment.parse(<<~EOXML)
             <p id="content">hi</p> x <!--y--> <p>another paragraph</p>
           EOXML
-          children = fragment.css('p')
+          children = fragment.css("p")
           assert_equal(2, children.length)
           # removing the last node instead does not yield the error. Probably the
           # node removal leaves around two consecutive text nodes which make the
           # css search crash?
           children.first.remove
-          assert_equal(1, fragment.xpath('.//p | self::p').length)
-          assert_equal(1, fragment.css('p').length)
+          assert_equal(1, fragment.xpath(".//p | self::p").length)
+          assert_equal(1, fragment.css("p").length)
         end
 
         def test_fragment_search_three_ways
@@ -146,13 +146,13 @@ module Nokogiri
           assert_equal(2, expected.length)
 
           [
-            [:css, '#content'],
-            [:search, '#content'],
-            [:search, './*[@id = \'content\']'],
+            [:css, "#content"],
+            [:search, "#content"],
+            [:search, "./*[@id = 'content']"],
           ].each do |method, query|
             result = frag.send(method, query)
             assert_equal(expected, result,
-                         "fragment search with :#{method} using '#{query}' expected '#{expected}' got '#{result}'")
+              "fragment search with :#{method} using '#{query}' expected '#{expected}' got '#{result}'")
           end
         end
 
@@ -169,9 +169,9 @@ module Nokogiri
           fragment = Nokogiri::XML.fragment(xml)
           assert_kind_of(Nokogiri::XML::DocumentFragment, fragment)
 
-          assert_equal(3, fragment.xpath('.//div', './/p').length)
-          assert_equal(3, fragment.css('.title', '.content', 'p').length)
-          assert_equal(3, fragment.search('.//div', 'p.blah').length)
+          assert_equal(3, fragment.xpath(".//div", ".//p").length)
+          assert_equal(3, fragment.css(".title", ".content", "p").length)
+          assert_equal(3, fragment.search(".//div", "p.blah").length)
         end
 
         def test_fragment_without_a_namespace_does_not_get_a_namespace
@@ -215,7 +215,7 @@ module Nokogiri
           util_decorate(xml, x)
           fragment = Nokogiri::XML::DocumentFragment.new(xml, "<div>a</div><div>b</div>")
 
-          assert(node_set = fragment.css('div'))
+          assert(node_set = fragment.css("div"))
           assert(node_set.respond_to?(:awesome!))
           node_set.each do |node|
             assert(node.respond_to?(:awesome!), node.class)
@@ -234,8 +234,8 @@ module Nokogiri
         end
 
         def test_add_node_to_doc_fragment_segfault
-          frag = Nokogiri::XML::DocumentFragment.new(xml, '<p>hello world</p>')
-          Nokogiri::XML::Comment.new(frag, 'moo')
+          frag = Nokogiri::XML::DocumentFragment.new(xml, "<p>hello world</p>")
+          Nokogiri::XML::Comment.new(frag, "moo")
         end
 
         def test_issue_1077_parsing_of_frozen_strings


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes #2250 which describes a segfault when calling `DocumentFragment#path` with libxml > 2.9.10.

**Have you included adequate test coverage?**

Yes. Introduced test coverage for both `DocumentFragment#path` and `Document#path`

**Does this change affect the behavior of either the C or the Java implementations?**

This maintains the behavior of the C extension across versions of libxml2. That, however, doesn't mean that the behavior makes sense, and we should fix it when we're ready to introduce breaking changes into `DocumentFragment#xpath`.