### PR TITLE
fix(v1.11.x): `DocumentFragment#path` with libxml > 2.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## 1.11.6 / unreleased
+
+### Fixed
+
+* [CRuby] `DocumentFragment#xpath` checks for error case introduced in libxml > 2.9.10. In v1.11.4 and v1.11.5, calling `DocumentFragment#path` results in a segfault.
+
+
 ## 1.11.5 / 2021-05-19
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,6 +59,7 @@
     - [#572](https://github.com/sparklemotion/nokogiri/issues/572)
   could we fix this by making DocumentFragment be a subclass of NodeSet?
 
+* potentially related, we should figure out a way that we can round-trip `DocumentFragment#path` through `#xpath` and get the `DocumentFragment back again - [#2250](https://github.com/sparklemotion/nokogiri/issues/2250)
 
 ## Better Syntax for custom XPath function handler
 

--- a/rakelib/markdown.rake
+++ b/rakelib/markdown.rake
@@ -1,2 +1,2 @@
 require "hoe/markdown"
-Hoe::Markdown::Standalone.new("nokogiri").define_markdown_tasks("CHANGELOG.md", "CONTRIBUTING.md")
+Hoe::Markdown::Standalone.new("nokogiri").define_markdown_tasks("CHANGELOG.md", "CONTRIBUTING.md", "ROADMAP.md")

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -1167,6 +1167,18 @@ module Nokogiri
             assert_equal("expected Nokogiri::XML::Node but received Nokogiri::XML::NodeSet", e.message);
           end
         end
+
+        describe "#path" do
+          it "should return '/'" do
+            xml = <<~EOF
+              <root></root>
+            EOF
+
+            doc = Nokogiri::XML::Document.parse(xml)
+            assert_equal("/", doc.path)
+            assert_equal(doc, doc.at_xpath(doc.path)) # make sure we can round-trip
+          end
+        end
       end
     end
   end

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -363,6 +363,25 @@ module Nokogiri
             end
           end
         end
+
+        describe "#path" do
+          it "should return '?'" do
+            # see https://github.com/sparklemotion/nokogiri/issues/2250
+            # this behavior is clearly undesirable, but is what libxml <= 2.9.10 returned, and so we
+            # do this for now to preserve the behavior across libxml2 versions.
+            xml = <<~EOF
+              <root1></root1>
+              <root2></root2>
+            EOF
+
+            frag = Nokogiri::XML::DocumentFragment.parse(xml)
+            assert_equal "?", frag.path
+
+            # # TODO: we should circle back and fix both the `#path` behavior and the `#xpath`
+            # # behavior so we can round-trip and get the DocumentFragment back again.
+            # assert_equal(frag, frag.at_xpath(doc.path)) # make sure we can round-trip
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This is a version of PR #2251 that applies the fix for #2250 to the v1.11.x branch.