### PR TITLE
fix: address ruby 3.0 compiler warnings

### DIFF
--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -313,7 +313,7 @@ parse_args_mark(void *parse_args)
 static VALUE
 wrap_parse_args(ParseArgs *args)
 {
-  return Data_Wrap_Struct(rb_cData, parse_args_mark, RUBY_NEVER_FREE, args);
+  return Data_Wrap_Struct(rb_cObject, parse_args_mark, RUBY_NEVER_FREE, args);
 }
 
 // Returnsd the underlying ParseArgs wrapped by wrap_parse_args.

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -1,7 +1,7 @@
 #ifndef NOKOGIRI_NATIVE
 #define NOKOGIRI_NATIVE
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
 #  endif /* WIN32_LEAN_AND_MEAN */
@@ -15,7 +15,7 @@
 #  include <windows.h>
 #endif
 
-#if _WIN32
+#ifdef _WIN32
 #  define NOKOPUBFUN __declspec(dllexport)
 #  define NOKOPUBVAR __declspec(dllexport) extern
 #else


### PR DESCRIPTION
**What problem is this PR intended to solve?**

- Ruby 3.0 deprecates `rb_cData`
- Ruby head emits warnings around `_MSC_VER` and `_WIN32` macros
