### PR TITLE
build against upstream libxml2 and libxslt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,52 +162,6 @@ jobs:
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
 
-  ruby-head:
-    needs: ["basic"]
-    strategy:
-      fail-fast: false
-      matrix:
-        sys: ["enable", "disable"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: MSP-Greg/setup-ruby-pkgs@v1
-        with:
-          ruby-version: "head"
-          apt-get: "libxml2-dev libxslt1-dev pkg-config"
-          bundler-cache: true
-      - uses: actions/cache@v2
-        if: matrix.sys == 'disable'
-        with:
-          path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
-      - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
-      - run: bundle exec rake test
-
-  ruby-head-valgrind:
-    needs: ["ruby-head"]
-    strategy:
-      fail-fast: false
-      matrix:
-        sys: ["enable", "disable"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: MSP-Greg/setup-ruby-pkgs@v1
-        with:
-          ruby-version: "head"
-          apt-get: "libxml2-dev libxslt1-dev pkg-config valgrind"
-          bundler-cache: true
-      - uses: actions/cache@v2
-        if: matrix.sys == 'disable'
-        with:
-          path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
-      - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
-      - run: bundle exec rake test:valgrind
-
   osx:
     needs: ["basic"]
     strategy:
@@ -264,7 +218,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["jruby-9.2", "jruby-head"]
+        ruby: ["jruby-9.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,0 +1,40 @@
+name: upstream
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - v*.*.x
+    tags:
+      - v*.*.*
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - '*'
+  schedule:
+    - cron: "0 8 * * 1,3,5" # At 08:00 on Monday, Wednesday, and Friday # https://crontab.guru/#0_8_*_*_1,3,5
+
+jobs:
+  xmlsoft:
+    runs-on: ubuntu-latest
+    container:
+      image: flavorjones/nokogiri-test:mri-3.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup libxml2
+        run: |
+          git clone --depth=1 https://gitlab.gnome.org/GNOME/libxml2
+          cd libxml2
+          env NOCONFIGURE=t ./autogen.sh
+      - name: Setup libxslt
+        run: |
+          git clone --depth=1 https://gitlab.gnome.org/GNOME/libxslt
+          cd libxslt
+          env NOCONFIGURE=t ./autogen.sh
+      - name: "Run bundle install"
+        run: "bundle install --local || bundle install"
+      - name: "Compile against libxml2 and libxslt source directories"
+        run: "bundle exec rake compile -- --with-xml2-source-dir=${GITHUB_WORKSPACE}/libxml2 --with-xslt-source-dir=${GITHUB_WORKSPACE}/libxslt"
+      - name: "Run bundle exec rake test"
+        run: "env NOKOGIRI_TEST_GC_LEVEL=minor bundle exec rake test"
+      - run: "bundle exec rake test:valgrind"

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -15,7 +15,7 @@ on:
     - cron: "0 8 * * 1,3,5" # At 08:00 on Monday, Wednesday, and Friday # https://crontab.guru/#0_8_*_*_1,3,5
 
 jobs:
-  xmlsoft:
+  xmlsoft-head:
     runs-on: ubuntu-latest
     container:
       image: flavorjones/nokogiri-test:mri-3.0
@@ -35,6 +35,90 @@ jobs:
         run: "bundle install --local || bundle install"
       - name: "Compile against libxml2 and libxslt source directories"
         run: "bundle exec rake compile -- --with-xml2-source-dir=${GITHUB_WORKSPACE}/libxml2 --with-xslt-source-dir=${GITHUB_WORKSPACE}/libxslt"
-      - name: "Run bundle exec rake test"
-        run: "env NOKOGIRI_TEST_GC_LEVEL=minor bundle exec rake test"
+      - run: "bundle exec rake test"
+
+  xmlsoft-head-valgrind:
+    needs: ["xmlsoft-head"]
+    runs-on: ubuntu-latest
+    container:
+      image: flavorjones/nokogiri-test:mri-3.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup libxml2
+        run: |
+          git clone --depth=1 https://gitlab.gnome.org/GNOME/libxml2
+          cd libxml2
+          env NOCONFIGURE=t ./autogen.sh
+      - name: Setup libxslt
+        run: |
+          git clone --depth=1 https://gitlab.gnome.org/GNOME/libxslt
+          cd libxslt
+          env NOCONFIGURE=t ./autogen.sh
+      - name: "Run bundle install"
+        run: "bundle install --local || bundle install"
+      - name: "Compile against libxml2 and libxslt source directories"
+        run: "bundle exec rake compile -- --with-xml2-source-dir=${GITHUB_WORKSPACE}/libxml2 --with-xslt-source-dir=${GITHUB_WORKSPACE}/libxslt"
       - run: "bundle exec rake test:valgrind"
+
+  ruby-head:
+    strategy:
+      fail-fast: false
+      matrix:
+        plat: ["ubuntu", "windows", "macos"]
+        sys: ["enable", "disable"]
+    runs-on: ${{matrix.plat}}-latest
+    steps:
+      - name: configure git crlf
+        if: matrix.plat == 'windows'
+        run: |
+          git config --system core.autocrlf false
+          git config --system core.eol lf
+      - uses: actions/checkout@v2
+      - uses: MSP-Greg/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "head"
+          apt-get: "libxml2-dev libxslt1-dev pkg-config"
+          mingw: "libxml2 libxslt"
+          bundler-cache: true
+      - uses: actions/cache@v2
+        if: matrix.sys == 'disable'
+        with:
+          path: ports/archives
+          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          restore-keys: tarballs-
+      - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
+      - run: bundle exec rake test
+
+  ruby-head-valgrind:
+    needs: ["ruby-head"]
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: ["enable", "disable"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: MSP-Greg/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "head"
+          apt-get: "libxml2-dev libxslt1-dev pkg-config valgrind"
+          bundler-cache: true
+      - uses: actions/cache@v2
+        if: matrix.sys == 'disable'
+        with:
+          path: ports/archives
+          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          restore-keys: tarballs-
+      - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
+      - run: bundle exec rake test:valgrind
+
+  jruby-head:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "jruby-head"
+          bundler-cache: true
+      - run: bundle exec rake compile
+      - run: bundle exec rake test

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -14,7 +14,7 @@ RECOMMENDED_LIBXML_VERSION = "2.9.3"
 
 # The gem version constraint in the Rakefile is not respected at install time.
 # Keep this version in sync with the one in the Rakefile !
-REQUIRED_MINI_PORTILE_VERSION = "~> 2.5.1"
+REQUIRED_MINI_PORTILE_VERSION = "~> 2.6.1"
 REQUIRED_PKG_CONFIG_VERSION = "~> 1.1"
 
 # Keep track of what versions of what libraries we build against

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-ENV['RC_ARCHS'] = '' if RUBY_PLATFORM =~ /darwin/
+ENV["RC_ARCHS"] = "" if RUBY_PLATFORM =~ /darwin/
 
 require "mkmf"
 require "rbconfig"
@@ -8,7 +8,7 @@ require "shellwords"
 require "pathname"
 
 # helpful constants
-PACKAGE_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+PACKAGE_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
 REQUIRED_LIBXML_VERSION = "2.6.21"
 RECOMMENDED_LIBXML_VERSION = "2.9.3"
 
@@ -150,7 +150,7 @@ HELP
 #  utility functions
 #
 def config_clean?
-  enable_config('clean', true)
+  enable_config("clean", true)
 end
 
 def config_static?
@@ -164,24 +164,24 @@ end
 
 def config_system_libraries?
   enable_config("system-libraries", ENV.key?("NOKOGIRI_USE_SYSTEM_LIBRARIES")) do |_, default|
-    arg_config('--use-system-libraries', default)
+    arg_config("--use-system-libraries", default)
   end
 end
 
 def windows?
-  RbConfig::CONFIG['target_os'] =~ /mingw32|mswin/
+  RbConfig::CONFIG["target_os"] =~ /mingw32|mswin/
 end
 
 def solaris?
-  RbConfig::CONFIG['target_os'] =~ /solaris/
+  RbConfig::CONFIG["target_os"] =~ /solaris/
 end
 
 def darwin?
-  RbConfig::CONFIG['target_os'] =~ /darwin/
+  RbConfig::CONFIG["target_os"] =~ /darwin/
 end
 
 def openbsd?
-  RbConfig::CONFIG['target_os'] =~ /openbsd/
+  RbConfig::CONFIG["target_os"] =~ /openbsd/
 end
 
 def aix?
@@ -193,7 +193,7 @@ def nix?
 end
 
 def truffle?
-  ::RUBY_ENGINE == 'truffleruby'
+  ::RUBY_ENGINE == "truffleruby"
 end
 
 def concat_flags(*args)
@@ -222,9 +222,9 @@ def try_package_configuration(pc)
   # let's fall back to the pkg-config gem, which knows how to parse .pc files, and wrap it with the
   # same logic as MakeMakefile#pkg_config
   begin
-    require 'rubygems'
-    gem('pkg-config', REQUIRED_PKG_CONFIG_VERSION)
-    require 'pkg-config'
+    require "rubygems"
+    gem("pkg-config", REQUIRED_PKG_CONFIG_VERSION)
+    require "pkg-config"
 
     checking_for("#{pc} using pkg-config gem version #{PKGConfig::VERSION}", LOCAL_PACKAGE_RESPONSE) do
       if PKGConfig.have_package(pc)
@@ -285,7 +285,7 @@ def chdir_for_build
   # When using rake-compiler-dock on Windows, the underlying Virtualbox shared
   # folders don't support symlinks, but libiconv expects it for a build on
   # Linux. We work around this limitation by using the temp dir for cooking.
-  build_dir = ENV['RCD_HOST_RUBY_PLATFORM'].to_s =~ /mingw|mswin|cygwin/ ? '/tmp' : '.'
+  build_dir = ENV["RCD_HOST_RUBY_PLATFORM"].to_s =~ /mingw|mswin|cygwin/ ? "/tmp" : "."
   Dir.chdir(build_dir) do
     yield
   end
@@ -339,8 +339,8 @@ def have_libxml_headers?(version = nil)
 end
 
 def try_link_iconv(using = nil)
-  checking_for(using ? "iconv using #{using}" : 'iconv') do
-    ['', '-liconv'].any? do |opt|
+  checking_for(using ? "iconv using #{using}" : "iconv") do
+    ["", "-liconv"].any? do |opt|
       preserving_globals do
         yield if block_given?
 
@@ -371,22 +371,22 @@ def iconv_configure_flags
     end
 
     return [
-      '--with-iconv=yes',
-      *("CPPFLAGS=#{idirs.map { |dir| '-I' + dir }.join(' ')}" if idirs),
-      *("LDFLAGS=#{ldirs.map { |dir| '-L' + dir }.join(' ')}" if ldirs),
+      "--with-iconv=yes",
+      *("CPPFLAGS=#{idirs.map { |dir| "-I" + dir }.join(" ")}" if idirs),
+      *("LDFLAGS=#{ldirs.map { |dir| "-L" + dir }.join(" ")}" if ldirs),
     ]
   end
 
   if try_link_iconv
-    return ['--with-iconv=yes']
+    return ["--with-iconv=yes"]
   end
 
-  config = preserving_globals { have_package_configuration('libiconv') }
-  if config && try_link_iconv('pkg-config libiconv') { have_package_configuration('libiconv') }
+  config = preserving_globals { have_package_configuration("libiconv") }
+  if config && try_link_iconv("pkg-config libiconv") { have_package_configuration("libiconv") }
     cflags, ldflags, libs = config
 
     return [
-      '--with-iconv=yes',
+      "--with-iconv=yes",
       "CPPFLAGS=#{cflags}",
       "LDFLAGS=#{ldflags}",
       "LIBS=#{libs}",
@@ -397,9 +397,9 @@ def iconv_configure_flags
 end
 
 def process_recipe(name, version, static_p, cross_p)
-  require 'rubygems'
-  gem('mini_portile2', REQUIRED_MINI_PORTILE_VERSION)
-  require 'mini_portile2'
+  require "rubygems"
+  gem("mini_portile2", REQUIRED_MINI_PORTILE_VERSION)
+  require "mini_portile2"
   message("Using mini_portile version #{MiniPortile::VERSION}\n")
 
   unless ["libxml2", "libxslt"].include?(name)
@@ -412,7 +412,7 @@ def process_recipe(name, version, static_p, cross_p)
     # correct compiler prefix for cross build, but use host if not set.
     recipe.host = RbConfig::CONFIG["host_alias"].empty? ? RbConfig::CONFIG["host"] : RbConfig::CONFIG["host_alias"]
     recipe.patch_files = Dir[File.join(PACKAGE_ROOT_DIR, "patches", name, "*.patch")].sort
-    recipe.configure_options << "--libdir=#{File.join(recipe.path, 'lib')}"
+    recipe.configure_options << "--libdir=#{File.join(recipe.path, "lib")}"
 
     yield recipe
 
@@ -456,10 +456,10 @@ def process_recipe(name, version, static_p, cross_p)
       ]
     end
 
-    if RbConfig::CONFIG['target_cpu'] == 'universal'
+    if RbConfig::CONFIG["target_cpu"] == "universal"
       %w[CFLAGS LDFLAGS].each do |key|
-        unless env[key].include?('-arch')
-          env[key] = concat_flags(env[key], RbConfig::CONFIG['ARCH_FLAG'])
+        unless env[key].include?("-arch")
+          env[key] = concat_flags(env[key], RbConfig::CONFIG["ARCH_FLAG"])
         end
       end
     end
@@ -497,7 +497,7 @@ def process_recipe(name, version, static_p, cross_p)
 
       EOM
 
-      message(<<~EOM) if name == 'libxml2'
+      message(<<~EOM) if name == "libxml2"
         Note, however, that nokogiri cannot guarantee compatibility with every
         version of libxml2 that may be provided by OS/package vendors.
 
@@ -516,7 +516,7 @@ def copy_packaged_libraries_headers(to_path:, from_recipes:)
   FileUtils.rm_rf(to_path, secure: true)
   FileUtils.mkdir(to_path)
   from_recipes.each do |recipe|
-    FileUtils.cp_r(Dir[File.join(recipe.path, 'include/*')], to_path)
+    FileUtils.cp_r(Dir[File.join(recipe.path, "include/*")], to_path)
   end
 end
 
@@ -530,22 +530,22 @@ def do_clean
   pwd  = Pathname(Dir.pwd)
 
   # Skip if this is a development work tree
-  unless (root + '.git').exist?
+  unless (root + ".git").exist?
     message("Cleaning files only used during build.\n")
 
     # (root + 'tmp') cannot be removed at this stage because
     # nokogiri.so is yet to be copied to lib.
 
     # clean the ports build directory
-    Pathname.glob(pwd.join('tmp', '*', 'ports')) do |dir|
+    Pathname.glob(pwd.join("tmp", "*", "ports")) do |dir|
       FileUtils.rm_rf(dir, verbose: true)
     end
 
     if config_static?
       # ports installation can be safely removed if statically linked.
-      FileUtils.rm_rf(root + 'ports', verbose: true)
+      FileUtils.rm_rf(root + "ports", verbose: true)
     else
-      FileUtils.rm_rf(root + 'ports' + 'archives', verbose: true)
+      FileUtils.rm_rf(root + "ports" + "archives", verbose: true)
     end
   end
 
@@ -555,25 +555,25 @@ end
 #
 #  main
 #
-do_help if arg_config('--help')
-do_clean if arg_config('--clean')
+do_help if arg_config("--help")
+do_clean if arg_config("--clean")
 
 if openbsd? && !config_system_libraries?
-  if %x(#{ENV['CC'] || '/usr/bin/cc'} -v 2>&1) !~ /clang/
-    (ENV['CC'] ||= find_executable('egcc')) ||
+  if %x(#{ENV["CC"] || "/usr/bin/cc"} -v 2>&1) !~ /clang/
+    (ENV["CC"] ||= find_executable("egcc")) ||
       abort("Please install gcc 4.9+ from ports using `pkg_add -v gcc`")
   end
   append_cppflags "-I/usr/local/include"
 end
 
-if ENV['CC']
-  RbConfig::CONFIG['CC'] = RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC']
+if ENV["CC"]
+  RbConfig::CONFIG["CC"] = RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"]
 end
 
 # use same c compiler for libxml and libxslt
-ENV['CC'] = RbConfig::CONFIG['CC']
+ENV["CC"] = RbConfig::CONFIG["CC"]
 
-if arg_config('--prevent-strip')
+if arg_config("--prevent-strip")
   old_cflags = $CFLAGS.split.join(" ")
   old_ldflags = $LDFLAGS.split.join(" ")
   old_dldflags = $DLDFLAGS.split.join(" ")
@@ -619,13 +619,13 @@ append_cppflags(' "-Idummypath"') if windows?
 if config_system_libraries?
   message "Building nokogiri using system libraries.\n"
   ensure_package_configuration(opt: "zlib", pc: "zlib", lib: "z",
-                               headers: "zlib.h", func: "gzdopen")
+    headers: "zlib.h", func: "gzdopen")
   ensure_package_configuration(opt: "xml2", pc: "libxml-2.0", lib: "xml2",
-                               headers: "libxml/parser.h", func: "xmlParseDoc")
+    headers: "libxml/parser.h", func: "xmlParseDoc")
   ensure_package_configuration(opt: "xslt", pc: "libxslt", lib: "xslt",
-                               headers: "libxslt/xslt.h", func: "xsltParseStylesheetDoc")
+    headers: "libxslt/xslt.h", func: "xsltParseStylesheetDoc")
   ensure_package_configuration(opt: "exslt", pc: "libexslt", lib: "exslt",
-                               headers: "libexslt/exslt.h", func: "exsltFuncRegister")
+    headers: "libexslt/exslt.h", func: "exsltFuncRegister")
 
   have_libxml_headers?(REQUIRED_LIBXML_VERSION) ||
     abort("ERROR: libxml2 version #{REQUIRED_LIBXML_VERSION} or later is required!")
@@ -636,15 +636,15 @@ else
   message "Building nokogiri using packaged libraries.\n"
 
   static_p = config_static?
-  message "Static linking is #{static_p ? 'enabled' : 'disabled'}.\n"
+  message "Static linking is #{static_p ? "enabled" : "disabled"}.\n"
 
   cross_build_p = config_cross_build?
-  message "Cross build is #{cross_build_p ? 'enabled' : 'disabled'}.\n"
+  message "Cross build is #{cross_build_p ? "enabled" : "disabled"}.\n"
 
-  require 'yaml'
+  require "yaml"
   dependencies = YAML.load_file(File.join(PACKAGE_ROOT_DIR, "dependencies.yml"))
 
-  dir_config('zlib')
+  dir_config("zlib")
 
   if cross_build_p || windows?
     zlib_recipe = process_recipe("zlib", dependencies["zlib"]["version"], static_p, cross_build_p) do |recipe|
@@ -658,8 +658,8 @@ else
 
           def configure
             Dir.chdir(work_path) do
-              mk = File.read('win32/Makefile.gcc')
-              File.open('win32/Makefile.gcc', 'wb') do |f|
+              mk = File.read("win32/Makefile.gcc")
+              File.open("win32/Makefile.gcc", "wb") do |f|
                 f.puts "BINARY_PATH = #{path}/bin"
                 f.puts "LIBRARY_PATH = #{path}/lib"
                 f.puts "INCLUDE_PATH = #{path}/include"
@@ -671,7 +671,7 @@ else
 
           def configured?
             Dir.chdir(work_path) do
-              !!(File.read('win32/Makefile.gcc') =~ /^BINARY_PATH/)
+              !!(File.read("win32/Makefile.gcc") =~ /^BINARY_PATH/)
             end
           end
 
@@ -689,7 +689,7 @@ else
           def configure
             cflags = concat_flags(ENV["CFLAGS"], "-fPIC", "-g")
             execute("configure",
-["env", "CHOST=#{host}", "CFLAGS=#{cflags}", "./configure", "--static", configure_prefix])
+              ["env", "CHOST=#{host}", "CFLAGS=#{cflags}", "./configure", "--static", configure_prefix])
           end
 
           def compile
@@ -705,7 +705,7 @@ else
 
     unless nix?
       libiconv_recipe = process_recipe("libiconv", dependencies["libiconv"]["version"], static_p,
-cross_build_p) do |recipe|
+        cross_build_p) do |recipe|
         recipe.files = [{
           url: "http://ftp.gnu.org/pub/gnu/libiconv/#{recipe.name}-#{recipe.version}.tar.gz",
           sha256: dependencies["libiconv"]["sha256"],
@@ -722,7 +722,7 @@ cross_build_p) do |recipe|
         ]
       end
     end
-  elsif darwin? && !have_header('iconv.h')
+  elsif darwin? && !have_header("iconv.h")
     abort(<<~EOM.chomp)
       -----
       The file "iconv.h" is missing in your build environment,
@@ -738,8 +738,8 @@ cross_build_p) do |recipe|
   end
 
   unless windows?
-    preserving_globals { local_have_library('z', 'gzdopen', 'zlib.h') } ||
-      abort('zlib is missing; necessary for building libxml2')
+    preserving_globals { local_have_library("z", "gzdopen", "zlib.h") } ||
+      abort("zlib is missing; necessary for building libxml2")
   end
 
   libxml2_recipe = process_recipe("libxml2", dependencies["libxml2"]["version"], static_p, cross_build_p) do |recipe|
@@ -813,12 +813,12 @@ cross_build_p) do |recipe|
       libname = recipe.name[/\Alib(.+)\z/, 1]
       File.join(recipe.path, "bin", "#{libname}-config").tap do |config|
         # call config scripts explicit with 'sh' for compat with Windows
-        $CPPFLAGS = %x(sh #{config} --cflags).strip << ' ' << $CPPFLAGS
+        $CPPFLAGS = %x(sh #{config} --cflags).strip << " " << $CPPFLAGS
         %x(sh #{config} --libs).strip.shellsplit.each do |arg|
           case arg
           when /\A-L(.+)\z/
             # Prioritize ports' directories
-            $LIBPATH = if Regexp.last_match(1).start_with?(PACKAGE_ROOT_DIR + '/')
+            $LIBPATH = if Regexp.last_match(1).start_with?(PACKAGE_ROOT_DIR + "/")
               [Regexp.last_match(1)] | $LIBPATH
             else
               $LIBPATH | [Regexp.last_match(1)]
@@ -826,26 +826,26 @@ cross_build_p) do |recipe|
           when /\A-l./
             libs.unshift(arg)
           else
-            $LDFLAGS << ' ' << arg.shellescape
+            $LDFLAGS << " " << arg.shellescape
           end
         end
       end
 
-      patches_string = recipe.patch_files.map { |path| File.basename(path) }.join(' ')
+      patches_string = recipe.patch_files.map { |path| File.basename(path) }.join(" ")
       append_cppflags(%[-DNOKOGIRI_#{recipe.name.upcase}_PATCHES="\\\"#{patches_string}\\\""])
 
       case libname
-      when 'xml2'
+      when "xml2"
         # xslt-config --libs or pkg-config libxslt --libs does not include
         # -llzma, so we need to add it manually when linking statically.
-        if static_p && preserving_globals { local_have_library('lzma') }
+        if static_p && preserving_globals { local_have_library("lzma") }
           # Add it at the end; GH #988
-          libs << '-llzma'
+          libs << "-llzma"
         end
-      when 'xslt'
+      when "xslt"
         # xslt-config does not have a flag to emit options including
         # -lexslt, so add it manually.
-        libs.unshift('-lexslt')
+        libs.unshift("-lexslt")
       end
     end
   end.shelljoin
@@ -853,10 +853,10 @@ cross_build_p) do |recipe|
   if static_p
     $libs = $libs.shellsplit.map do |arg|
       case arg
-      when '-lxml2'
-        File.join(libxml2_recipe.path, 'lib', libflag_to_filename(arg))
-      when '-lxslt', '-lexslt'
-        File.join(libxslt_recipe.path, 'lib', libflag_to_filename(arg))
+      when "-lxml2"
+        File.join(libxml2_recipe.path, "lib", libflag_to_filename(arg))
+      when "-lxslt", "-lexslt"
+        File.join(libxslt_recipe.path, "lib", libflag_to_filename(arg))
       else
         arg
       end
@@ -878,9 +878,9 @@ libgumbo_recipe = process_recipe("libgumbo", "1.0.0-nokogiri", static_p, cross_b
 
     def extract
       target = File.join(tmp_path, "gumbo-parser")
-      output "Copying gumbo-parser files into #{target}..."
-      FileUtils.mkdir_p target
-      FileUtils.cp Dir.glob(File.join(PACKAGE_ROOT_DIR, "gumbo-parser/src/*")), target
+      output("Copying gumbo-parser files into #{target}...")
+      FileUtils.mkdir_p(target)
+      FileUtils.cp(Dir.glob(File.join(PACKAGE_ROOT_DIR, "gumbo-parser/src/*")), target)
     end
 
     def configured?
@@ -891,14 +891,14 @@ libgumbo_recipe = process_recipe("libgumbo", "1.0.0-nokogiri", static_p, cross_b
       lib_dir = File.join(port_path, "lib")
       inc_dir = File.join(port_path, "include")
       FileUtils.mkdir_p([lib_dir, inc_dir])
-      FileUtils.cp File.join(work_path, "libgumbo.a"), lib_dir
-      FileUtils.cp Dir.glob(File.join(work_path, "*.h")), inc_dir
+      FileUtils.cp(File.join(work_path, "libgumbo.a"), lib_dir)
+      FileUtils.cp(Dir.glob(File.join(work_path, "*.h")), inc_dir)
     end
 
     def compile
       cflags = concat_flags(ENV["CFLAGS"], "-fPIC", "-g")
 
-      env = {"CC" => gcc_cmd, "CFLAGS" => cflags}
+      env = { "CC" => gcc_cmd, "CFLAGS" => cflags }
       if config_cross_build?
         if host =~ /darwin/
           env["AR"] = "#{host}-libtool"
@@ -909,7 +909,7 @@ libgumbo_recipe = process_recipe("libgumbo", "1.0.0-nokogiri", static_p, cross_b
         env["RANLIB"] = "#{host}-ranlib"
       end
 
-      execute("compile", make_cmd, {env: env})
+      execute("compile", make_cmd, { env: env })
     end
   end
 end
@@ -918,14 +918,14 @@ $libs = $libs + " " + File.join(libgumbo_recipe.path, "lib", "libgumbo.a")
 $LIBPATH = $LIBPATH | [File.join(libgumbo_recipe.path, "lib")]
 ensure_func("gumbo_parse_with_options", "gumbo.h")
 
-have_func('xmlHasFeature') || abort("xmlHasFeature() is missing.") # introduced in libxml 2.6.21
-have_func('xmlFirstElementChild') # introduced in libxml 2.7.3
-have_func('xmlRelaxNGSetParserStructuredErrors') # introduced in libxml 2.6.24
-have_func('xmlRelaxNGSetValidStructuredErrors') # introduced in libxml 2.6.21
-have_func('xmlSchemaSetValidStructuredErrors') # introduced in libxml 2.6.23
-have_func('xmlSchemaSetParserStructuredErrors') # introduced in libxml 2.6.23
+have_func("xmlHasFeature") || abort("xmlHasFeature() is missing.") # introduced in libxml 2.6.21
+have_func("xmlFirstElementChild") # introduced in libxml 2.7.3
+have_func("xmlRelaxNGSetParserStructuredErrors") # introduced in libxml 2.6.24
+have_func("xmlRelaxNGSetValidStructuredErrors") # introduced in libxml 2.6.21
+have_func("xmlSchemaSetValidStructuredErrors") # introduced in libxml 2.6.23
+have_func("xmlSchemaSetParserStructuredErrors") # introduced in libxml 2.6.23
 
-have_func('vasprintf')
+have_func("vasprintf")
 
 other_library_versions_string = OTHER_LIBRARY_VERSIONS.map { |k, v| [k, v].join(":") }.join(",")
 append_cppflags(%[-DNOKOGIRI_OTHER_LIBRARY_VERSIONS="\\\"#{other_library_versions_string}\\\""])
@@ -935,25 +935,25 @@ unless config_system_libraries?
     # When precompiling native gems, copy packaged libraries' headers to ext/nokogiri/include
     # These are packaged up by the cross-compiling callback in the ExtensionTask
     copy_packaged_libraries_headers(to_path: File.join(PACKAGE_ROOT_DIR, "ext/nokogiri/include"),
-                                    from_recipes: [libxml2_recipe, libxslt_recipe])
+      from_recipes: [libxml2_recipe, libxslt_recipe])
   else
     # When compiling during installation, install packaged libraries' header files into ext/nokogiri/include
     copy_packaged_libraries_headers(to_path: "include",
-                                    from_recipes: [libxml2_recipe, libxslt_recipe])
+      from_recipes: [libxml2_recipe, libxslt_recipe])
     $INSTALLFILES << ["include/**/*.h", "$(rubylibdir)"]
   end
 end
 
-create_makefile('nokogiri/nokogiri')
+create_makefile("nokogiri/nokogiri")
 
 if config_clean?
   # Do not clean if run in a development work tree.
-  File.open('Makefile', 'at') do |mk|
+  File.open("Makefile", "at") do |mk|
     mk.print(<<~EOF)
 
       all: clean-ports
       clean-ports: $(DLLIB)
-      \t-$(Q)$(RUBY) $(srcdir)/extconf.rb --clean --#{static_p ? 'enable' : 'disable'}-static
+      \t-$(Q)$(RUBY) $(srcdir)/extconf.rb --clean --#{static_p ? "enable" : "disable"}-static
     EOF
   end
 end

--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -316,7 +316,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
 
   spec.add_runtime_dependency("racc", "~> 1.4")
-  spec.add_runtime_dependency("mini_portile2", "~> 2.5.1") unless java_p # keep version in sync with extconf.rb
+  spec.add_runtime_dependency("mini_portile2", "~> 2.6.1") unless java_p # keep version in sync with extconf.rb
 
   spec.add_development_dependency("bundler", "~> 2.2")
   spec.add_development_dependency("concourse", "~> 0.41")

--- a/test/html/test_attributes_properly_escaped.rb
+++ b/test/html/test_attributes_properly_escaped.rb
@@ -5,7 +5,9 @@ module Nokogiri
     class TestAttributesProperlyEscaped < Nokogiri::TestCase
 
       def test_attribute_macros_are_escaped
-        skip if Nokogiri::VersionInfo.instance.libxml2? && Nokogiri::VersionInfo.instance.libxml2_using_system?
+        if Nokogiri.uses_libxml? && !Nokogiri::VERSION_INFO["libxml"]["patches"]&.include?("0001-Remove-script-macro-support.patch")
+          skip("libxml2 has not been patched to be safe against attribute macros")
+        end
 
         html = "<p><i for=\"&{<test>}\"></i></p>"
         document = Nokogiri::HTML::Document.new
@@ -15,7 +17,9 @@ module Nokogiri
       end
 
       def test_libxml_escapes_server_side_includes
-        skip if Nokogiri::VersionInfo.instance.libxml2? && Nokogiri::VersionInfo.instance.libxml2_using_system?
+        if Nokogiri.uses_libxml? && !Nokogiri::VERSION_INFO["libxml"]["patches"]&.include?("0002-Update-entities-to-remove-handling-of-ssi.patch")
+          skip("libxml2 has not been patched to be safe against SSI")
+        end
 
         original_html = %(<p><a href='<!--"><test>-->'></a></p>)
         document = Nokogiri::HTML::Document.new
@@ -25,7 +29,9 @@ module Nokogiri
       end
 
       def test_libxml_escapes_server_side_includes_without_nested_quotes
-        skip if Nokogiri::VersionInfo.instance.libxml2? && Nokogiri::VersionInfo.instance.libxml2_using_system?
+        if Nokogiri.uses_libxml? && !Nokogiri::VERSION_INFO["libxml"]["patches"]&.include?("0002-Update-entities-to-remove-handling-of-ssi.patch")
+          skip("libxml2 has not been patched to be safe against SSI")
+        end
 
         original_html = %(<p><i for="<!--<test>-->"></i></p>)
         document = Nokogiri::HTML::Document.new


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Do more-frequent integration testing with upstream libraries, to find issues early. Related to #2247.

- update to mini_portile 2.6.0
- modify extconf.rb
- make sure tests will be green against unpatched upstream today
- add a github actions pipeline
