### PR TITLE
fix: libxml2 xpath recursion limit bug (v1.11.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## 1.11.7 / unreleased
+
+* [CRuby] Backporting an upstream fix to XPath recursion depth limits which impacted some users of complex XPath queries. This issue is present in libxml 2.9.11 and 2.9.12. [[#2257](https://github.com/sparklemotion/nokogiri/issues/2257)]
+
+
 ## 1.11.6 / 2021-05-26
 
 ### Fixed

--- a/patches/libxml2/0007-Fix-XPath-recursion-limit.patch
+++ b/patches/libxml2/0007-Fix-XPath-recursion-limit.patch
@@ -1,0 +1,31 @@
+From 3e1aad4fe584747fd7d17cc7b2863a78e2d21a77 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Wed, 2 Jun 2021 17:31:49 +0200
+Subject: [PATCH] Fix XPath recursion limit
+
+Fix accounting of recursion depth when parsing XPath expressions.
+
+This silly bug introduced in commit 804c5297 could lead to spurious
+errors when parsing larger expressions or XSLT documents.
+
+Should fix #264.
+---
+ xpath.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xpath.c b/xpath.c
+index 7497ba0..1aa2f1a 100644
+--- a/xpath.c
++++ b/xpath.c
+@@ -10983,7 +10983,7 @@ xmlXPathCompileExpr(xmlXPathParserContextPtr ctxt, int sort) {
+     }
+ 
+     if (xpctxt != NULL)
+-        xpctxt->depth -= 1;
++        xpctxt->depth -= 10;
+ }
+ 
+ /**
+-- 
+2.31.0
+


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Backporting an upstream libxml2 fix for the problem described in #2257
