### PR TITLE
dev: switch from `rvm` to `rbenv` in scripts/test-gem-set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Clone https://github.com/sparklemotion/nokogiri and run `bundle install`.
 
 ### Advanced
 
-Please install the latest or previous version of CRuby (e.g., 3.0 or 2.7 as of 2021-02), and a recent version of JRuby. We recommend using a Ruby manager like `rvm` or `chruby` to make it easy to switch.
+Please install the latest or previous version of CRuby (e.g., 3.0 or 2.7 as of 2021-02), and a recent version of JRuby. We recommend using `rbenv`, which is used in test scripts when necessary to test gems against multiple rubies.
 
 Please install a system version of libxml2/libxslt (see [Installing Nokogiri](https://nokogiri.org/tutorials/installing_nokogiri.html#installing-using-standard-system-libraries) for details) so that you can test against both the packaged libraries and your system libraries.
 

--- a/scripts/test-gem-set
+++ b/scripts/test-gem-set
@@ -4,7 +4,7 @@
 #  - test-gem-file-contents
 #  - conditionally, if the local system can do it, test-gem-installation
 #
-source "$HOME/.rvm/scripts/rvm"
+eval "$(rbenv init - bash)"
 
 set -o errexit
 set -o pipefail
@@ -18,9 +18,8 @@ function remove_all_nokogiris {
 function install_and_test {
   gem=$1
   if [[ $gem =~ "java" ]] ; then
-    rvm use jruby
-  else
-    rvm use default
+    jruby_version=$(rbenv versions --bare | fgrep jruby | sort | tail -1)
+    rbenv shell ${jruby_version}
   fi
   remove_all_nokogiris
   gem install --local $gem
@@ -34,8 +33,6 @@ function install_and_test {
 }
 
 gems=$*
-
-rvm use default
 
 for gem in $gems ; do
   ./scripts/test-gem-file-contents $gem


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Recommending that developers of Nokogiri use `rbenv` instead of `rvm` to enable us to more easily test against custom Ruby builds (like the "extensions check" PR I'm writing for upstream Ruby).

We only use RVM in one place: installing and testing the built gems with `scripts/test-gem-set` (and that's only used from `scripts/build-gems`). This PR replaces it with `rbenv`.
