### PR TITLE
ci: github actions concurrency and cancel-in-progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: ci
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -1,4 +1,7 @@
 name: gem-install
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,4 +1,7 @@
 name: upstream
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Trying to optimize feedback loops: If a branch CI is already running, and another commit is pushed, cancel CI in progress.
