### PR TITLE
CI: Add UCRT based test on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,12 +33,22 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: 30
-    - ruby_version: 30
+    - ruby_version: head-x64
+    - ruby_version: head-x64
+      INSTALL_PACKAGES: "mingw-w64-ucrt-x86_64-libxslt"
+      EXTCONF_PARAMS: "--use-system-libraries"
+
+    - ruby_version: head-x86
+    - ruby_version: head-x86
       INSTALL_PACKAGES: "mingw-w64-i686-libxslt"
       EXTCONF_PARAMS: "--use-system-libraries"
 
-    - ruby_version: 27
-    - ruby_version: 27
+    - ruby_version: 25
+    - ruby_version: 25
       INSTALL_PACKAGES: "mingw-w64-i686-libxslt"
       EXTCONF_PARAMS: "--use-system-libraries"
+
+matrix:
+  allow_failures:
+    - ruby_version: head-x64
+    - ruby_version: head-x86


### PR DESCRIPTION
and use a wider range of ruby versions

**What problem is this PR intended to solve?**

I would like to test nokogiri on rubyinstaller-head which has switched to a newer C runtime called UCRT. Unfortuantely https://github.com/MSP-Greg/setup-ruby-pkgs doesn't support UCRT yet, so that I reactivated appveyor x64 build for it. While being over there, I would suggest to use a wider range of ruby versions, so that the latest and newest supported version is checked.

**Have you included adequate test coverage?**

The CI run.

**Does this change affect the behavior of either the C or the Java implementations?**

Only C.