### PR TITLE
ci: add truffleruby to github actions

### DIFF
--- a/.github/workflows/truffle.yml
+++ b/.github/workflows/truffle.yml
@@ -1,0 +1,32 @@
+name: truffle
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1,3,5" # At 08:00 on Monday, Wednesday, and Friday # https://crontab.guru/#0_8_*_*_1,3,5
+
+jobs:
+  truffleruby-head:
+    strategy:
+      fail-fast: false
+      matrix:
+        flags:
+          - "--disable-system-libraries --disable-static"
+          - "--disable-system-libraries --enable-static"
+          - "--enable-system-libraries"
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    container:
+      image: flavorjones/nokogiri-test:truffle-nightly
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ports/archives
+          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          restore-keys: tarballs-
+      - run: bundle install --local || bundle install
+      - run: bundle exec rake compile -- ${{matrix.flags}}
+      - run: bundle exec rake test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ environment:
       INSTALL_PACKAGES: "mingw-w64-i686-libxslt"
       EXTCONF_PARAMS: "--use-system-libraries"
 
-    - ruby_version: 27
-    - ruby_version: 27
+    - ruby_version: 25
+    - ruby_version: 25
       INSTALL_PACKAGES: "mingw-w64-i686-libxslt"
       EXTCONF_PARAMS: "--use-system-libraries"

--- a/rakelib/check-manifest.rake
+++ b/rakelib/check-manifest.rake
@@ -44,9 +44,11 @@ task :check_manifest do
     STANDARD_RESPONSES.md
     Vagrantfile
     [a-z]*.{log,out}
+    [0-9]*
     appveyor.yml
     gumbo-parser/test/*
     lib/nokogiri/**/nokogiri.{jar,so}
+    lib/nokogiri/nokogiri.{jar,so}
     nokogiri.gemspec
   ]
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Ensure we have some TruffleRuby coverage in the Github Actions pipelines. Previously we had coverage on Concourse, which has been dropped as a CI platform. See #2247 for context.