### PR TITLE
ci: try UCRT for windows ruby-head builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -80,7 +79,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
@@ -136,7 +134,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -160,7 +157,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
@@ -184,7 +180,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-macos-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 
@@ -212,7 +207,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-windows-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: ./scripts/test-gem-build gems ruby
       - uses: actions/upload-artifact@v2
         with:
@@ -111,7 +110,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: "./scripts/test-gem-build gems ${{matrix.plat}}"
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/truffle.yml
+++ b/.github/workflows/truffle.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- ${{matrix.flags}}
       - run: bundle exec rake test

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -88,7 +88,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-${{matrix.plat}}-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 
@@ -111,7 +110,6 @@ jobs:
         with:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
-          restore-keys: tarballs-
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
 

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -77,12 +77,13 @@ jobs:
           git config --system core.autocrlf false
           git config --system core.eol lf
       - uses: actions/checkout@v2
-      - uses: MSP-Greg/setup-ruby-pkgs@v1
+      - uses: MSP-Greg/setup-ruby-pkgs@ucrt
         with:
           ruby-version: "head"
           apt-get: "libxml2-dev libxslt1-dev pkg-config"
-          mingw: "libxml2 libxslt"
+          mingw: "_upgrade_ libxml2 libxslt pkgconf"
           bundler-cache: true
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/00-win-ucrt
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Please also note that the `Nokogiri::HTML` parse methods still use libxml2's HTM
 
 Many thanks to Sam Ruby, Steve Checkoway, and Craig Barnes for creating and maintaining Nokogumbo and supporting the Gumbo HTML5 parser. They're now Nokogiri core contributors with all the powers and privileges pertaining thereto. 🙌
 
+#### Other
+
+* [CRuby] `Nokogiri::VERSION_INFO["libxslt"]["datetime_enabled"]` is a new boolean value which describes whether libxslt (or, more properly, libexslt) has compiled-in datetime support. This generally going to be `true`, but some distros ship without this support (e.g., some mingw UCRT-based packages, see https://github.com/msys2/MINGW-packages/pull/8957). See [#2272](https://github.com/sparklemotion/nokogiri/issues/2272) for more details.
+
 
 ### Changed
 

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -218,6 +218,13 @@ Init_nokogiri()
 #endif
 
   xmlInitParser();
+  exsltRegisterAll();
+
+  if (xsltExtModuleFunctionLookup((xmlChar*)"date-time", EXSLT_DATE_NAMESPACE)) {
+    rb_const_set(mNokogiri, rb_intern("LIBXSLT_DATETIME_ENABLED"), Qtrue);
+  } else {
+    rb_const_set(mNokogiri, rb_intern("LIBXSLT_DATETIME_ENABLED"), Qfalse);
+  }
 
   cNokogiriSyntaxError = rb_define_class_under(mNokogiri, "SyntaxError", rb_eStandardError);
   noko_init_xml_syntax_error();

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -64,7 +64,6 @@ parse_stylesheet_doc(VALUE klass, VALUE xmldocobj)
   VALUE errstr, exception;
   xsltStylesheetPtr ss ;
   Data_Get_Struct(xmldocobj, xmlDoc, xml);
-  exsltRegisterAll();
 
   errstr = rb_str_new(0, 0);
   xsltSetGenericErrorFunc((void *)errstr, xslt_generic_error_handler);

--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -52,6 +52,10 @@ module Nokogiri
       defined?(Nokogiri::LIBXML_ICONV_ENABLED) && Nokogiri::LIBXML_ICONV_ENABLED
     end
 
+    def libxslt_has_datetime?
+      defined?(Nokogiri::LIBXSLT_DATETIME_ENABLED) && Nokogiri::LIBXSLT_DATETIME_ENABLED
+    end
+
     def libxml2_using_packaged?
       libxml2? && Nokogiri::PACKAGED_LIBRARIES
     end
@@ -151,6 +155,7 @@ module Nokogiri
             else
               libxslt["source"] = "system"
             end
+            libxslt["datetime_enabled"] = libxslt_has_datetime?
             libxslt["compiled"] = compiled_libxslt_version.to_s
             libxslt["loaded"] = loaded_libxslt_version.to_s
           end

--- a/test/test_nokogiri.rb
+++ b/test/test_nokogiri.rb
@@ -1,54 +1,55 @@
+# frozen_string_literal: true
 require "helper"
 
-class TestNokogiri < Nokogiri::TestCase
-  def test_libxml_iconv
-    skip_unless_libxml2("this constant is only set in the C extension when libxml2 is used")
-    assert Nokogiri.const_defined?(:LIBXML_ICONV_ENABLED)
-  end
+class Nokogiri::TestCase
+  describe Nokogiri do
+    def test_libxml_iconv
+      skip_unless_libxml2("this constant is only set in the C extension when libxml2 is used")
+      assert(Nokogiri.const_defined?(:LIBXML_ICONV_ENABLED))
+    end
 
-  def test_parse_with_io
-    doc = Nokogiri.parse(
-      StringIO.new("<html><head><title></title><body></body></html>")
-    )
-    assert_instance_of Nokogiri::HTML::Document, doc
-  end
+    def test_parse_with_io
+      doc = Nokogiri.parse(StringIO.new("<html><head><title></title><body></body></html>"))
+      assert_instance_of(Nokogiri::HTML::Document, doc)
+    end
 
-  def test_xml?
-    doc = Nokogiri.parse(File.read(XML_FILE))
-    assert doc.xml?
-    assert !doc.html?
-  end
+    def test_xml?
+      doc = Nokogiri.parse(File.read(XML_FILE))
+      assert(doc.xml?)
+      assert(!doc.html?)
+    end
 
-  def test_atom_is_xml?
-    doc = Nokogiri.parse(File.read(XML_ATOM_FILE))
-    assert doc.xml?
-    assert !doc.html?
-  end
+    def test_atom_is_xml?
+      doc = Nokogiri.parse(File.read(XML_ATOM_FILE))
+      assert(doc.xml?)
+      assert(!doc.html?)
+    end
 
-  def test_html?
-    doc = Nokogiri.parse(File.read(HTML_FILE))
-    assert !doc.xml?
-    assert doc.html?
-  end
+    def test_html?
+      doc = Nokogiri.parse(File.read(HTML_FILE))
+      assert(!doc.xml?)
+      assert(doc.html?)
+    end
 
-  def test_nokogiri_method_with_html
-    doc1 = Nokogiri(File.read(HTML_FILE))
-    doc2 = Nokogiri.parse(File.read(HTML_FILE))
-    assert_equal doc1.serialize, doc2.serialize
-  end
+    def test_nokogiri_method_with_html
+      doc1 = Nokogiri(File.read(HTML_FILE))
+      doc2 = Nokogiri.parse(File.read(HTML_FILE))
+      assert_equal(doc1.serialize, doc2.serialize)
+    end
 
-  def test_nokogiri_method_with_block
-    doc = Nokogiri { b "bold tag" }
-    assert_equal("<b>bold tag</b>", doc.to_html.chomp)
-  end
+    def test_nokogiri_method_with_block
+      doc = Nokogiri { b("bold tag") }
+      assert_equal("<b>bold tag</b>", doc.to_html.chomp)
+    end
 
-  def test_make_with_html
-    doc = Nokogiri.make("<b>bold tag</b>")
-    assert_equal("<b>bold tag</b>", doc.to_html.chomp)
-  end
+    def test_make_with_html
+      doc = Nokogiri.make("<b>bold tag</b>")
+      assert_equal("<b>bold tag</b>", doc.to_html.chomp)
+    end
 
-  def test_make_with_block
-    doc = Nokogiri.make { b "bold tag" }
-    assert_equal("<b>bold tag</b>", doc.to_html.chomp)
+    def test_make_with_block
+      doc = Nokogiri.make { b("bold tag") }
+      assert_equal("<b>bold tag</b>", doc.to_html.chomp)
+    end
   end
 end

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -59,6 +59,7 @@ module TestVersionInfoTests
     assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxml"]["loaded"])
 
     assert(version_info["libxml"].key?("iconv_enabled"))
+    assert(version_info["libxslt"].key?("datetime_enabled"))
   end
 
   def test_version_info_for_libxslt

--- a/test/test_xslt_transforms.rb
+++ b/test/test_xslt_transforms.rb
@@ -218,10 +218,12 @@ class Nokogiri::TestCase
 
       assert_equal("func-result", result_doc.at("/root/function").content)
       assert_equal(3, result_doc.at("/root/max").content.to_i)
-      assert_match(
-        /\d{4}-\d\d-\d\d([-|+]\d\d:\d\d)?/,
-        result_doc.at("/root/date").content
-      )
+      if Nokogiri::VersionInfo.instance.libxslt_has_datetime?
+        assert_match(
+          /\d{4}-\d\d-\d\d([-|+]\d\d:\d\d)?/,
+          result_doc.at("/root/date").content
+        )
+      end
       result_doc.xpath("/root/params/*").each do |p|
         assert_equal(p.content, params[p.name.intern])
       end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

The 3.1.0.dev windows ruby installer uses UCRT, see #2268 for context. This gives Nokogiri and @larskanis a feedback loop.
