### PR TITLE
ci: make the GA cache platform-specific

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
@@ -79,7 +79,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
@@ -135,7 +135,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
@@ -159,7 +159,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
@@ -183,7 +183,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-macos-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -211,7 +211,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-windows-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: ./scripts/test-gem-build gems ruby
       - uses: actions/upload-artifact@v2
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: "./scripts/test-gem-build gems ${{matrix.plat}}"
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/truffle.yml
+++ b/.github/workflows/truffle.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- ${{matrix.flags}}

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -87,7 +87,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-${{matrix.plat}}-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -110,7 +110,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports/archives
-          key: tarballs-${{hashFiles('**/dependencies.yml')}}
+          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
           restore-keys: tarballs-
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind


### PR DESCRIPTION
**What problem is this PR intended to solve?**

make the github actions cache platform-specific

because, e.g., zlib isn't used on linux but it used on windows, and if it's not in the cache then we'll end up re-downloading and potentially getting throttled.