### PR TITLE
improve CI caching of compiled dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
-          path: ports/archives
-          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
+          path: ports
+          key: ports-ubuntu-${{hashFiles('**/dependencies.yml')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -77,8 +77,8 @@ jobs:
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
-          path: ports/archives
-          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
+          path: ports
+          key: ports-ubuntu-${{hashFiles('**/dependencies.yml')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
@@ -132,8 +132,8 @@ jobs:
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
-          path: ports/archives
-          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
+          path: ports
+          key: ports-ubuntu-${{hashFiles('**/dependencies.yml')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -155,8 +155,8 @@ jobs:
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
-          path: ports/archives
-          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
+          path: ports
+          key: ports-ubuntu-${{hashFiles('**/dependencies.yml')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
@@ -178,8 +178,8 @@ jobs:
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
-          path: ports/archives
-          key: tarballs-macos-${{hashFiles('**/dependencies.yml')}}
+          path: ports
+          key: ports-macos-${{hashFiles('**/dependencies.yml')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 
@@ -205,8 +205,8 @@ jobs:
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
-          path: ports/archives
-          key: tarballs-windows-${{hashFiles('**/dependencies.yml')}}
+          path: ports
+          key: ports-windows-${{hashFiles('**/dependencies.yml')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -87,8 +87,8 @@ jobs:
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
-          path: ports/archives
-          key: tarballs-${{matrix.plat}}-${{hashFiles('**/dependencies.yml')}}
+          path: ports
+          key: ports-${{matrix.plat}}-${{hashFiles('**/dependencies.yml')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 
@@ -109,8 +109,8 @@ jobs:
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
-          path: ports/archives
-          key: tarballs-ubuntu-${{hashFiles('**/dependencies.yml')}}
+          path: ports
+          key: ports-ubuntu-${{hashFiles('**/dependencies.yml')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
 

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -402,7 +402,7 @@ def iconv_configure_flags
   abort_could_not_find_library("libiconv")
 end
 
-def process_recipe(name, version, static_p, cross_p)
+def process_recipe(name, version, static_p, cross_p, cacheable_p=true)
   require "rubygems"
   gem("mini_portile2", REQUIRED_MINI_PORTILE_VERSION)
   require "mini_portile2"
@@ -413,7 +413,7 @@ def process_recipe(name, version, static_p, cross_p)
   end
 
   MiniPortile.new(name, version).tap do |recipe|
-    recipe.target = File.join(PACKAGE_ROOT_DIR, "ports")
+    recipe.target = File.join(PACKAGE_ROOT_DIR, "ports") if cacheable_p
     # Prefer host_alias over host in order to use i586-mingw32msvc as
     # correct compiler prefix for cross build, but use host if not set.
     recipe.host = RbConfig::CONFIG["host_alias"].empty? ? RbConfig::CONFIG["host"] : RbConfig::CONFIG["host_alias"]
@@ -893,7 +893,7 @@ else
   ensure_func("exsltFuncRegister", "libexslt/exslt.h")
 end
 
-libgumbo_recipe = process_recipe("libgumbo", "1.0.0-nokogiri", static_p, cross_build_p) do |recipe|
+libgumbo_recipe = process_recipe("libgumbo", "1.0.0-nokogiri", static_p, cross_build_p, false) do |recipe|
   recipe.configure_options = []
 
   class << recipe


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Quite a bit of CI time is spent compiling our packaged dependencies (libxml2, libxslt, libiconv, zlib). For a given platform, we should be able to cache these libraries once compiled.

This PR does two things:

- move libgumbo out of `/ports`
- caches `/ports` for most jobs that were previously caching just `/ports/archives` (which only contains the tarballs)

I'll run CI twice on this branch and compare the timing to previous runs to make sure this is actually effective.
