### PR TITLE
ci: ensure that nokogumbo 2.0.4 and 2.0.5 both work

### DIFF
--- a/scripts/test-gem-install
+++ b/scripts/test-gem-install
@@ -38,4 +38,5 @@ rake test
 
 # delete the Gemfile because that's confusing to older versions of rubygems (e.g., bionic32)
 rm -f Gemfile Gemfile.lock
-./scripts/test-nokogumbo-compatibility
+./scripts/test-nokogumbo-compatibility 2.0.4
+./scripts/test-nokogumbo-compatibility 2.0.5

--- a/scripts/test-nokogumbo-compatibility
+++ b/scripts/test-nokogumbo-compatibility
@@ -22,18 +22,26 @@ raise "could not find installed gem" unless gemspec
 
 require "bundler/inline"
 
+nokogumbo_version = if ARGV[0] =~ /\d+\.\d+\.\d+/
+  ARGV[0]
+end
+
 gemfile(true) do
   source "https://rubygems.org"
   gem "minitest"
   gem "minitest-reporters"
   gem "nokogiri", "=#{gemspec.version}"
-  gem "nokogumbo"
+  if nokogumbo_version
+    gem "nokogumbo", "=#{nokogumbo_version}"
+  else
+    gem "nokogumbo"
+  end
 end
 
-nokogumbo_gemspec = Gem::Specification.find_by_name('nokogumbo')
+nokogumbo_gemspec = Gem::Specification.find_by_name("nokogumbo")
 
-require 'nokogumbo'
-require 'yaml'
+require "nokogumbo"
+require "yaml"
 
 if ARGV.include?("-v")
   puts "---------- Nokogiri version info ----------"
@@ -54,6 +62,8 @@ Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
 puts "Testing #{gemspec.full_name} installed in #{gemspec.base_dir}"
 describe gemspec.full_name do
   it "works" do
-    assert(Nokogiri::HTML5::Document.parse("<div>ahoy</div>"))
+    doc = Nokogiri::HTML5::Document.parse("<div>ahoy</div>")
+    assert(doc)
+    assert_equal("ahoy", doc.at_css("/html/body/div").text)
   end
 end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Adding test coverage to ensure that we don't break any applications that have upgraded Nokogiri but haven't dropped Nokogumbo yet.

Related to #2204

**Have you included adequate test coverage?**

This PR is pure test coverage :sunglasses: 

**Does this change affect the behavior of either the C or the Java implementations?**

No behavior changes.