### PR TITLE
ci: skip the problematic Enumerator#each test with ASan

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -211,6 +211,15 @@ module Nokogiri
       # https://stackoverflow.com/questions/365458/how-can-i-detect-if-a-program-is-running-from-within-valgrind/62364698#62364698
       ENV["LD_PRELOAD"] =~ /valgrind|vgpreload/
     end
+
+    def i_am_running_with_asan
+      # https://stackoverflow.com/questions/35012059/check-whether-sanitizer-like-addresssanitizer-is-active
+      begin
+        %x"ldd #{Gem.ruby}" =~ /libasan\.so/
+      rescue
+        false
+      end
+    end
   end
 
   module SAX

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -740,6 +740,7 @@ module Nokogiri
               skip("cannot use Ruby 2.5 Enumerator#each in a systemd container")
             end
             skip("enumerators confuse valgrind") if i_am_running_in_valgrind
+            skip("enumerators confuse ASan") if i_am_running_with_asan
 
             employees = xml.search("//employee")
             enum = employees.each


### PR DESCRIPTION
**What problem is this PR intended to solve?**

In an attempt to speed up CI, I'm experimenting with moving from Valgrind to using ASan for detecting memory issues.

One issue was reported at https://bugs.ruby-lang.org/issues/18001

The second issue is that we see a warning like:

> ==108142==WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0x7ffc026fc000; bottom 0x7f18d53ae000; size: 0x00e32d34e000 (975716016128)
> False positive error reports may follow
> For details see https://github.com/google/sanitizers/issues/189

when we run the Enumerator#each test. Note that we've had to take precautions with this test with valgrind as well, because of the way the stack is manipulated within Enumerator.

This PR skips this test when it detects that ASan has been linked in.
