### PR TITLE
Update html5 tests

### DIFF
--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -4437,7 +4437,13 @@ static void handle_in_foreign_content(GumboParser* parser, GumboToken* token) {
     ) {
       pop_current_node(parser);
     }
-    handle_in_body(parser, token);
+    // XXX: The spec currently says to handle this using the in body insertion
+    // mode rules. That seems wrong. See
+    // <https://github.com/whatwg/html/issues/6808>. Instead, use the current
+    // insertion mode which seems like it works.
+    //
+    // handle_in_body(parser, token);
+    handle_html_content(parser, token);
     return;
   }
 

--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -4418,6 +4418,7 @@ static void handle_in_foreign_content(GumboParser* parser, GumboToken* token) {
         || token_has_attribute(token, "size")
       )
     )
+    || tag_in(token, kEndTag, &(const TagSet) { TAG(BR), TAG(P) })
   ) {
     /* Parse error */
     parser_add_parse_error(parser, token);
@@ -4427,20 +4428,17 @@ static void handle_in_foreign_content(GumboParser* parser, GumboToken* token) {
      * fragment parsing algorithm, then act as described in the "any other
      * start tag" entry below.
      */
-    if (!is_fragment_parser(parser)) {
-      do {
-        pop_current_node(parser);
-      } while (
-        !(
-          is_mathml_integration_point(get_current_node(parser))
-          || is_html_integration_point(get_current_node(parser))
-          || get_current_node(parser)->v.element.tag_namespace == GUMBO_NAMESPACE_HTML
-        )
-      );
-      parser->_parser_state->_reprocess_current_token = true;
-      return;
+    while (
+      !(
+        is_mathml_integration_point(get_current_node(parser))
+        || is_html_integration_point(get_current_node(parser))
+        || get_current_node(parser)->v.element.tag_namespace == GUMBO_NAMESPACE_HTML
+      )
+    ) {
+      pop_current_node(parser);
     }
-    // This is a start tag so the next if's then branch will be taken.
+    handle_in_body(parser, token);
+    return;
   }
 
   if (token->type == GUMBO_TOKEN_START_TAG) {

--- a/gumbo-parser/test/parser.cc
+++ b/gumbo-parser/test/parser.cc
@@ -2240,4 +2240,76 @@ TEST_F(GumboParserTest, ForeignFragment) {
   ASSERT_EQ(GUMBO_NAMESPACE_SVG, foo->v.element.tag_namespace);
 }
 
+TEST_F(GumboParserTest, FosterParenting) {
+  Parse("<!doctype><body><table><colgroup><svg><g>foo</g><g>bar</g><p>baz</table><p>quux");
+  EXPECT_EQ(1, GetChildCount(root_));
+  GumboNode* html = GetChild(root_, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, html->type);
+  EXPECT_EQ(GUMBO_TAG_HTML, html->v.element.tag);
+  EXPECT_EQ(2, GetChildCount(html));
+
+  GumboNode* body = GetChild(html, 1);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, body->type);
+  EXPECT_EQ(GUMBO_TAG_BODY, body->v.element.tag);
+  EXPECT_EQ(4, GetChildCount(body));
+
+  GumboNode* svg = GetChild(body, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, svg->type);
+  EXPECT_EQ(GUMBO_TAG_SVG, svg->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_SVG, svg->v.element.tag_namespace);
+  EXPECT_EQ(2, GetChildCount(svg));
+
+  GumboNode* g = GetChild(svg, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, g->type);
+  EXPECT_EQ(std::string("g"), g->v.element.name);
+  EXPECT_EQ(GUMBO_NAMESPACE_SVG, g->v.element.tag_namespace);
+  EXPECT_EQ(1, GetChildCount(g));
+
+  GumboNode* text = GetChild(g, 0);
+  ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
+  EXPECT_EQ(std::string("foo"), text->v.text.text);
+
+  g = GetChild(svg, 1);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, g->type);
+  EXPECT_EQ(std::string("g"), g->v.element.name);
+  EXPECT_EQ(GUMBO_NAMESPACE_SVG, g->v.element.tag_namespace);
+  EXPECT_EQ(1, GetChildCount(g));
+
+  text = GetChild(g, 0);
+  ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
+  EXPECT_EQ(std::string("bar"), text->v.text.text);
+
+  GumboNode* p = GetChild(body, 1);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, p->type);
+  EXPECT_EQ(GUMBO_TAG_P, p->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, p->v.element.tag_namespace);
+  EXPECT_EQ(1, GetChildCount(p));
+
+  text = GetChild(p, 0);
+  ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
+  EXPECT_EQ(std::string("baz"), text->v.text.text);
+
+  GumboNode* table = GetChild(body, 2);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, table->type);
+  EXPECT_EQ(GUMBO_TAG_TABLE, table->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, table->v.element.tag_namespace);
+  EXPECT_EQ(1, GetChildCount(table));
+
+  GumboNode* colgroup = GetChild(table, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, colgroup->type);
+  EXPECT_EQ(GUMBO_TAG_COLGROUP, colgroup->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, colgroup->v.element.tag_namespace);
+  EXPECT_EQ(0, GetChildCount(colgroup));
+
+  p = GetChild(body, 3);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, p->type);
+  EXPECT_EQ(GUMBO_TAG_P, p->v.element.tag);
+  EXPECT_EQ(GUMBO_NAMESPACE_HTML, p->v.element.tag_namespace);
+  EXPECT_EQ(1, GetChildCount(p));
+
+  text = GetChild(p, 0);
+  ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
+  EXPECT_EQ(std::string("quux"), text->v.text.text);
+}
+
 }  // namespace

--- a/gumbo-parser/test/parser.cc
+++ b/gumbo-parser/test/parser.cc
@@ -2220,4 +2220,24 @@ TEST_F(GumboParserTest, FragmentWithoutForm) {
   EXPECT_EQ(0, GetChildCount(span));
 }
 
+TEST_F(GumboParserTest, ForeignFragment) {
+  ParseFragment("</p><foo>", "svg", GUMBO_NAMESPACE_SVG);
+  EXPECT_EQ(1, GetChildCount(root_));
+  GumboNode* html = GetChild(root_, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, html->type);
+  EXPECT_EQ(GUMBO_TAG_HTML, html->v.element.tag);
+  EXPECT_EQ(2, GetChildCount(html));
+
+  ASSERT_EQ(2, GetChildCount(html));
+  GumboNode* p = GetChild(html, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, p->type);
+  ASSERT_EQ(GUMBO_TAG_P, p->v.element.tag);
+  ASSERT_EQ(GUMBO_NAMESPACE_HTML, p->v.element.tag_namespace);
+
+  GumboNode* foo = GetChild(html, 1);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, foo->type);
+  ASSERT_EQ(std::string("foo"), foo->v.element.name);
+  ASSERT_EQ(GUMBO_NAMESPACE_SVG, foo->v.element.tag_namespace);
+}
+
 }  // namespace


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

html5lib-tests has updated since I forked it to fix a bunch of errors. Some of the updates include new tests to test functionality that changed in the spec. This updates the code to parse the new tests, updates the submodule to include my fixes to the latest version of html5lib-tests, and updates the gumbo parser to accommodate the spec changes.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

The new tests were mentioned in https://github.com/sparklemotion/nokogiri/issues/2204#issuecomment-863550189.

**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

Yes. The changes to the parser include parser-specific tests and the update to html5lib-tests includes end-to-end tests to test the behavior.

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

This only affects the C implementation as the gumbo parser isn't use for the Java implementation.
