### PR TITLE
libxslt: tests should handle changed XSLT template resolution

### DIFF
--- a/test/xslt/test_custom_functions.rb
+++ b/test/xslt/test_custom_functions.rb
@@ -41,14 +41,14 @@ module Nokogiri
             xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
             xmlns:f="http://e.org/functions"
             extension-element-prefixes="f">
-            <xsl:template match="text()">
-              <xsl:copy-of select="f:capitalize(.)"/>
-            </xsl:template>
             <xsl:template match="@*|node()">
               <xsl:copy>
                 <xsl:apply-templates select="@*|node()"/>
                 <xsl:apply-imports/>
               </xsl:copy>
+            </xsl:template>
+            <xsl:template match="text()">
+              <xsl:copy-of select="f:capitalize(.)"/>
             </xsl:template>
           </xsl:stylesheet>
         EOXSL
@@ -108,14 +108,14 @@ module Nokogiri
             xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
             xmlns:f="http://e.org/functions"
             extension-element-prefixes="f">
-            <xsl:template match="text()">
-              <xsl:copy-of select="f:america(.)"/>
-            </xsl:template>
             <xsl:template match="@*|node()">
               <xsl:copy>
                 <xsl:apply-templates select="@*|node()"/>
                 <xsl:apply-imports/>
               </xsl:copy>
+            </xsl:template>
+            <xsl:template match="text()">
+              <xsl:copy-of select="f:america(.)"/>
             </xsl:template>
           </xsl:stylesheet>
         EOXSL


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Upstream libxslt started failing after https://gitlab.gnome.org/GNOME/libxslt/-/commit/b0074eeca3c6b21b4da14fdf712b853900c51635 which addresses https://gitlab.gnome.org/GNOME/libxslt/-/issues/55.

Update the test to order the templates appropriately to reflect this change to how templates are resolved.


**Have you included adequate test coverage?**

This change affects only tests, not functional behavior.


**Does this change affect the behavior of either the C or the Java implementations?**

This change to the tests is forward-looking, as the next version of libxslt is likely to include the related change to the xslt template resolver.
