### PR TITLE
ci: run minitest in verbose mode on CI

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -75,6 +75,7 @@ def nokogiri_test_task_configuration(t)
   t.libs << "test"
   t.test_files = FileList["test/**/test_*.rb"]
   t.verbose = true
+  t.options = "-v" if ENV["CI"]
 end
 
 Rake::TestTask.new do |t|


### PR DESCRIPTION
**What problem is this PR intended to solve?**

When running in Github Actions, the default minitest progress reporter makes the Actions UI appear to hang while the tests are running (presumably because there are no newlines to cause a flush of IO?).

Let's move to using `-v` when running in CI so that we have a better sense of progress. Disk is cheap! Right?
