### PR TITLE
Switch to upstream html5lib-tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "test/html5lib-tests"]
 	path = test/html5lib-tests
-	url = https://github.com/stevecheckoway/html5lib-tests.git
-	branch = all-error-fixes
+	url = https://github.com/html5lib/html5lib-tests.git
+	branch = master


### PR DESCRIPTION
My PR to fix the errors
https://github.com/html5lib/html5lib-tests/pull/136 was merged. We can
now track the upstream repository.

Closes #2282

<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

The html5 tests had been tracking my fork of html5lib-tests but with https://github.com/html5lib/html5lib-tests/pull/136 merged, we can track upstream. #2282 

**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

There is no change in test coverage.

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

This is only relevant to the C implementation, but it affects the behavior of neither.