### PR TITLE
ci(upstream): run against latest html5lib-tests master

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -134,3 +134,25 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake compile
       - run: bundle exec rake test
+
+  html5lib-tests:
+    runs-on: ubuntu-latest
+    container:
+      image: flavorjones/nokogiri-test:mri-3.0
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: ports
+          key: ports-ubuntu-${{hashFiles('**/dependencies.yml')}}
+      - name: Update html5lib-tests
+        run: |
+          cd test/html5lib-tests
+          git remote update origin
+          git checkout origin/master
+          git log --pretty=oneline -n1
+      - run: bundle install --local || bundle install
+      - run: bundle exec rake compile -- --disable-system-libraries
+      - run: bundle exec rake test


### PR DESCRIPTION
**What problem is this PR intended to solve?**

As the `html5lib-tests` repo changes over time, I think it might be helpful to automatically run against the latest so that if any failures are introduced, we can address them proactively.

This PR adds a job to the `upstream` CI pipeline, which runs periodically every few days, running against the latest versions of some of Nokogiri's dependencies.

I'll rely on @stevecheckoway to tell me if this is _actually_ useful.

**Have you included adequate test coverage?**

This PR introduces new test coverage.

**Does this change affect the behavior of either the C or the Java implementations?**

No functional changes.