### PR TITLE
Resolve potential NPE in SchemaResourceResolver

### DIFF
--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -276,7 +276,7 @@ public class XmlSchema extends RubyObject
                     String systemId,
                     String baseURI)
     {
-      if (noNet && (systemId.startsWith("http://") || systemId.startsWith("ftp://"))) {
+      if (noNet && systemId != null && (systemId.startsWith("http://") || systemId.startsWith("ftp://"))) {
         if (systemId.startsWith(XMLConstants.W3C_XML_SCHEMA_NS_URI)) {
           return null; // use default resolver
         }

--- a/test/html4/test_node.rb
+++ b/test/html4/test_node.rb
@@ -187,21 +187,19 @@ module Nokogiri
             nokogiri.at("p").to_html.gsub(/ /, '')
         end
       end
-    end
 
-    def test_GH_1042
-      file = File.join(ASSETS_DIR, 'GH_1042.html');
-      html = Nokogiri::HTML(File.read(file))
-      table = html.xpath("//table")[1]
-      trs = table.xpath("tr").drop(1)
+      def test_GH_1042
+        file = File.join(ASSETS_DIR, 'GH_1042.html');
+        html = Nokogiri::HTML(File.read(file))
+        table = html.xpath("//table")[1]
+        trs = table.xpath("tr").drop(1)
 
-      # the jruby inplementation of drop uses dup() on the IRubyObject (which
-      # is NOT the same dup() method on the ruby Object) which produces a
-      # shallow clone. a shallow of valid XMLNode triggers several
-      # NullPointerException on inspect() since loads of invariants
-      # are not set. the fix for GH1042 ensures a proper working clone.
-      assert_nothing_raised do
-        trs.inspect
+        # the jruby inplementation of drop uses dup() on the IRubyObject (which
+        # is NOT the same dup() method on the ruby Object) which produces a
+        # shallow clone. a shallow of valid XMLNode triggers several
+        # NullPointerException on inspect() since loads of invariants
+        # are not set. the fix for GH1042 ensures a proper working clone.
+        trs.inspect # assert_nothing_raised
       end
     end
   end

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -214,6 +214,21 @@ module Nokogiri
         end
       end
 
+      def test_xsd_import_with_no_systemid
+        # https://github.com/sparklemotion/nokogiri/pull/2296
+        xsd = <<~EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://www.w3.org/1998/Math/MathML"
+            targetNamespace="http://www.w3.org/1998/Math/MathML"
+          >
+          <xs:import/>
+          </xs:schema>
+        EOF
+        Nokogiri::XML::Schema(xsd) # assert_nothing_raised
+      end
+
       describe "CVE-2020-26247" do
         # https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m
         let(:schema) do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

The LSResourceResolver interface specifies that the systemId parameter may be null. The SchemaResourceResolver uses this argument without checking for this which can result a NullPointerException. This patch adds an extra null check before using the parameter.

**Have you included adequate test coverage?**

I'm seeing this NPE in my code, but I'm afraid I haven't been able to derive a simple reproduction case yet. No test yet either as a consequence.

**Does this change affect the behavior of either the C or the Java implementations?**

Only the Java implementation.