### PR TITLE
fix BSD support for libgumbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,3 +272,24 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake compile
       - run: bundle exec rake test
+
+  bsd:
+    needs: ["basic"]
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: ["enable", "disable"]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: vmactions/freebsd-vm@v0.1.5
+        with:
+          usesh: true
+          prepare: pkg install -y ruby devel/ruby-gems pkgconf libxml2 libxslt
+          run: |
+            gem install bundler
+            bundle install --local || bundle install
+            bundle exec rake compile -- --${{matrix.sys}}-system-libraries
+            bundle exec rake test

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,9 @@ boxen << Box.new("bionic32", "mkorenkov/ubuntu-bionic32", <<~EOF)
   apt-get install -y libxslt-dev libxml2-dev pkg-config
   apt-get install -y ruby ruby-dev bundler git
 EOF
+boxen << Box.new("freebsd", "freebsd/FreeBSD-13.0-CURRENT", <<~EOF)
+  pkg install rbenv ruby-build
+EOF
 
 Vagrant.configure("2") do |config|
   boxen.each do |box|

--- a/gumbo-parser/src/Makefile
+++ b/gumbo-parser/src/Makefile
@@ -7,10 +7,27 @@ CFLAGS += -std=c99 -Wall
 # allow the ENV var to override this
 RANLIB ?= ranlib
 
-gumbo_objs := $(patsubst %.c,%.o,$(wildcard *.c))
+gumbo_objs := \
+	ascii.o \
+	attribute.o \
+	char_ref.o \
+	error.o \
+	foreign_attrs.o \
+	parser.o \
+	string_buffer.o \
+	string_piece.o \
+	svg_attrs.o \
+	svg_tags.o \
+	tag.o \
+	tag_lookup.o \
+	token_buffer.o \
+	tokenizer.o \
+	utf8.o \
+	util.o \
+	vector.o
 
 libgumbo.a: $(gumbo_objs)
-	$(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $(gumbo_objs)
 	- ($(RANLIB) $@ || true) >/dev/null 2>&1
 
 clean:

--- a/gumbo-parser/src/Makefile
+++ b/gumbo-parser/src/Makefile
@@ -2,7 +2,7 @@
 # to enable a mini_portile2 recipe to build the gumbo parser
 .PHONY: clean
 
-override CFLAGS += -std=c99 -Wall
+CFLAGS += -std=c99 -Wall
 
 # allow the ENV var to override this
 RANLIB ?= ranlib


### PR DESCRIPTION
**What problem is this PR intended to solve?**

The makefile in `gumbo-parser/src/Makefile` contained Gnu-isms that are not compatible with BSD `make` (see #2298). This PR adds CI coverage for FreeBSD and updates the makefile to be portable across both flavors of `make`.


**Have you included adequate test coverage?**

Yes! New jobs in the `ci` pipeline will cover BSD with and without system libraries.


**Does this change affect the behavior of either the C or the Java implementations?**

Just the C implementation on BSD, and just at install-time.
