### PR TITLE
ext: load C extension files from non-native gems via "require"

### DIFF
--- a/lib/nokogiri/extension.rb
+++ b/lib/nokogiri/extension.rb
@@ -2,6 +2,7 @@
 
 # load the C or Java extension
 begin
+  # native precompiled gems package shared libraries in <gem_dir>/lib/nokogiri/<ruby_version>
   ::RUBY_VERSION =~ /(\d+\.\d+)/
   require_relative "#{Regexp.last_match(1)}/nokogiri"
 rescue LoadError => e
@@ -22,5 +23,9 @@ rescue LoadError => e
     EOM
     raise e
   end
-  require_relative "nokogiri"
+
+  # use "require" instead of "require_relative" because non-native gems will place C extension files
+  # in Gem::BasicSpecification#extension_dir after compilation (during normal installation), which
+  # is in $LOAD_PATH but not necessarily relative to this file (see #2300)
+  require "nokogiri/nokogiri"
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

As reported in #2300, we should be loading the C extension relying on `require` and `$LOAD_PATH` and not using `require_relative`.


**Have you included adequate test coverage?**

No. This is a bit challenging to test, as we'd have to modify the gem installation (and delete the `nokogiri.so` files present under "lib/nokogiri"), and the regression value is pretty low (especially given the verbose comment in this PR).

That said, this change has adequate test coverage already in the `gem-install` CI pipeline, to ensure we don't break unmodified installations.


**Does this change affect the behavior of either the C or the Java implementations?**

No.