### PR TITLE
Revert "ci: avoid warnings from setup-ruby-ref"

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -89,6 +89,7 @@ jobs:
           apt-get: "libxml2-dev libxslt1-dev pkg-config"
           mingw: "_upgrade_ libxml2 libxslt pkgconf"
           bundler-cache: true
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/00-win-ucrt
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:


### PR DESCRIPTION
This reverts commit a81343b2192ede40db8ddd89dd5a0a3e67c4c7a3.

**What problem is this PR intended to solve?**

Ruby-head on windows is failing. It's not clear to me why

The first failure was [here](https://github.com/sparklemotion/nokogiri/actions/runs/1105925545), with an error message indicating it might have been a server-side problem, but I recently introduced a81343b2192ede40db8ddd89dd5a0a3e67c4c7a3 to quash warnings and a different failure is now being raised, which seems to be packages not being found when enabling system libraries, and a segfault when using packaged libraries.

Here I'm just experimentally unwinding that change to see if I can learn what's going wrong.