### PR TITLE
ci: generate and use images to/from ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ concurrency:
   cancel-in-progress: true
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 3" # At 08:00 on Wednesday # https://crontab.guru/#0_8_*_*_3
   push:
     branches:
       - main
@@ -19,7 +21,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:mri-3.0
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
     steps:
       - uses: actions/checkout@v2
         with:
@@ -61,7 +63,7 @@ jobs:
         sys: ["enable"]
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:${{matrix.image}}
+      image: ghcr.io/sparklemotion/nokogiri-test:${{matrix.image}}
     steps:
       - uses: actions/checkout@v1 # v1 because of https://github.com/actions/checkout/issues/334
         with:
@@ -79,7 +81,7 @@ jobs:
         ruby: ["2.5", "2.6", "2.7", "3.0"]
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:mri-${{matrix.ruby}}
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -102,7 +104,7 @@ jobs:
         ruby: ["2.5", "2.6", "2.7", "3.0"]
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:mri-${{matrix.ruby}}
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -124,7 +126,7 @@ jobs:
         sys: ["enable"]
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:alpine
+      image: ghcr.io/sparklemotion/nokogiri-test:alpine
     steps:
       - uses: actions/checkout@v1 # v1 because of https://github.com/actions/checkout/issues/334
         with:
@@ -142,7 +144,7 @@ jobs:
         sys: ["disable"]
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:alpine
+      image: ghcr.io/sparklemotion/nokogiri-test:alpine
     steps:
       - uses: actions/checkout@v1 # v1 because of https://github.com/actions/checkout/issues/334
         with:
@@ -163,7 +165,7 @@ jobs:
       BUNDLE_GEMFILE: "Gemfile-libxml-ruby"
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:mri-${{matrix.ruby}}
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -188,7 +190,7 @@ jobs:
       BUNDLE_GEMFILE: "Gemfile-libxml-ruby"
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:mri-${{matrix.ruby}}
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/generate-ci-images.yml
+++ b/.github/workflows/generate-ci-images.yml
@@ -7,99 +7,75 @@ on:
     - cron: "0 5 * * 3" # At 05:00 on Wednesday # https://crontab.guru/#0_5_*_*_3
 # reference: https://github.com/marketplace/actions/build-and-push-docker-images
 jobs:
-  alpine:
+  build_images:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/build-push-action@v2
-        id: docker_build
+      - uses: actions/checkout@v2
         with:
+          submodules: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+          bundler-cache: true
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - name: alpine
+        uses: docker/build-push-action@v2
+        with:
+          context: "."
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:alpine
           file: oci-images/nokogiri-test/alpine.dockerfile
-      - name: Log the image digest
-        run: echo ${{steps.docker_build.outputs.digest}}
-  bionic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/build-push-action@v2
-        id: docker_build
+      - name: bionic
+        uses: docker/build-push-action@v2
         with:
+          context: "."
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:bionic
           file: oci-images/nokogiri-test/bionic.dockerfile
-      - name: Log the image digest
-        run: echo ${{steps.docker_build.outputs.digest}}
-  bionic32:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/build-push-action@v2
-        id: docker_build
+      - name: bionic32
+        uses: docker/build-push-action@v2
         with:
+          context: "."
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:bionic32
           file: oci-images/nokogiri-test/bionic32.dockerfile
-      - name: Log the image digest
-        run: echo ${{steps.docker_build.outputs.digest}}
-  mri_2_5:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/build-push-action@v2
-        id: docker_build
+      - name: mri-2.5
+        uses: docker/build-push-action@v2
         with:
+          context: "."
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:mri-2.5
           file: oci-images/nokogiri-test/mri-2.5.dockerfile
-      - name: Log the image digest
-        run: echo ${{steps.docker_build.outputs.digest}}
-  mri_2_6:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/build-push-action@v2
-        id: docker_build
+      - name: mri-2.6
+        uses: docker/build-push-action@v2
         with:
+          context: "."
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:mri-2.6
           file: oci-images/nokogiri-test/mri-2.6.dockerfile
-      - name: Log the image digest
-        run: echo ${{steps.docker_build.outputs.digest}}
-  mri_2_7:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/build-push-action@v2
-        id: docker_build
+      - name: mri-2.7
+        uses: docker/build-push-action@v2
         with:
+          context: "."
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:mri-2.7
           file: oci-images/nokogiri-test/mri-2.7.dockerfile
-      - name: Log the image digest
-        run: echo ${{steps.docker_build.outputs.digest}}
-  mri_3_0:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/build-push-action@v2
-        id: docker_build
+      - name: mri-3.0
+        uses: docker/build-push-action@v2
         with:
+          context: "."
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
           file: oci-images/nokogiri-test/mri-3.0.dockerfile
-      - name: Log the image digest
-        run: echo ${{steps.docker_build.outputs.digest}}
-  truffle_nightly:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/build-push-action@v2
-        id: docker_build
+      - name: truffle-nightly
+        uses: docker/build-push-action@v2
         with:
+          context: "."
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:truffle-nightly
           file: oci-images/nokogiri-test/truffle-nightly.dockerfile
-      - name: Log the image digest
-        run: echo ${{steps.docker_build.outputs.digest}}

--- a/.github/workflows/truffle.yml
+++ b/.github/workflows/truffle.yml
@@ -19,7 +19,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:truffle-nightly
+      image: ghcr.io/sparklemotion/nokogiri-test:truffle-nightly
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -21,7 +21,7 @@ jobs:
   xmlsoft-head:
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:mri-3.0
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
     steps:
       - uses: actions/checkout@v2
         with:
@@ -46,7 +46,7 @@ jobs:
     needs: ["xmlsoft-head"]
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:mri-3.0
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
     steps:
       - uses: actions/checkout@v2
         with:
@@ -138,7 +138,7 @@ jobs:
   html5lib-tests:
     runs-on: ubuntu-latest
     container:
-      image: flavorjones/nokogiri-test:mri-3.0
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
     steps:
       - uses: actions/checkout@v2
         with:

--- a/oci-images/nokogiri-test/truffle-nightly.dockerfile
+++ b/oci-images/nokogiri-test/truffle-nightly.dockerfile
@@ -1,4 +1,4 @@
-FROM flavorjones/truffleruby:nightly
+FROM ghcr.io/flavorjones/truffleruby:nightly
 
 # -*- dockerfile -*-
 

--- a/oci-images/nokogiri-test/truffle.erb
+++ b/oci-images/nokogiri-test/truffle.erb
@@ -1,4 +1,4 @@
-FROM flavorjones/truffleruby:<%= version %>
+FROM ghcr.io/flavorjones/truffleruby:<%= version %>
 
 <%= File.read "debian-prelude.step" %>
 


### PR DESCRIPTION
Part of #2271

- make sure all images are generated from the same Gemfile.lock
- use the generated images (from ghcr.io) in all the pipelines
- schedule ci.yml to integration test the containers after they're generated
