### PR TITLE
feat(cruby): support line numbers larger than a short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## next / unreleased
+
+### Improved
+
+* [CRuby] `Node#line` is no longer capped at 65535. libxml v2.9.0 and later support a new parse option, exposed as `Nokogiri::XML::ParseOptions::PARSE_BIG_LINES` and set in `ParseOptions::DEFAULT_XML`, `::DEFAULT_XSLT`, `::DEFAULT_HTML`, and `::DEFAULT_SCHEMA`. (Note that JRuby never had this problem.) [[#1764](https://github.com/sparklemotion/nokogiri/issues/1764), [#1493](https://github.com/sparklemotion/nokogiri/issues/1493), [#1617](https://github.com/sparklemotion/nokogiri/issues/1617), [#1505](https://github.com/sparklemotion/nokogiri/issues/1505), [#1003](https://github.com/sparklemotion/nokogiri/issues/1003), [#533](https://github.com/sparklemotion/nokogiri/issues/533)]
+
+
 ## 1.12.3 / 2021-08-10
 
 ### Fixed

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -68,15 +68,17 @@ module Nokogiri
       NOBASEFIX   = 1 << 18
       # relax any hardcoded limit from the parser
       HUGE        = 1 << 19
+      # line numbers stored as long int (instead of a short int)
+      BIG_LINES   = 1 << 22
 
       # the default options used for parsing XML documents
-      DEFAULT_XML  = RECOVER | NONET
+      DEFAULT_XML  = RECOVER | NONET | BIG_LINES
       # the default options used for parsing XSLT stylesheets
-      DEFAULT_XSLT = RECOVER | NONET | NOENT | DTDLOAD | DTDATTR | NOCDATA
+      DEFAULT_XSLT = RECOVER | NONET | NOENT | DTDLOAD | DTDATTR | NOCDATA | BIG_LINES
       # the default options used for parsing HTML documents
-      DEFAULT_HTML = RECOVER | NOERROR | NOWARNING | NONET
+      DEFAULT_HTML = RECOVER | NOERROR | NOWARNING | NONET | BIG_LINES
       # the default options used for parsing XML schemas
-      DEFAULT_SCHEMA = NONET
+      DEFAULT_SCHEMA = NONET | BIG_LINES
 
       attr_accessor :options
       def initialize options = STRICT


### PR DESCRIPTION
**What problem is this PR intended to solve?**

As noted in #1493, #1617, #1505, #1003, and #533, libxml2 has not historically supported line numbers greater than a `short int`. Starting in libxml v2.9.0, setting the parse option `BIG_LINES` would allow tracking line numbers in longer documents.

Specifically this PR makes the following changes:

- set `BIG_LINES` parse option by default which will allow `Node#line` to return large integers
- allow `Node#line=` to set large line numbers on text nodes

Fixes #1764 

**Have you included adequate test coverage?**

Yes!

**Does this change affect the behavior of either the C or the Java implementations?**

JRuby's Xerces-based implementation did not suffer from this particular shortcoming, although its line number functionality is questionable in other ways (see #2177 / b32c875).