### PR TITLE
feat(cruby): raise RuntimeError if reparenting creates a cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 * [CRuby] Handle abruptly-closed HTML comments as WHATWG recommends for browsers. (Thanks to HackerOne user [tehryanx](https://hackerone.com/tehryanx?type=user) for reporting this!)
 * [CRuby] `Node#line` is no longer capped at 65535. libxml v2.9.0 and later support a new parse option, exposed as `Nokogiri::XML::ParseOptions::PARSE_BIG_LINES` and set in `ParseOptions::DEFAULT_XML`, `::DEFAULT_XSLT`, `::DEFAULT_HTML`, and `::DEFAULT_SCHEMA`. (Note that JRuby never had this problem.) [[#1764](https://github.com/sparklemotion/nokogiri/issues/1764), [#1493](https://github.com/sparklemotion/nokogiri/issues/1493), [#1617](https://github.com/sparklemotion/nokogiri/issues/1617), [#1505](https://github.com/sparklemotion/nokogiri/issues/1505), [#1003](https://github.com/sparklemotion/nokogiri/issues/1003), [#533](https://github.com/sparklemotion/nokogiri/issues/533)]
+* [CRuby] If a cycle is introduced when reparenting a node (i.e., the node becomes its own ancestor), a `RuntimeError` is raised. libxml2 does no checking for this, which means cycles would otherwise result in infinite loops on subsequent operations. (Note: JRuby/Xerces already does this.) [[#1912](https://github.com/sparklemotion/nokogiri/issues/1912)]
 
 
 ## 1.12.3 / 2021-08-10

--- a/test/xml/test_node_reparenting.rb
+++ b/test/xml/test_node_reparenting.rb
@@ -768,6 +768,22 @@ module Nokogiri
             assert_match(/<Component>/, insert_point.children.to_xml)
           end
         end
+
+        describe "creating a cycle in the graph" do
+          it "raises an exception" do
+            doc = Nokogiri::XML("<root><a><b/></a></root>")
+            a = doc.at_css("a")
+            b = doc.at_css("b")
+            exception = assert_raise(RuntimeError) do
+              a.parent = b
+            end
+            if Nokogiri.jruby?
+              assert_match(/HIERARCHY_REQUEST_ERR/, exception.message)
+            else
+              assert_match(/cycle detected/, exception.message)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes #1912

**Have you included adequate test coverage?**

Yes

**Does this change affect the behavior of either the C or the Java implementations?**

C is now at parity with Java
