### PR TITLE
dep: update libiconv to 1.16

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -64,11 +64,10 @@ zlib:
   # SHA-256 hash provided on http://zlib.net/
 
 libiconv:
-  version: "1.15"
-  sha256: "ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178"
-  # gpg: Signature made Fri Feb  3 00:38:12 2017 CET
+  version: "1.16"
+  sha256: "e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04"
+  # gpg: Signature made Fri 26 Apr 2019 03:36:38 PM EDT
   # gpg:                using RSA key 4F494A942E4616C2
-  # gpg: Good signature from "Bruno Haible (Open Source Development) <bruno@clisp.org>" [unknown]
-  # gpg: WARNING: This key is not certified with a trusted signature!
-  # gpg:          There is no indication that the signature belongs to the owner.
+  # gpg: Good signature from "Bruno Haible (Open Source Development) <bruno@clisp.org>" [expired]
+  # gpg: Note: This key has expired!
   # Primary key fingerprint: 68D9 4D8A AEEA D48A E7DC  5B90 4F49 4A94 2E46 16C2


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes #2206

**Have you included adequate test coverage?**

CI pipelines on darwin and windows should be sufficient.

**Does this change affect the behavior of either the C or the Java implementations?**

No.