### PR TITLE
Restore Builder namespace inheritance behavior, and introduce Document#namespace_inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,61 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] If a cycle is introduced when reparenting a node (i.e., the node becomes its own ancestor), a `RuntimeError` is raised. libxml2 does no checking for this, which means cycles would otherwise result in infinite loops on subsequent operations. (Note: JRuby/Xerces already does this.) [[#1912](https://github.com/sparklemotion/nokogiri/issues/1912)]
 
 
+## 1.12.4 / unreleased
+
+### Notable fix: Namespace inheritance
+
+Namespace behavior when reparenting nodes has historically been poorly specified and the behavior
+diverged between CRuby and JRuby. As a result, making this behavior consistent in v1.12.0 introduced
+a breaking change.
+
+This patch release reverts the Builder behavior present in v1.12.0..v1.12.3 but keeps the Document
+behavior. This release also introduces a Document attribute to allow affected users to easily change
+this behavior for their legacy code without invasive changes.
+
+
+#### Compensating Feature in XML::Document
+
+This release of Nokogiri introduces a new `Document` boolean attribute, `namespace_inheritance`,
+which controls whether children should inherit a namespace when they are reparented.
+`Nokogiri::XML:Document` defaults this attribute to `false` meaning "do not inherit," thereby making
+explicit the behavior change introduced in v1.12.0.
+
+CRuby users who desire the pre-v1.12.0 behavior may set `document.namespace_inheritance = true` before
+reparenting nodes.
+
+See https://nokogiri.org/rdoc/Nokogiri/XML/Document.html#namespace_inheritance-instance_method for
+example usage.
+
+
+#### Fix for XML::Builder
+
+However, recognizing that we want `Builder`-created children to inherit namespaces, Builder now will
+set `namespace_inheritance=true` on the underlying document for both JRuby and CRuby. This means that, on CRuby, the pre-v1.12.0 behavior is restored.
+
+Users who want to turn this behavior off may pass a keyword argument to the Builder constructor like
+so:
+
+``` ruby
+Nokogiri::XML::Builder.new(namespace_inheritance: false)
+```
+
+See https://nokogiri.org/rdoc/Nokogiri/XML/Builder.html#label-Namespace+inheritance for example
+usage.
+
+
+#### Downstream gem maintainers
+
+Note that any downstream gems may want to specifically omit Nokogiri v1.12.0--v1.12.3 from their dependency specification if they rely on child namespace inheritance:
+
+``` ruby
+Gem::Specification.new do |gem|
+  # ...
+  gem.add_runtime_dependency 'nokogiri', '!=1.12.3', '!=1.12.2', '!=1.12.1', '!=1.12.0'
+  # ...
+end
+```
+
 ### Fixed
 
 * [JRuby] Fix NPE in Schema parsing when an imported resource doesn't have a `systemId`. [[#2296](https://github.com/sparklemotion/nokogiri/issues/2296)] (Thanks, [@pepijnve](https://github.com/pepijnve)!)

--- a/ext/java/nokogiri/XmlDocumentFragment.java
+++ b/ext/java/nokogiri/XmlDocumentFragment.java
@@ -34,8 +34,6 @@ import org.w3c.dom.NamedNodeMap;
 public class XmlDocumentFragment extends XmlNode
 {
 
-  private XmlElement fragmentContext;
-
   public
   XmlDocumentFragment(Ruby ruby)
   {
@@ -75,10 +73,6 @@ public class XmlDocumentFragment extends XmlNode
     fragment.setDocument(context, doc);
     fragment.setNode(context.runtime, doc.getDocument().createDocumentFragment());
 
-    //TODO: Get namespace definitions from doc.
-    if (args.length == 3 && args[2] != null && args[2] instanceof XmlElement) {
-      fragment.fragmentContext = (XmlElement)args[2];
-    }
     Helpers.invoke(context, fragment, "initialize", args);
     return fragment;
   }
@@ -156,12 +150,6 @@ public class XmlDocumentFragment extends XmlNode
       }
     }
     return null;
-  }
-
-  public XmlElement
-  getFragmentContext()
-  {
-    return fragmentContext;
   }
 
   @Override

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -69,6 +69,13 @@ relink_namespace(xmlNodePtr reparented)
   /* Avoid segv when relinking against unlinked nodes. */
   if (reparented->type != XML_ELEMENT_NODE || !reparented->parent) { return; }
 
+  /* Make sure that our reparented node has the correct namespaces */
+  if (!reparented->ns &&
+      (reparented->doc != (xmlDocPtr)reparented->parent) &&
+      (rb_iv_get(DOC_RUBY_OBJECT(reparented->doc), "@namespace_inheritance") == Qtrue)) {
+    xmlSetNs(reparented, reparented->parent->ns);
+  }
+
   /* Search our parents for an existing definition */
   if (reparented->nsDef) {
     xmlNsPtr curr = reparented->nsDef;

--- a/lib/nokogiri/xml/builder.rb
+++ b/lib/nokogiri/xml/builder.rb
@@ -196,6 +196,41 @@ module Nokogiri
     #
     # Note the "foo:object" tag.
     #
+    # === Namespace inheritance
+    #
+    # In the Builder context, children will inherit their parent's namespace. This is the same
+    # behavior as if the underlying {XML::Document} set +namespace_inheritance+ to +true+:
+    #
+    #   result = Nokogiri::XML::Builder.new do |xml|
+    #     xml["soapenv"].Envelope("xmlns:soapenv" => "http://schemas.xmlsoap.org/soap/envelope/") do
+    #       xml.Header
+    #     end
+    #   end
+    #   result.doc.to_xml
+    #   # => <?xml version="1.0" encoding="utf-8"?>
+    #   #    <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+    #   #      <soapenv:Header/>
+    #   #    </soapenv:Envelope>
+    #
+    # Users may turn this behavior off by passing a keyword argument +namespace_inheritance:false+
+    # to the initializer:
+    #
+    #   result = Nokogiri::XML::Builder.new(namespace_inheritance: false) do |xml|
+    #     xml["soapenv"].Envelope("xmlns:soapenv" => "http://schemas.xmlsoap.org/soap/envelope/") do
+    #       xml.Header
+    #       xml["soapenv"].Body # users may explicitly opt into the namespace
+    #     end
+    #   end
+    #   result.doc.to_xml
+    #   # => <?xml version="1.0" encoding="utf-8"?>
+    #   #    <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+    #   #      <Header/>
+    #   #      <soapenv:Body/>
+    #   #    </soapenv:Envelope>
+    #
+    # For more information on namespace inheritance, please see {XML::Document#namespace_inheritance}
+    #
+    #
     # == Document Types
     #
     # To create a document type (DTD), access use the Builder#doc method to get
@@ -226,6 +261,8 @@ module Nokogiri
     #   </root>
     #
     class Builder
+      DEFAULT_DOCUMENT_OPTIONS = {namespace_inheritance: true}
+
       # The current Document object being built
       attr_accessor :doc
 
@@ -282,6 +319,7 @@ module Nokogiri
         @arity = nil
         @ns = nil
 
+        options = DEFAULT_DOCUMENT_OPTIONS.merge(options)
         options.each do |k, v|
           @doc.send(:"#{k}=", v)
         end

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -113,9 +113,55 @@ module Nokogiri
       # A list of Nokogiri::XML::SyntaxError found when parsing a document
       attr_accessor :errors
 
+      # When true, reparented elements without a namespace will inherit their new parent's
+      # namespace (if one exists). Defaults to +false+.
+      #
+      # @example Default behavior of namespace inheritance
+      #   xml = <<~EOF
+      #           <root xmlns:foo="http://nokogiri.org/default_ns/test/foo">
+      #             <foo:parent>
+      #             </foo:parent>
+      #           </root>
+      #         EOF
+      #   doc = Nokogiri::XML(xml)
+      #   parent = doc.at_xpath("//foo:parent", "foo" => "http://nokogiri.org/default_ns/test/foo")
+      #   parent.add_child("<child></child>")
+      #   doc.to_xml
+      #   # => <?xml version="1.0"?>
+      #   #    <root xmlns:foo="http://nokogiri.org/default_ns/test/foo">
+      #   #      <foo:parent>
+      #   #        <child/>
+      #   #      </foo:parent>
+      #   #    </root>
+      #
+      # @example Setting namespace inheritance to +true+
+      #   xml = <<~EOF
+      #           <root xmlns:foo="http://nokogiri.org/default_ns/test/foo">
+      #             <foo:parent>
+      #             </foo:parent>
+      #           </root>
+      #         EOF
+      #   doc = Nokogiri::XML(xml)
+      #   doc.namespace_inheritance = true
+      #   parent = doc.at_xpath("//foo:parent", "foo" => "http://nokogiri.org/default_ns/test/foo")
+      #   parent.add_child("<child></child>")
+      #   doc.to_xml
+      #   # => <?xml version="1.0"?>
+      #   #    <root xmlns:foo="http://nokogiri.org/default_ns/test/foo">
+      #   #      <foo:parent>
+      #   #        <foo:child/>
+      #   #      </foo:parent>
+      #   #    </root>
+      #
+      # @return [Boolean]
+      #
+      # @since v1.12.4
+      attr_accessor :namespace_inheritance
+
       def initialize *args # :nodoc:
         @errors     = []
         @decorators = nil
+        @namespace_inheritance = false
       end
 
       ##

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -15,6 +15,13 @@ module Nokogiri
 
         let(:xml) { Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) }
 
+        def test_default_namespace_inheritance
+          doc = Nokogiri::XML::Document.new
+          refute(doc.namespace_inheritance)
+          doc.namespace_inheritance = true
+          assert(doc.namespace_inheritance)
+        end
+
         def test_dtd_with_empty_internal_subset
           doc = Nokogiri::XML(<<~eoxml)
             <?xml version="1.0"?>

--- a/test/xml/test_node_reparenting.rb
+++ b/test/xml/test_node_reparenting.rb
@@ -557,6 +557,35 @@ module Nokogiri
               end
             end
           end
+
+          describe "given a parent node with a non-default namespace" do
+            let(:doc) do
+              Nokogiri::XML(<<~EOF)
+                <root xmlns:foo="http://nokogiri.org/default_ns/test/foo">
+                  <foo:parent>
+                  </foo:parent>
+                </root>
+              EOF
+            end
+            let(:parent) { doc.at_xpath("//foo:parent", "foo" => "http://nokogiri.org/default_ns/test/foo") }
+
+            describe "and namespace_inheritance is off" do
+              it "inserts a child node that does not inherit the parent's namespace" do
+                refute(doc.namespace_inheritance)
+                child = parent.add_child("<child></child>").first
+                assert_nil(child.namespace)
+              end
+            end
+
+            describe "and namespace_inheritance is on" do
+              it "inserts a child node that inherits the parent's namespace" do
+                doc.namespace_inheritance = true
+                child = parent.add_child("<child></child>").first
+                assert_not_nil(child.namespace)
+                assert_equal("http://nokogiri.org/default_ns/test/foo", child.namespace.href)
+              end
+            end
+          end
         end
 
         describe "#add_previous_sibling" do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

- allow users to determine how namespaces are inherited by reparented children via `Document#namespace_inheritance` atttribute which defaults to `false`
- `XML::Builder` sets `Document#namespace_inheritance` to `true` but allows it to be overridden via constructor parameter

I'd like this to be backported to v1.12.

**Deeper context**

Prior to v1.12.0, the CRuby and JRuby implementations had different behavior with respect to how children inherit namespaces when added to a parent node (via the `Node#add_child` family of methods). In CRuby, children without a namespace would automatically inherit their new parent's namespace (a bug originally reported in 2011 at [#425](https://github.com/sparklemotion/nokogiri/issues/425)). In JRuby, this was not the case and the child would either have the document's default namespace or no namespace.

In v1.12.0, a intentional change was introduced to the CRuby implementation to bring it in line with the JRuby implementation. While the maintainers consider this a "bug" "fix", it was nevertheless a breaking change for some libraries and users (see, for example, https://github.com/ebeigarts/signer/issues/30).

In addition, the intentional "fix" in v1.12.0 introduced an unintentional regression in `Nokogiri::XML::Builder` in which we actually _do_ want children to inherit their parent's namespace by default (see, for example, [#2317](https://github.com/sparklemotion/nokogiri/issues/2317)).

That said, there's evidence that users may want different namespace inheritance behavior depending on the situation. For example, [#1712](https://github.com/sparklemotion/nokogiri/issues/1712) requests a way to avoid Builder namespace inheritance.


**Have you included adequate test coverage?**

Yes. Historically the incompleteness of test coverage around namespaces during reparenting has been an issue, but I believe we now have adequate coverage to prevent regressions.


**Does this change affect the behavior of either the C or the Java implementations?**

Previously the C and Java implementations had different behavior; v1.12.0 improved that somewhat; this changeset includes changes to bring them completely in line with each other (as far as our current test coverage goes).
