### PR TITLE
fix: HTML4::Document.to_xhtml self-closing tags

### DIFF
--- a/lib/nokogiri/xml/node/save_options.rb
+++ b/lib/nokogiri/xml/node/save_options.rb
@@ -34,7 +34,7 @@ module Nokogiri
           DEFAULT_HTML = FORMAT | NO_DECLARATION | NO_EMPTY_TAGS | AS_HTML
         end
         # the default for XHTML document
-        DEFAULT_XHTML = FORMAT | NO_DECLARATION | NO_EMPTY_TAGS | AS_XHTML
+        DEFAULT_XHTML = FORMAT | NO_DECLARATION | AS_XHTML
 
         # Integer representation of the SaveOptions
         attr_reader :options

--- a/test/html4/test_document.rb
+++ b/test/html4/test_document.rb
@@ -372,6 +372,15 @@ module Nokogiri
           assert_match("UTF-8", html.to_xhtml(encoding: "UTF-8"))
         end
 
+        def test_to_xhtml_self_closing_tags
+          # https://github.com/sparklemotion/nokogiri/issues/2324
+          html = "<html><body><br><table><colgroup><col>"
+          doc = Nokogiri::HTML::Document.parse(html)
+          xhtml = doc.to_xhtml
+          assert_match(%r(<br ?/>), xhtml)
+          assert_match(%r(<col ?/>), xhtml)
+        end
+
         def test_no_xml_header
           html = Nokogiri::HTML(<<~EOHTML)
             <html>

--- a/test/html4/test_document.rb
+++ b/test/html4/test_document.rb
@@ -103,21 +103,21 @@ module Nokogiri
           assert_nil(doc.root)
         end
 
-        unless Nokogiri.uses_libxml?("~> 2.6.0")
-          def test_to_xhtml_with_indent
-            doc = Nokogiri::HTML("<html><body><a>foo</a></body></html>")
-            doc = Nokogiri::HTML(doc.to_xhtml(indent: 2))
-            assert_indent(2, doc)
-          end
+        def test_to_xhtml_with_indent
+          skip if Nokogiri.uses_libxml?("~> 2.6.0")
+          doc = Nokogiri::HTML("<html><body><a>foo</a></body></html>")
+          doc = Nokogiri::HTML(doc.to_xhtml(indent: 2))
+          assert_indent(2, doc)
+        end
 
-          def test_write_to_xhtml_with_indent
-            io = StringIO.new
-            doc = Nokogiri::HTML("<html><body><a>foo</a></body></html>")
-            doc.write_xhtml_to(io, indent: 5)
-            io.rewind
-            doc = Nokogiri::HTML(io.read)
-            assert_indent(5, doc)
-          end
+        def test_write_to_xhtml_with_indent
+          skip if Nokogiri.uses_libxml?("~> 2.6.0")
+          io = StringIO.new
+          doc = Nokogiri::HTML("<html><body><a>foo</a></body></html>")
+          doc.write_xhtml_to(io, indent: 5)
+          io.rewind
+          doc = Nokogiri::HTML(io.read)
+          assert_indent(5, doc)
         end
 
         def test_swap_should_not_exist
@@ -360,8 +360,10 @@ module Nokogiri
           File.open(HTML_FILE, "rb") { |f| temp_html_file.write(f.read) }
           temp_html_file.close
           temp_html_file.open
-          assert_equal(Nokogiri::HTML.parse(File.read(HTML_FILE)).xpath("//div/a").length,
-                       Nokogiri::HTML.parse(temp_html_file).xpath("//div/a").length)
+          assert_equal(
+            Nokogiri::HTML.parse(File.read(HTML_FILE)).xpath("//div/a").length,
+            Nokogiri::HTML.parse(temp_html_file).xpath("//div/a").length
+          )
         end
 
         def test_to_xhtml
@@ -454,8 +456,8 @@ module Nokogiri
           assert_equal("-//W3C//DTD XHTML 1.1//EN", html.internal_subset.external_id)
           assert_equal("http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd", html.internal_subset.system_id)
           assert_equal(
-            "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">", html.to_s[0,
-97]
+            "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">",
+            html.to_s[0, 97]
           )
         end
 
@@ -614,7 +616,7 @@ module Nokogiri
           EOHTML
           list = doc.css(".red")
           assert_equal(2, list.length)
-          assert_equal(%w{RED RED}, list.map(&:text))
+          assert_equal(["RED", "RED"], list.map(&:text))
         end
 
         def test_parse_can_take_io
@@ -836,8 +838,10 @@ module Nokogiri
 
             it "passes arguments to #initialize" do
               doc = klass.new("http://www.w3.org/TR/REC-html40/loose.dtd", "-//W3C//DTD HTML 4.0 Transitional//EN")
-              assert_equal(["http://www.w3.org/TR/REC-html40/loose.dtd", "-//W3C//DTD HTML 4.0 Transitional//EN"],
-                           doc.initialized_with)
+              assert_equal(
+                ["http://www.w3.org/TR/REC-html40/loose.dtd", "-//W3C//DTD HTML 4.0 Transitional//EN"],
+                doc.initialized_with
+              )
             end
           end
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Addresses the bug described in #2324

Commit 1d06b4f1 introduced `NO_EMPTY_TAGS` into `SaveOptions::DEFAULT_XHTML` which libxml2 ignored due to a long-standing bug in serialization.

libxml2 v2.9.11 fixed that serialization bug
(https://gitlab.gnome.org/GNOME/libxml2/-/commit/dc6f009) and started paying attention to the `NO_EMPTY_TAGS` save option, resulting in seeing output containing, e.g. `<col></col>` instead of `<col/>`.

This commit updates the default XHTML save options to drop the `NO_EMPTY_TAGS` flag, restoring this behavior.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

This brings the C implementation for libxml >= 2.9.11 back into agreement with the Java implementation.
