### PR TITLE
fix: HTML4::Document.to_xhtml self-closing tags (v1.12.x)

### DIFF
--- a/lib/nokogiri/xml/node/save_options.rb
+++ b/lib/nokogiri/xml/node/save_options.rb
@@ -34,7 +34,7 @@ module Nokogiri
           DEFAULT_HTML = FORMAT | NO_DECLARATION | NO_EMPTY_TAGS | AS_HTML
         end
         # the default for XHTML document
-        DEFAULT_XHTML = FORMAT | NO_DECLARATION | NO_EMPTY_TAGS | AS_XHTML
+        DEFAULT_XHTML = FORMAT | NO_DECLARATION | AS_XHTML
 
         # Integer representation of the SaveOptions
         attr_reader :options

--- a/test/html4/test_document.rb
+++ b/test/html4/test_document.rb
@@ -370,6 +370,15 @@ module Nokogiri
           assert_match("UTF-8", html.to_xhtml(encoding: "UTF-8"))
         end
 
+        def test_to_xhtml_self_closing_tags
+          # https://github.com/sparklemotion/nokogiri/issues/2324
+          html = "<html><body><br><table><colgroup><col>"
+          doc = Nokogiri::HTML::Document.parse(html)
+          xhtml = doc.to_xhtml
+          assert_match(%r(<br ?/>), xhtml)
+          assert_match(%r(<col ?/>), xhtml)
+        end
+
         def test_no_xml_header
           html = Nokogiri::HTML(<<~EOHTML)
             <html>


### PR DESCRIPTION
This is #2326 backported to v1.12.x for a patch release.