### PR TITLE
Remove outdated comments

### DIFF
--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -4423,11 +4423,6 @@ static void handle_in_foreign_content(GumboParser* parser, GumboToken* token) {
     /* Parse error */
     parser_add_parse_error(parser, token);
 
-    /*
-     * Fragment case: If the parser was originally created for the HTML
-     * fragment parsing algorithm, then act as described in the "any other
-     * start tag" entry below.
-     */
     while (
       !(
         is_mathml_integration_point(get_current_node(parser))
@@ -4437,12 +4432,6 @@ static void handle_in_foreign_content(GumboParser* parser, GumboToken* token) {
     ) {
       pop_current_node(parser);
     }
-    // XXX: The spec currently says to handle this using the in body insertion
-    // mode rules. That seems wrong. See
-    // <https://github.com/whatwg/html/issues/6808>. Instead, use the current
-    // insertion mode which seems like it works.
-    //
-    // handle_in_body(parser, token);
     handle_html_content(parser, token);
     return;
   }


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

There are outdated comments in the code. The standard changed and the comments either reflected an earlier version of the standard or described how the standard was going to change.

The first comment is incorrect. The fragment case was changed to match
the nonfragment case in https://github.com/whatwg/html/pull/6399.

The outdated comments were discovered while investigating https://github.com/sparklemotion/nokogiri/issues/2335.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

There is no functional change and no tests were added.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

Neither.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
