### PR TITLE
fix: memory leak in Reader#base_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] Fix memory leak in `Document#canonicalize` when an argument type error is raised. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]
 * [CRuby] Fix memory leak in `EncodingHandler` where iconv handlers were not being cleaned up. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]
 * [CRuby] Fix memory leak in XPath custom handlers where string arguments were not being cleaned up. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]
+* [CRuby] Fix memory leak in `Reader#base_uri` where the string returned by libxml2 was not freed. [[#2347](https://github.com/sparklemotion/nokogiri/issues/2347)]
 
 
 ### Improved

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -414,16 +414,23 @@ name(VALUE self)
  * Get the xml:base of the node
  */
 static VALUE
-base_uri(VALUE self)
+rb_xml_reader_base_uri(VALUE rb_reader)
 {
-  xmlTextReaderPtr reader;
-  const char *base_uri;
+  VALUE rb_base_uri;
+  xmlTextReaderPtr c_reader;
+  xmlChar *c_base_uri;
 
-  Data_Get_Struct(self, xmlTextReader, reader);
-  base_uri = (const char *)xmlTextReaderBaseUri(reader);
-  if (base_uri == NULL) { return Qnil; }
+  Data_Get_Struct(rb_reader, xmlTextReader, c_reader);
 
-  return NOKOGIRI_STR_NEW2(base_uri);
+  c_base_uri = xmlTextReaderBaseUri(c_reader);
+  if (c_base_uri == NULL) {
+    return Qnil;
+  }
+
+  rb_base_uri = NOKOGIRI_STR_NEW2(c_base_uri);
+  xmlFree(c_base_uri);
+
+  return rb_base_uri;
 }
 
 /*
@@ -672,7 +679,7 @@ noko_init_xml_reader()
   rb_define_method(cNokogiriXmlReader, "attribute_count", attribute_count, 0);
   rb_define_method(cNokogiriXmlReader, "attribute_nodes", rb_xml_reader_attribute_nodes, 0);
   rb_define_method(cNokogiriXmlReader, "attributes?", attributes_eh, 0);
-  rb_define_method(cNokogiriXmlReader, "base_uri", base_uri, 0);
+  rb_define_method(cNokogiriXmlReader, "base_uri", rb_xml_reader_base_uri, 0);
   rb_define_method(cNokogiriXmlReader, "default?", default_eh, 0);
   rb_define_method(cNokogiriXmlReader, "depth", depth, 0);
   rb_define_method(cNokogiriXmlReader, "empty_element?", empty_element_p, 0);


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Playing with [ruby_memcheck](https://github.com/peterzhu2118/ruby_memcheck) led to finding a few easy-to-fix memory leaks.

- `Reader#base_uri` was not freeing the string returned by `xmlTextReaderBaseUri()`

This PR also cleans up the Reader C function.


**Have you included adequate test coverage?**

#2344 is a parallel effort to automate the leak checking that I ran on the existing test suite to find these.
