### PR TITLE
Configure zlib and iconv consistently

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -285,7 +285,8 @@ ensure
 end
 
 def abort_could_not_find_library(lib)
-  abort("-----\n#{caller(1..1).first}\n#{lib} is missing. Please locate mkmf.log to investigate how it is failing.\n-----")
+  callers = caller(1..2).join("\n")
+  abort("-----\n#{callers}\n#{lib} is missing. Please locate mkmf.log to investigate how it is failing.\n-----")
 end
 
 def chdir_for_build(&block)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Bring zlib and iconv config closer to how we configure the other libraries. Specifically, we remove the `windows?` check for zlib, and we explicitly add the `include` directories for both if the mini_portile recipe has been invoked.


**Have you included adequate test coverage?**

I think existing coverage is fine, this is a refactoring. Note that this commit was originally part of #2332 and breakage was caught by the `gem-install` pipeline on windows.


**Does this change affect the behavior of either the C or the Java implementations?**

It's a slight change to how the Windows C extension is built; but a small one.