### PR TITLE
fix(jruby): XHTML formatting of non-container element closing tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] Fix memory leak in XPath custom handlers where string arguments were not being cleaned up. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]
 * [CRuby] Fix memory leak in `Reader#base_uri` where the string returned by libxml2 was not freed. [[#2347](https://github.com/sparklemotion/nokogiri/issues/2347)]
 * [JRuby] Deleting a `Namespace` from a `NodeSet` no longer modifies the `href` to be the default namespace URL.
+* [JRuby] Fix XHTML formatting of closing tags for non-container elements. [[#2355](https://github.com/sparklemotion/nokogiri/issues/2355)]
 
 
 ### Improved

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -673,6 +673,8 @@ public class SaveContextVisitor
       if (!isEmpty(name) && noEmpty) {
         buffer.append("</").append(name).append('>');
       }
+    } else if (asXhtml && !isEmpty(name)) {
+      buffer.append("</").append(name).append('>');
     }
     if (needBreakInClosing(element)) {
       if (!containsText(element)) { indentation.pop(); }

--- a/test/html4/test_node.rb
+++ b/test/html4/test_node.rb
@@ -203,6 +203,12 @@ module Nokogiri
         # are not set. the fix for GH1042 ensures a proper working clone.
         trs.inspect # assert_nothing_raised
       end
+
+      def test_fragment_node_to_xhtml # see #2355
+        html = "<h1><a></a><br>First H1</h1>"
+        fragment = Nokogiri::HTML4::DocumentFragment.parse(html)
+        assert_equal("<h1><a></a><br />First H1</h1>", fragment.at_css("h1").to_xhtml)
+      end
     end
   end
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes #2355

The JRuby code for SaveContextVisitor is brittle and clearly
buggy (since this bug exists for fragment nodes but not fragments or
document nodes?), but this seems like an easy fix.

**Have you included adequate test coverage?**

Yes. Though I fear we still don't have enough coverage on JRuby formatting.

**Does this change affect the behavior of either the C or the Java implementations?**

This brings the JRuby implementation in line with the C implementation and the XHTML spec.