### PR TITLE
ci: run native gem install on musl

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -147,6 +147,19 @@ jobs:
           path: gems
       - run: ./scripts/test-gem-install gems
 
+  cruby-x86_64-musl-install:
+    needs: ["cruby-native-package"]
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:3.0-alpine
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-x86_64-linux-gem
+          path: gems
+      - run: ./scripts/test-gem-install gems
+
   cruby-x86_64-darwin-install:
     needs: ["cruby-native-package"]
     strategy:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

This is a draft PR that I don't intend to merge. It's been created to demonstrate how the github download-artifact action fails on musl libc systems.
