### PR TITLE
ci: test native gem install on musl systems

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -147,6 +147,23 @@ jobs:
           path: gems
       - run: ./scripts/test-gem-install gems
 
+  cruby-x86_64-musl-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/sparklemotion/nokogiri-test:alpine
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-x86_64-linux-gem
+          path: gems
+      - run: ./scripts/test-gem-install gems
+
   cruby-x86_64-darwin-install:
     needs: ["cruby-native-package"]
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,12 +219,13 @@ The bulk of CI is running in Github Actions since May 2021: https://github.com/s
 
 However, we also run tests against 32-bit windows (which aren't supported by GA as of this writing) in Appveyor: https://ci.appveyor.com/project/flavorjones/nokogiri
 
-Please note that there are some known holes in CI coverage due to `actions/download-artifact` (as well as other actions) not supporting systems other than 64-bit glibc:
+Please note that there are some known holes in CI coverage due to github actions limitations:
 
-- installing ruby and native gems on Alpine/musl
-- installing ruby and native gems on 32-bit Linux
+- installing ruby and native gems on 32-bit Linux, see:
+  - [Error: /etc/*release "no such file or directory" · Issue #334 · actions/checkout](https://github.com/actions/checkout/issues/334)
+  - [actions/cache is not working as expected in 32-bit linux containers · Issue #675 · actions/cache](https://github.com/actions/cache/issues/675)
+  - [actions/upload-artifact is not working as expected in 32-bit linux containers · Issue #266 · actions/upload-artifact](https://github.com/actions/upload-artifact/issues/266)
 
-For more information, please check out [#2244](https://github.com/sparklemotion/nokogiri/issues/2244) and [#2247](https://github.com/sparklemotion/nokogiri/issues/2247) which document the migration from Concourse to Github Actions.
 
 ### Coverage
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Add CI coverage for native linux gem installation on musl libc systems.

At one point in 2021 this didn't work because the download-artifact action was failing on musl systems, but it appears to work now.

See related:

  https://github.com/flavorjones/ruby-c-extensions-explained/pull/4
