### PR TITLE
ci: oci image for alpine should have git installed

### DIFF
--- a/.github/workflows/generate-ci-images.yml
+++ b/.github/workflows/generate-ci-images.yml
@@ -18,6 +18,9 @@ jobs:
           ruby-version: "3.0"
           bundler-cache: true
       - uses: docker/setup-buildx-action@v1
+        with: # see https://github.com/docker/buildx/issues/834
+          buildkitd-flags: --debug
+          driver-opts: image=moby/buildkit:v0.9.1
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/oci-images/nokogiri-test/alpine.dockerfile
+++ b/oci-images/nokogiri-test/alpine.dockerfile
@@ -2,7 +2,7 @@ FROM ruby:alpine3.12
 
 # prelude
 RUN apk update
-RUN apk add bash build-base
+RUN apk add bash build-base git
 
 # valgrind
 RUN apk add valgrind

--- a/oci-images/nokogiri-test/alpine.erb
+++ b/oci-images/nokogiri-test/alpine.erb
@@ -2,7 +2,7 @@ FROM ruby:alpine3.12
 
 # prelude
 RUN apk update
-RUN apk add bash build-base
+RUN apk add bash build-base git
 
 # valgrind
 RUN apk add valgrind

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -66,6 +66,9 @@ module DockerHelper
                   ruby-version: "3.0"
                   bundler-cache: true
               - uses: docker/setup-buildx-action@v1
+                with: # see https://github.com/docker/buildx/issues/834
+                  buildkitd-flags: --debug
+                  driver-opts: image=moby/buildkit:v0.9.1
               - uses: docker/login-action@v1
                 with:
                   registry: ghcr.io


### PR DESCRIPTION
Update the alpine CI image to install git, in order for actions/checkout to clone submodules
