### PR TITLE
ci: allow windows 2.5 builds to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,7 @@ jobs:
       - run: bundle exec rake test
 
   windows:
+    continue-on-error: ${{matrix.ruby == '2.5'}} # see https://github.com/sparklemotion/nokogiri/issues/2354
     needs: ["basic"]
     strategy:
       fail-fast: false


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See https://github.com/sparklemotion/nokogiri/issues/2354 for an investigation into why Ruby 2.5 Windows jobs started failing last week. Until that gets sorted, this PR will make those builds "nonblocking" when they fail.
