### PR TITLE
ci: revert buildx workaround in image-building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v1 # v1 because of https://github.com/actions/checkout/issues/334
         with:
           submodules: true
-      # skip cache because of https://github.com/actions/checkout/issues/334
+      # skip cache because of https://github.com/actions/cache/issues/675
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@v1 # v1 because of https://github.com/actions/checkout/issues/334
         with:
           submodules: true
-      # skip cache because of https://github.com/actions/checkout/issues/334
+      # skip cache because of https://github.com/actions/cache/issues/675
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind

--- a/.github/workflows/generate-ci-images.yml
+++ b/.github/workflows/generate-ci-images.yml
@@ -18,9 +18,6 @@ jobs:
           ruby-version: "3.0"
           bundler-cache: true
       - uses: docker/setup-buildx-action@v1
-        with: # see https://github.com/docker/buildx/issues/834
-          buildkitd-flags: --debug
-          driver-opts: image=moby/buildkit:v0.9.1
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -66,9 +66,6 @@ module DockerHelper
                   ruby-version: "3.0"
                   bundler-cache: true
               - uses: docker/setup-buildx-action@v1
-                with: # see https://github.com/docker/buildx/issues/834
-                  buildkitd-flags: --debug
-                  driver-opts: image=moby/buildkit:v0.9.1
               - uses: docker/login-action@v1
                 with:
                   registry: ghcr.io


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Revert the workaround to https://github.com/docker/buildx/issues/834 that was solved by https://github.com/moby/buildkit/pull/2461
