### PR TITLE
Actions - use windows-2022, add windows ucrt job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,8 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.5", "2.6", "2.7", "3.0", "mingw"]
-    runs-on: windows-latest
+        ruby: ["2.5", "2.6", "2.7", "3.0", "mingw", "head"]
+    runs-on: windows-2022
     steps:
       - name: configure git crlf
         run: |
@@ -245,11 +245,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: MSP-Greg/setup-ruby-pkgs@v1
+      - uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
         with:
           ruby-version: "${{matrix.ruby}}"
           mingw: "libxml2 libxslt"
           bundler-cache: true
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Use a new Actions windows image, add full testing with Windows head build, which is a MSYS2 UCRT64 build, which will be released in a few weeks as 3.1.

The code used for Ruby setup uses the same branch as [PR 224](https://github.com/ruby/setup-ruby/pull/224) in [ruby/setup-ruby](https://github.com/ruby/setup-ruby).

**Have you included adequate test coverage?**

Used existing...

**Does this change affect the behavior of either the C or the Java implementations?**

NA