### PR TITLE
ci: vmactions/freebsd-vm needs macos-10.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

When actions's `macos-latest` moved to macos-11, the `vmactions/freebsd-vm` started failing with this error:

```
/usr/bin/sudo vboxmanage import /Users/runner/work/_actions/vmactions/freebsd-vm/v0.1.5/freebsd-13.0.ova
sudo: vboxmanage: command not found
Error: The process '/usr/bin/sudo' failed with exit code 1
```

This PR locks that job to macos-10.15.
