### PR TITLE
dep(dev): rake-compiler 1.1.2 broke darwin native builds

### DIFF
--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -325,7 +325,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest", "~> 5.8")
   spec.add_development_dependency("minitest-reporters", "~> 1.4")
   spec.add_development_dependency("rake", "~> 13.0")
-  spec.add_development_dependency("rake-compiler", "~> 1.1")
+  spec.add_development_dependency("rake-compiler", "= 1.1.1")
   spec.add_development_dependency("rake-compiler-dock", "~> 1.1")
   spec.add_development_dependency("rdoc", ">= 6.3.2")
   spec.add_development_dependency("rexical", "~> 1.0.5")


### PR DESCRIPTION
**What problem is this PR intended to solve?**

rake-compiler v1.1.2 broke darwin native builds, see https://github.com/sparklemotion/nokogiri/runs/4458677557?check_suite_focus=true for an example

This PR pins us to v1.1.1 for now

cc @larskanis 