### PR TITLE
ci: skip tests that are causing issues in CI

### DIFF
--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -88,6 +88,7 @@ module Nokogiri
       end
 
       def test_nil_raises
+        skip("https://github.com/sparklemotion/nokogiri/issues/2354") if Nokogiri::VersionInfo.instance.windows?
         assert_raises(ArgumentError) do
           Nokogiri::XML::Reader.from_memory(nil)
         end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

see #2354 which describes tests segfaulting in CI for Windows Ruby 2.5

This PR simply skips a test that we know is segfaulting in an attempt to ignore the likely root cause of gcc version incompatibilities in CI.