### PR TITLE
cleanup: remove unnecessary conditional

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1895,9 +1895,7 @@ in_context(VALUE self, VALUE _str, VALUE _options)
    */
   child_iter = node->doc->children ;
   while (child_iter) {
-    if (child_iter->parent != (xmlNodePtr)node->doc) {
-      child_iter->parent = (xmlNodePtr)node->doc;
-    }
+    child_iter->parent = (xmlNodePtr)node->doc;
     child_iter = child_iter->next;
   }
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

@kwilczynski mentioned that a static analysis tool found this:

> duplicateConditionalAssign ext/nokogiri/xml_node.c:1898 The statement 'if (child_iter->parent!=(xmlNodePtr)node->doc) child_iter->parent=(xmlNodePtr)node->doc' is logically equivalent to 'child_iter->parent=(xmlNodePtr)node->doc'.

https://gist.github.com/kwilczynski/4b2f4650b00cead133e337714260a416
