### PR TITLE
use the correct classes for fragment parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ A related discussion about Trust exists at [#2357](https://github.com/sparklemot
 ### Fixed
 
 * XML::Builder blocks restore context properly when exceptions are raised. [[#2372](https://github.com/sparklemotion/nokogiri/issues/2372)] (Thanks, [@ric2b](https://github.com/ric2b) and [@rinthedev](https://github.com/rinthedev)!)
+* Error recovery from in-context parsing (e.g., `Node#parse`) now always uses the correct `DocumentFragment` class. Previously `Nokogiri::HTML4::DocumentFragment` was always used, even for XML documents. [[#1158](https://github.com/sparklemotion/nokogiri/issues/1158)]
 * [CRuby] Fix memory leak in `Document#canonicalize` when inclusive namespaces are passed in. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]
 * [CRuby] Fix memory leak in `Document#canonicalize` when an argument type error is raised. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]
 * [CRuby] Fix memory leak in `EncodingHandler` where iconv handlers were not being cleaned up. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]

--- a/lib/nokogiri.rb
+++ b/lib/nokogiri.rb
@@ -115,6 +115,7 @@ def Nokogiri(*args, &block)
 end
 
 require_relative "nokogiri/version"
+require_relative "nokogiri/class_resolver"
 require_relative "nokogiri/syntax_error"
 require_relative "nokogiri/xml"
 require_relative "nokogiri/xslt"

--- a/lib/nokogiri/class_resolver.rb
+++ b/lib/nokogiri/class_resolver.rb
@@ -1,0 +1,67 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+require "set"
+
+module Nokogiri
+  #
+  # Some classes in Nokogiri are namespaced as a group, for example
+  # Document, DocumentFragment, and Builder.
+  #
+  # It's sometimes necessary to look up the related class, e.g.:
+  #
+  #   XML::Builder → XML::Document
+  #   HTML4::Builder → HTML4::Document
+  #   HTML5::Document → HTML5::DocumentFragment
+  #
+  # This module is included into those key classes who need to do this.
+  #
+  module ClassResolver
+    # #related_class restricts matching namespaces to those matching this set.
+    VALID_NAMESPACES = Set.new(["HTML", "HTML4", "HTML5", "XML"])
+
+    # :call-seq:
+    #   related_class(class_name) → Class
+    #
+    # Find a class constant within the
+    #
+    # Some examples:
+    #
+    #   Nokogiri::XML::Document.new.related_class("DocumentFragment")
+    #   # => Nokogiri::XML::DocumentFragment
+    #   Nokogiri::HTML4::Document.new.related_class("DocumentFragment")
+    #   # => Nokogiri::HTML4::DocumentFragment
+    #
+    # Note this will also work for subclasses that follow the same convention, e.g.:
+    #
+    #   Loofah::HTML::Document.new.related_class("DocumentFragment")
+    #   # => Loofah::HTML::DocumentFragment
+    #
+    # And even if it's a subclass, this will iterate through the superclasses:
+    #
+    #   class ThisIsATopLevelClass < Nokogiri::HTML4::Builder ; end
+    #   ThisIsATopLevelClass.new.related_class("Document")
+    #   # => Nokogiri::HTML4::Document
+    #
+    def related_class(class_name)
+      klass = nil
+      inspecting = self.class
+
+      while inspecting
+        namespace_path = inspecting.name.split("::")[0..-2]
+        inspecting = inspecting.superclass
+
+        next unless VALID_NAMESPACES.include?(namespace_path.last)
+
+        related_class_name = (namespace_path << class_name).join("::")
+        klass = begin
+          Object.const_get(related_class_name)
+        rescue NameError
+          nil
+        end
+        break if klass
+      end
+      klass
+    end
+  end
+end

--- a/lib/nokogiri/xml/builder.rb
+++ b/lib/nokogiri/xml/builder.rb
@@ -262,6 +262,8 @@ module Nokogiri
     #   </root>
     #
     class Builder
+      include Nokogiri::ClassResolver
+
       DEFAULT_DOCUMENT_OPTIONS = { namespace_inheritance: true }
 
       # The current Document object being built
@@ -307,13 +309,7 @@ module Nokogiri
           @doc = root.document
           @parent = root
         else
-          klassname = "::" + (self.class.name.split("::")[0..-2] + ["Document"]).join("::")
-          klass = begin
-            Object.const_get(klassname)
-          rescue NameError
-            Nokogiri::XML::Document
-          end
-          @parent = @doc = klass.new
+          @parent = @doc = related_class("Document").new
         end
 
         @context = nil

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -56,6 +56,7 @@ module Nokogiri
     class Node
       include Nokogiri::XML::PP::Node
       include Nokogiri::XML::Searchable
+      include Nokogiri::ClassResolver
       include Enumerable
 
       # Element node type, see Nokogiri::XML::Node#element?
@@ -936,8 +937,7 @@ module Nokogiri
       # Create a DocumentFragment containing +tags+ that is relative to _this_
       # context node.
       def fragment(tags)
-        type = document.html? ? Nokogiri::HTML : Nokogiri::XML
-        type::DocumentFragment.new(document, tags, self)
+        document.related_class("DocumentFragment").new(document, tags, self)
       end
 
       ###
@@ -988,7 +988,7 @@ module Nokogiri
         node_set = in_context(contents, options.to_i)
         if node_set.empty? && (document.errors.length > error_count)
           if options.recover?
-            fragment = Nokogiri::HTML4::DocumentFragment.parse(contents)
+            fragment = document.related_class("DocumentFragment").parse(contents)
             node_set = fragment.children
           else
             raise document.errors[error_count]

--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -232,6 +232,7 @@ Gem::Specification.new do |spec|
     "lib/nekodtd.jar",
     "lib/nekohtml.jar",
     "lib/nokogiri.rb",
+    "lib/nokogiri/class_resolver.rb",
     "lib/nokogiri/css.rb",
     "lib/nokogiri/css/node.rb",
     "lib/nokogiri/css/parser.rb",

--- a/rakelib/check-manifest.rake
+++ b/rakelib/check-manifest.rake
@@ -18,6 +18,7 @@ task :check_manifest do
     coverage
     doc
     gems
+    misc
     nokogumbo-import
     oci-images
     patches
@@ -38,6 +39,8 @@ task :check_manifest do
     .gitignore
     .gitmodules
     .yardopts
+    .rubocop.yml
+    .rubocop_todo.yml
     CHANGELOG.md
     CODE_OF_CONDUCT.md
     CONTRIBUTING.md
@@ -76,10 +79,10 @@ task :check_manifest do
 
   unless missing_files.empty?
     puts "missing:"
-    missing_files.each { |f| puts "- #{f}" }
+    missing_files.sort.each { |f| puts "- #{f}" }
   end
   unless extra_files.empty?
     puts "unexpected:"
-    extra_files.each { |f| puts "+ #{f}" }
+    extra_files.sort.each { |f| puts "+ #{f}" }
   end
 end

--- a/test/xml/test_builder.rb
+++ b/test/xml/test_builder.rb
@@ -424,11 +424,14 @@ module Nokogiri
         xml_builder = Nokogiri::XML::Builder.new
         assert_instance_of(Nokogiri::XML::Document, xml_builder.doc)
 
-        html_builder = Nokogiri::HTML::Builder.new
-        assert_instance_of(Nokogiri::HTML::Document, html_builder.doc)
+        html_builder = Nokogiri::HTML4::Builder.new
+        assert_instance_of(Nokogiri::HTML4::Document, html_builder.doc)
 
         foo_builder = ThisIsATestBuilder.new
         assert_instance_of(Nokogiri::XML::Document, foo_builder.doc)
+
+        foo_builder = ThisIsAnotherTestBuilder.new
+        assert_instance_of(Nokogiri::HTML4::Document, foo_builder.doc)
       end
 
       private
@@ -441,5 +444,9 @@ module Nokogiri
 end
 
 class ThisIsATestBuilder < Nokogiri::XML::Builder
+  # this exists for the test_builder_uses_proper_document_class and should be empty
+end
+
+class ThisIsAnotherTestBuilder < Nokogiri::HTML4::Builder
   # this exists for the test_builder_uses_proper_document_class and should be empty
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#1158 reported a bug whose root cause is the use of incorrect class (Nokogiri::HTML4::DocumentFragment instead of Nokogiri::XML::DocumentFragment) during fragment parse error recovery.

This PR introduces a new mixin, `Nokogiri::ClassResolver` for the few places in the codebase where an appropriate class needs to be chosen. (For example, a node in a `Nokogiri::XML::Document` needing to use the related `DocumentFragment` class.) `ClassResolver` is now used for fragment parsing as well as `Builder` document creation.

**Have you included adequate test coverage?**

Yes!

**Does this change affect the behavior of either the C or the Java implementations?**

No.
