### PR TITLE
update source links to https where possible

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -656,7 +656,7 @@ else
   if cross_build_p || windows?
     zlib_recipe = process_recipe("zlib", dependencies["zlib"]["version"], static_p, cross_build_p) do |recipe|
       recipe.files = [{
-        url: "http://zlib.net/fossils/#{recipe.name}-#{recipe.version}.tar.gz",
+        url: "https://zlib.net/fossils/#{recipe.name}-#{recipe.version}.tar.gz",
         sha256: dependencies["zlib"]["sha256"],
       }]
       if windows?
@@ -714,7 +714,7 @@ else
       libiconv_recipe = process_recipe("libiconv", dependencies["libiconv"]["version"], static_p,
         cross_build_p) do |recipe|
         recipe.files = [{
-          url: "http://ftp.gnu.org/pub/gnu/libiconv/#{recipe.name}-#{recipe.version}.tar.gz",
+          url: "https://ftp.gnu.org/pub/gnu/libiconv/#{recipe.name}-#{recipe.version}.tar.gz",
           sha256: dependencies["libiconv"]["sha256"],
         }]
 


### PR DESCRIPTION
* Update the source link for libiconv due to redirect not followed on windows
* Update zlib source link to `https` to be consistent where possible
* xmlsoft.org is left as `http` due to what looks like SNI hosting without `https` service for xmlsoft.org

**What problem is this PR intended to solve?**

Native build on windows seems to be failing due to redirects related to `libiconv` package retrieval.

```
---------- IMPORTANT NOTICE ----------
Building Nokogiri with a packaged version of libiconv-1.15.
Configuration options: --host\=x86_64-w64-mingw32 --enable-static
--disable-shared
--libdir\=C:/embedded/lib/ruby/gems/3.0.0/gems/nokogiri-1.12.5/ports/x86_64-w64-mingw32/libiconv/1.15/lib
--disable-dependency-tracking --disable-shared --enable-static CPPFLAGS\=-Wall
CFLAGS\=-IC:/embedded/include\ -m64\ -O3\ -march\=x86-64\
-O2\ -U_FORTIFY_SOURCE\ -g\ -fPIC
CXXFLAGS\=-IC:/metasploit-framework/embedded/include\ -m64\ -O3\ -march\=x86-64\
-O2\ -U_FORTIFY_SOURCE\ -g LDFLAGS\=

The Nokogiri maintainers intend to provide timely security updates, but if
this is a concern for you and want to use your OS/distro system library
instead, then abort this installation process and install nokogiri as
instructed at:

https://nokogiri.org/tutorials/installing_nokogiri.html#installing-using-standard-system-libraries

2 retrie(s) left for libiconv-1.15.tar.gz
1 retrie(s) left for libiconv-1.15.tar.gz
0 retrie(s) left for libiconv-1.15.tar.gz
Failed to open TCP connection to ftp.gnu.org:80 (A connection attempt failed
because the connected party did not properly respond after a period of time, or
established connection failed because connected host has failed to respond. -
connect(2) for "ftp.gnu.org" port 80)
*** extconf.rb failed ***
```

**Have you included adequate test coverage?**

No added tests as no code changes, only updates transport protocol or retrieval of external source.

**Does this change affect the behavior of either the C or the Java implementations?**

No