### PR TITLE
feat: print failing expression when nokogiri cli errors

### DIFF
--- a/bin/nokogiri
+++ b/bin/nokogiri
@@ -119,7 +119,12 @@ if @rng
     puts error.message
   end
 elsif @script
-  eval @script, binding, "<main>" # rubocop:disable Security/Eval
+  begin
+    eval(@script, binding, "<main>") # rubocop:disable Security/Eval
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    warn("ERROR: Exception raised while evaluating '#{@script}'")
+    raise e
+  end
 else
   puts "Your document is stored in @doc..."
   Nokogiri::CLI.console.start


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See #2392 for an example of UX confusion when the Nokogiri CLI contains an error that raises an exception.

This change will change the resulting output from:

```
$ nokogiri -e "$_" < /dev/null
<main>:1:in `<top (required)>': undefined local variable or method `xxxx' for main:Object (NameError)
	from /home/flavorjones/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/nokogiri-1.12.5-x86_64-linux/bin/nokogiri:112:in `eval'
	from /home/flavorjones/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/nokogiri-1.12.5-x86_64-linux/bin/nokogiri:112:in `<top (required)>'
	from /home/flavorjones/.rbenv/versions/3.0.3/bin/nokogiri:25:in `load'
	from /home/flavorjones/.rbenv/versions/3.0.3/bin/nokogiri:25:in `<main>'
```

to

```
bin/nokogiri -e "$_" < /dev/null
ERROR: Exception raised while evaluating 'asdf'
<main>:1:in `<main>': undefined local variable or method `asdf' for main:Object (NameError)
	from bin/nokogiri:123:in `eval'
	from bin/nokogiri:123:in `<main>'
```

**Have you included adequate test coverage?**

The CLI has pretty poor coverage, but I think we're OK with this right now.

**Does this change affect the behavior of either the C or the Java implementations?**

No.
