### PR TITLE
fix: DocumentFragment#> works properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ A related discussion about Trust exists at [#2357](https://github.com/sparklemot
 
 * XML::Builder blocks restore context properly when exceptions are raised. [[#2372](https://github.com/sparklemotion/nokogiri/issues/2372)] (Thanks, [@ric2b](https://github.com/ric2b) and [@rinthedev](https://github.com/rinthedev)!)
 * Error recovery from in-context parsing (e.g., `Node#parse`) now always uses the correct `DocumentFragment` class. Previously `Nokogiri::HTML4::DocumentFragment` was always used, even for XML documents. [[#1158](https://github.com/sparklemotion/nokogiri/issues/1158)]
+* `DocumentFragment#>` now works properly, matching a CSS selector against only the fragment roots. [[#1857](https://github.com/sparklemotion/nokogiri/issues/1857)]
 * [CRuby] Fix memory leak in `Document#canonicalize` when inclusive namespaces are passed in. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]
 * [CRuby] Fix memory leak in `Document#canonicalize` when an argument type error is raised. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]
 * [CRuby] Fix memory leak in `EncodingHandler` where iconv handlers were not being cleaned up. [[#2345](https://github.com/sparklemotion/nokogiri/issues/2345)]

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -133,15 +133,6 @@ module Nokogiri
         document.decorate(self)
       end
 
-      # :section: Searching via XPath or CSS Queries
-
-      ###
-      # Search this node's immediate children using CSS selector +selector+
-      def >(other)
-        ns = document.root.namespaces
-        xpath(CSS.xpath_for(other, prefix: "./", ns: ns).first)
-      end
-
       # :section: Manipulating Document Structure
 
       ###

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -103,13 +103,6 @@ module Nokogiri
       end
 
       ###
-      # Search this NodeSet's nodes' immediate children using CSS selector +selector+
-      def >(selector) # rubocop:disable Naming/BinaryOperatorParameterName
-        ns = document.root.namespaces
-        xpath(CSS.xpath_for(selector, prefix: "./", ns: ns).first)
-      end
-
-      ###
       # call-seq: search *paths, [namespace-bindings, xpath-variable-bindings, custom-handler-class]
       #
       # Search this object for +paths+, and return only the first

--- a/lib/nokogiri/xml/searchable.rb
+++ b/lib/nokogiri/xml/searchable.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 module Nokogiri
@@ -177,6 +178,15 @@ module Nokogiri
         xpath(*args).first
       end
 
+      # :call-seq:
+      #   >(selector) → NodeSet
+      #
+      # Search this node's immediate children using CSS selector +selector+
+      def >(selector) # rubocop:disable Naming/BinaryOperatorParameterName
+        ns = (document.root&.namespaces || {})
+        xpath(CSS.xpath_for(selector, prefix: "./", ns: ns).first)
+      end
+
       # :section:
 
       private
@@ -237,7 +247,7 @@ module Nokogiri
         end
         ns, binds = hashes.reverse
 
-        ns ||= document.root ? document.root.namespaces : {}
+        ns ||= (document.root&.namespaces || {})
 
         [params, handler, ns, binds]
       end

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -157,6 +157,25 @@ module Nokogiri
           end
         end
 
+        def test_search_direct_children_of_fragment
+          xml = <<~XML
+            <div class="section header" id="1">
+              <div class="subsection header">sub 1</div>
+              <div class="subsection header">sub 2</div>
+            </div>
+            <div class="section header" id="2">
+              <div class="subsection header">sub 3</div>
+              <div class="subsection header">sub 4</div>
+            </div>
+          XML
+          fragment = Nokogiri::XML.fragment(xml)
+          result = (fragment > "div.header")
+          assert_equal(2, result.length)
+          assert_equal(["1", "2"], result.map { |n| n["id"] })
+
+          assert_empty(fragment > ".no-such-match")
+        end
+
         def test_fragment_search_with_multiple_queries
           xml = <<~EOF
             <thing>

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -214,11 +214,46 @@ module Nokogiri
           assert_instance_of(subclass, node)
         end
 
-        def test_gt_string_arg
-          node = xml.at("employee")
-          nodes = (node > "name")
-          assert_equal(1, nodes.length)
-          assert_equal(node, nodes.first.parent)
+        def test_search_direct_children_of_node
+          xml = <<~XML
+            <root>
+              <div class="section header" id="1">
+                <div class="subsection header">sub 1</div>
+                <div class="subsection header">sub 2</div>
+              </div>
+              <div class="section header" id="2">
+                <div class="subsection header">sub 3</div>
+                <div class="subsection header">sub 4</div>
+              </div>
+            </root>
+          XML
+          node = Nokogiri::XML::Document.parse(xml).root
+          result = (node > "div.header")
+          assert_equal(2, result.length)
+          assert_equal(["1", "2"], result.map { |n| n["id"] })
+
+          assert_empty(node > ".no-such-match")
+        end
+
+        def test_search_direct_children_of_node_provides_root_namespaces_implicitly
+          xml = <<~XML
+            <root xmlns:foo="http://nokogiri.org/ns/foo">
+              <foo:div class="section header" id="1">
+                <foo:div class="subsection header">sub 1</foo:div>
+                <foo:div class="subsection header">sub 2</foo:div>
+              </foo:div>
+              <foo:div class="section header" id="2">
+                <foo:div class="subsection header">sub 3</foo:div>
+                <foo:div class="subsection header">sub 4</foo:div>
+              </foo:div>
+            </root>
+          XML
+          node = Nokogiri::XML::Document.parse(xml).root
+          result = (node > "foo|div.header")
+          assert_equal(2, result.length)
+          assert_equal(["1", "2"], result.map { |n| n["id"] })
+
+          assert_empty(node > ".no-such-match")
         end
 
         def test_next_element_when_next_sibling_is_element_should_return_next_sibling

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -398,9 +398,29 @@ module Nokogiri
           assert_match("<a>two</a>", html)
         end
 
-        it "gt_string_arg" do
-          assert(node_set = xml.search("//employee"))
-          assert_equal(node_set.xpath("./employeeId"), (node_set > "employeeId"))
+        it "searches direct children of nodes with :>" do
+          xml = <<~XML
+            <root>
+              <wrap>
+                <div class="section header" id="1">
+                  <div class="subsection header">sub 1</div>
+                  <div class="subsection header">sub 2</div>
+                </div>
+              </wrap>
+              <wrap>
+                <div class="section header" id="2">
+                  <div class="subsection header">sub 3</div>
+                  <div class="subsection header">sub 4</div>
+                </div>
+              </wrap>
+            </root>
+          XML
+          node_set = Nokogiri::XML::Document.parse(xml).xpath("/root/wrap")
+          result = (node_set > "div.header")
+          assert_equal(2, result.length)
+          assert_equal(["1", "2"], result.map { |n| n["id"] })
+
+          assert_empty(node_set > ".no-such-match")
         end
 
         it "at_performs_a_search_with_css" do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes #1857

Along the way we've extracted `#>` from Node and NodeSet into
Searchable.


**Have you included adequate test coverage?**

Yes, improved the existing tests for this method across
Node, NodeSet, and DocumentFragment.


**Does this change affect the behavior of either the C or the Java implementations?**

No, changes common code.