### PR TITLE
fix: Node.new second argument is typechecked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ This release ends support for:
 * [JRuby] Fix XHTML formatting of closing tags for non-container elements. [[#2355](https://github.com/sparklemotion/nokogiri/issues/2355)]
 
 
+### Deprecated
+
+* Passing a `Nokogiri::XML::Node` as the second parameter to `Node.new` is deprecated and will generate a warning. This will become an error in a future version of Nokogiri. [[#975](https://github.com/sparklemotion/nokogiri/issues/975)]
+
+
 ## 1.12.5 / 2021-09-27
 
 ### Security

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -305,6 +305,14 @@ public class XmlNode extends RubyObject
     IRubyObject name = args[0];
     IRubyObject doc = args[1];
 
+    if (!(doc instanceof XmlNode)) {
+      throw context.runtime.newArgumentError("document must be a Nokogiri::XML::Node");
+    }
+    if (!(doc instanceof XmlDocument)) {
+      // TODO: deprecate allowing Node
+      context.runtime.getWarnings().warn("Passing a Node as the second parameter to Node.new is deprecated. Please pass a Document instead, or prefer an alternative constructor like Node#add_child. This will become an error in a future release of Nokogiri.");
+    }
+
     Document document = asXmlNode(context, doc).getOwnerDocument();
     if (document == null) {
       throw context.runtime.newArgumentError("node must have owner document");

--- a/lib/nokogiri/html5.rb
+++ b/lib/nokogiri/html5.rb
@@ -254,6 +254,7 @@ module Nokogiri
     #  * :follow_limit => number of redirects which are followed
     #  * :basic_auth => [username, password]
     def self.get(uri, options = {})
+      # TODO: deprecate
       warn("Nokogiri::HTML5.get is deprecated and will be removed in a future version of Nokogiri.",
         uplevel: 1, category: :deprecated)
       get_impl(uri, options)

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -119,7 +119,7 @@ module Nokogiri
       #
       # [Parameters]
       # - +name+ (String)
-      # - +document+ (Nokogiri::XML::Document)
+      # - +document+ (Nokogiri::XML::Document) The document to which the the returned node will belong.
       # [Yields] Nokogiri::XML::Node
       # [Returns] Nokogiri::XML::Node
       #

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -726,6 +726,16 @@ module Nokogiri
           assert_equal(node, block_param, "Node.new block should be passed the new node")
         end
 
+        def test_xml_node_new_must_take_document_type
+          assert_raises(ArgumentError) do
+            Nokogiri::XML::Node.new("input", "not-a-document")
+          end
+
+          assert_output(nil, /deprecated/) do
+            Nokogiri::XML::Node.new("input", xml.root.children.first)
+          end
+        end
+
         def test_to_str
           name = xml.xpath("//name").first
           assert_match(/Margaret/, "" + name)

--- a/test/xml/test_unparented_node.rb
+++ b/test/xml/test_unparented_node.rb
@@ -91,7 +91,7 @@ module Nokogiri
       end
 
       def test_new
-        assert(node = Nokogiri::XML::Node.new("input", @node))
+        assert(node = Nokogiri::XML::Node.new("input", @node.document))
         assert_equal(1, node.node_type)
       end
 
@@ -423,7 +423,7 @@ module Nokogiri
       end
 
       def test_content
-        node = Nokogiri::XML::Node.new("form", @node)
+        node = Nokogiri::XML::Node.new("form", @node.document)
         assert_equal("", node.content)
 
         node.content = "hello world!"
@@ -445,7 +445,7 @@ module Nokogiri
         first = set[0]
         second = set[1]
 
-        node = Nokogiri::XML::Node.new("form", @node)
+        node = Nokogiri::XML::Node.new("form", @node.document)
         first.replace(node)
 
         assert(set = @node.search(".//employee"))


### PR DESCRIPTION

**What problem is this PR intended to solve?**

The second argument to Node.new **must** be a Node, and it _should_ be a Document (and a warning will be emitted if it is not).

Closes #975


**Have you included adequate test coverage?**

Yarp


**Does this change affect the behavior of either the C or the Java implementations?**

Both implementations have been updated.
