### PR TITLE
test: stop skipping windows test from #2354

### DIFF
--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -88,7 +88,6 @@ module Nokogiri
       end
 
       def test_nil_raises
-        skip("https://github.com/sparklemotion/nokogiri/issues/2354") if Nokogiri::VersionInfo.instance.windows?
         assert_raises(ArgumentError) do
           Nokogiri::XML::Reader.from_memory(nil)
         end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#2354 introduced a skip to tests that were failing on Ruby 2.5 on windows for reasons related to system library versions.

This PR removes that skip, now that 2.5 has been dropped.
