### PR TITLE
style: prefer symbols for ivar and method names

### DIFF
--- a/lib/nokogiri/html5.rb
+++ b/lib/nokogiri/html5.rb
@@ -299,7 +299,7 @@ module Nokogiri
       case response
       when Net::HTTPSuccess
         doc = parse(reencode(response.body, response["content-type"]), options)
-        doc.instance_variable_set("@response", response)
+        doc.instance_variable_set(:@response, response)
         doc.class.send(:attr_reader, :response)
         doc
       when Net::HTTPRedirection

--- a/test/html5/test_encoding.rb
+++ b/test/html5/test_encoding.rb
@@ -4,7 +4,7 @@
 require "helper"
 
 class TestHtml5Encoding < Nokogiri::TestCase
-  if "".respond_to?("encoding")
+  if "".respond_to?(:encoding)
     def test_macroman_encoding
       mac = (+"<span>\xCA</span>").force_encoding("macroman")
       doc = Nokogiri::HTML5(mac)

--- a/test/test_css_cache.rb
+++ b/test/test_css_cache.rb
@@ -64,7 +64,7 @@ class TestCssCache < Nokogiri::TestCase
     Nokogiri::CSS::Parser.set_cache(true)
 
     css = ".foo .bar .baz"
-    cache = Nokogiri::CSS::Parser.instance_variable_get("@cache")
+    cache = Nokogiri::CSS::Parser.instance_variable_get(:@cache)
 
     assert_nil(cache[css])
     Nokogiri::CSS.xpath_for(css)
@@ -79,7 +79,7 @@ class TestCssCache < Nokogiri::TestCase
     Nokogiri::CSS::Parser.set_cache(false)
 
     css = ".foo .bar .baz"
-    cache = Nokogiri::CSS::Parser.instance_variable_get("@cache")
+    cache = Nokogiri::CSS::Parser.instance_variable_get(:@cache)
 
     assert_nil(cache[css])
     Nokogiri::CSS.xpath_for(css)
@@ -91,7 +91,7 @@ class TestCssCache < Nokogiri::TestCase
     Nokogiri::CSS::Parser.set_cache(true)
 
     css = ".foo .bar .baz"
-    cache = Nokogiri::CSS::Parser.instance_variable_get("@cache")
+    cache = Nokogiri::CSS::Parser.instance_variable_get(:@cache)
 
     assert_nil(cache[css])
     Nokogiri::CSS::Parser.without_cache do

--- a/test/test_memory_leak.rb
+++ b/test/test_memory_leak.rb
@@ -167,8 +167,8 @@ class TestMemoryLeak < Nokogiri::TestCase
       20.times do
         10_000.times do
           Nokogiri::XML::Builder.new do |xml|
-            xml.send("Envelope", ns) do
-              xml.send("Foobar", ns)
+            xml.send(:Envelope, ns) do
+              xml.send(:Foobar, ns)
             end
           end
         end
@@ -182,8 +182,8 @@ class TestMemoryLeak < Nokogiri::TestCase
       20.times do
         10_000.times do
           Nokogiri::XML::Builder.new do |xml|
-            xml.send("Envelope", ns) do
-              xml.send("Foobar", ns)
+            xml.send(:Envelope, ns) do
+              xml.send(:Foobar, ns)
             end
           end
         end

--- a/test/xml/test_builder.rb
+++ b/test/xml/test_builder.rb
@@ -411,8 +411,8 @@ module Nokogiri
       def test_builder_reuses_namespaces
         # see https://github.com/sparklemotion/nokogiri/issues/1810 for memory leak report
         builder = Nokogiri::XML::Builder.new
-        builder.send("envelope", { "xmlns" => "http://schemas.xmlsoap.org/soap/envelope/" }) do
-          builder.send("package", { "xmlns" => "http://schemas.xmlsoap.org/soap/envelope/" })
+        builder.send(:envelope, { "xmlns" => "http://schemas.xmlsoap.org/soap/envelope/" }) do
+          builder.send(:package, { "xmlns" => "http://schemas.xmlsoap.org/soap/envelope/" })
         end
         envelope = builder.doc.at_css("envelope")
         package = builder.doc.at_css("package")


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Latest rubocop + style guide recommends using symbols instead of strings for method and ivar names.
