### PR TITLE
ci: test coverage for ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
     steps:
       - uses: actions/checkout@v2
         with:
@@ -47,7 +47,7 @@ jobs:
           submodules: true
       - uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.0" # OK for now, until ruby 3.1 CI is stable
           apt-get: "ragel"
           brew: "ragel"
           mingw: "ragel"
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
@@ -160,7 +160,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable"]
-        ruby: ["3.0"]
+        ruby: ["3.1"]
     env:
       BUNDLE_GEMFILE: "Gemfile-libxml-ruby"
     runs-on: ubuntu-latest
@@ -185,7 +185,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["disable"]
-        ruby: ["3.0"]
+        ruby: ["3.1"]
     env:
       BUNDLE_GEMFILE: "Gemfile-libxml-ruby"
     runs-on: ubuntu-latest
@@ -210,7 +210,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -234,7 +234,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.6", "2.7", "3.0", "mingw"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "mingw"]
     runs-on: windows-latest
     steps:
       - name: configure git crlf
@@ -302,7 +302,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["disable"]
-        ruby: ["3.0"]
+        ruby: ["3.1"]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,8 +234,8 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.6", "2.7", "3.0", "3.1", "mingw"]
-    runs-on: windows-latest
+        ruby: ["2.6", "2.7", "3.0", "3.1", "mingw", "head"]
+    runs-on: windows-2022
     steps:
       - name: configure git crlf
         run: |
@@ -244,11 +244,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: MSP-Greg/setup-ruby-pkgs@v1
+      - uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
         with:
           ruby-version: "${{matrix.ruby}}"
           mingw: "libxml2 libxslt"
           bundler-cache: true
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.6", "2.7", "3.0", "head"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.1"
       - uses: actions/download-artifact@v2
         with:
           name: cruby-gem
@@ -102,6 +102,29 @@ jobs:
           gem list -d nokogiri
           nokogiri -v
 
+  cruby-windows-install-ucrt:
+    needs: ["cruby-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: ["enable", "disable"]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: MSP-Greg/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "3.1"
+          mingw: "libxml2 libxslt"
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-gem
+          path: gems
+      - run: |
+          gem install --verbose --no-document gems/*.gem -- --${{matrix.sys}}-system-libraries
+          gem list -d nokogiri
+          nokogiri -v
 
   cruby-native-package:
     name: "cruby-native-package"

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -108,15 +108,16 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: MSP-Greg/setup-ruby-pkgs@v1
+      - uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
         with:
           ruby-version: "3.1"
           mingw: "libxml2 libxslt"
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
       - uses: actions/download-artifact@v2
         with:
           name: cruby-gem

--- a/.github/workflows/generate-ci-images.yml
+++ b/.github/workflows/generate-ci-images.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.1"
           bundler-cache: true
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
@@ -30,20 +30,6 @@ jobs:
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:alpine
           file: oci-images/nokogiri-test/alpine.dockerfile
-      - name: ubuntu
-        uses: docker/build-push-action@v2
-        with:
-          context: "."
-          push: true
-          tags: ghcr.io/sparklemotion/nokogiri-test:ubuntu
-          file: oci-images/nokogiri-test/ubuntu.dockerfile
-      - name: ubuntu32
-        uses: docker/build-push-action@v2
-        with:
-          context: "."
-          push: true
-          tags: ghcr.io/sparklemotion/nokogiri-test:ubuntu32
-          file: oci-images/nokogiri-test/ubuntu32.dockerfile
       - name: mri-2.6
         uses: docker/build-push-action@v2
         with:
@@ -65,6 +51,13 @@ jobs:
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
           file: oci-images/nokogiri-test/mri-3.0.dockerfile
+      - name: mri-3.1
+        uses: docker/build-push-action@v2
+        with:
+          context: "."
+          push: true
+          tags: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
+          file: oci-images/nokogiri-test/mri-3.1.dockerfile
       - name: truffle-nightly
         uses: docker/build-push-action@v2
         with:
@@ -72,3 +65,17 @@ jobs:
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:truffle-nightly
           file: oci-images/nokogiri-test/truffle-nightly.dockerfile
+      - name: ubuntu
+        uses: docker/build-push-action@v2
+        with:
+          context: "."
+          push: true
+          tags: ghcr.io/sparklemotion/nokogiri-test:ubuntu
+          file: oci-images/nokogiri-test/ubuntu.dockerfile
+      - name: ubuntu32
+        uses: docker/build-push-action@v2
+        with:
+          context: "."
+          push: true
+          tags: ghcr.io/sparklemotion/nokogiri-test:ubuntu32
+          file: oci-images/nokogiri-test/ubuntu32.dockerfile

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -21,7 +21,7 @@ jobs:
   xmlsoft-head:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
     steps:
       - uses: actions/checkout@v2
         with:
@@ -46,7 +46,7 @@ jobs:
     needs: ["xmlsoft-head"]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
     steps:
       - uses: actions/checkout@v2
         with:
@@ -138,7 +138,7 @@ jobs:
   html5lib-tests:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.0
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Clone https://github.com/sparklemotion/nokogiri and run `bundle install`.
 
 ### Advanced
 
-Please install the latest or previous version of CRuby (e.g., 3.0 or 2.7 as of 2021-02), and a recent version of JRuby. We recommend using `rbenv`, which is used in test scripts when necessary to test gems against multiple rubies.
+Please install the latest or previous version of CRuby (e.g., 3.1 or 3.0 as of 2022-01), and a recent version of JRuby. We recommend using `rbenv`, which is used in test scripts when necessary to test gems against multiple rubies.
 
 Please install a system version of libxml2/libxslt (see [Installing Nokogiri](https://nokogiri.org/tutorials/installing_nokogiri.html#installing-using-standard-system-libraries) for details) so that you can test against both the packaged libraries and your system libraries.
 

--- a/oci-images/nokogiri-test/mri-3.1.dockerfile
+++ b/oci-images/nokogiri-test/mri-3.1.dockerfile
@@ -1,0 +1,34 @@
+FROM ruby:3.1
+
+# -*- dockerfile -*-
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y apt-utils
+
+
+# -*- dockerfile -*-
+
+RUN apt-get install -y valgrind
+
+
+# -*- dockerfile -*-
+
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+
+
+# -*- dockerfile -*-
+
+RUN gem install bundler
+
+
+# -*- dockerfile -*-
+
+COPY Gemfile nokogiri/
+COPY Gemfile.lock nokogiri/
+COPY nokogiri.gemspec nokogiri/
+
+RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" nokogiri/Gemfile.lock | tail -n 1)"
+RUN cd nokogiri && bundle install
+

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -8,7 +8,7 @@ module DockerHelper
   IMAGE_DIR = "oci-images/nokogiri-test"
   IMAGE_NAME = "ghcr.io/sparklemotion/nokogiri-test"
   RUBIES = {
-    mri: ["2.6", "2.7", "3.0"],
+    mri: ["2.6", "2.7", "3.0", "3.1"],
     truffle: ["nightly"],
   }
 
@@ -63,7 +63,7 @@ module DockerHelper
                   submodules: true
               - uses: ruby/setup-ruby@v1
                 with:
-                  ruby-version: "3.0"
+                  ruby-version: "3.1"
                   bundler-cache: true
               - uses: docker/setup-buildx-action@v1
               - uses: docker/login-action@v1
@@ -87,7 +87,7 @@ EOF
       File.open(filename, "w") do |io|
         io.write(pipeline_prelude)
 
-        Dir.glob(File.join(IMAGE_DIR, "*.dockerfile")).each do |dockerfile|
+        Dir.glob(File.join(IMAGE_DIR, "*.dockerfile")).sort.each do |dockerfile|
           image_tag = Regexp.new("(.*)\.dockerfile").match(File.basename(dockerfile))[1]
           template_params = {
             job_name: image_tag,

--- a/suppressions/nokogiri_ruby.supp
+++ b/suppressions/nokogiri_ruby.supp
@@ -48,9 +48,7 @@
   Memcheck:Leak
   fun:malloc
   fun:objspace_xmalloc0
-  fun:ruby_xmalloc0
-  fun:ruby_xmalloc_body
-  fun:ruby_xmalloc
+  ...
   fun:xmlXPathNewParserContext
   fun:xmlXPathEval
   fun:evaluate
@@ -79,9 +77,7 @@
   Memcheck:Leak
   fun:malloc
   fun:objspace_xmalloc0
-  fun:ruby_xmalloc0
-  fun:ruby_xmalloc_body
-  fun:ruby_xmalloc
+  ...
   fun:xmlStrndup
   fun:xmlXPathParseNCName
   ...
@@ -127,9 +123,7 @@
   Memcheck:Leak
   fun:malloc
   fun:objspace_xmalloc0
-  fun:ruby_xmalloc0
-  fun:ruby_xmalloc_body
-  fun:ruby_xmalloc
+  ...
   fun:xmlXPathNodeSetCreate
   fun:xmlXPathNodeCollectAndTest
   fun:xmlXPathCompOpEval
@@ -144,9 +138,7 @@
   Memcheck:Leak
   fun:malloc
   fun:objspace_xmalloc0
-  fun:ruby_xmalloc0
-  fun:ruby_xmalloc_body
-  fun:ruby_xmalloc
+  ...
   fun:ar_alloc_table
   fun:rb_hash_aset
   fun:registr
@@ -167,9 +159,7 @@
   Memcheck:Leak
   fun:malloc
   fun:objspace_xmalloc0
-  fun:ruby_xmalloc0
-  fun:ruby_xmalloc_body
-  fun:ruby_xmalloc
+  ...
   fun:xmlNewNodeEatName
   fun:xmlNewDocNodeEatName
   fun:xmlSAX2StartElementNs
@@ -198,9 +188,7 @@
   Memcheck:Leak
   fun:malloc
   fun:objspace_xmalloc0
-  fun:ruby_xmalloc0
-  fun:ruby_xmalloc_body
-  fun:ruby_xmalloc
+  ...
   fun:xmlXPathWrapNodeSet
   fun:xmlXPathNodeCollectAndTest
   ...


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See #2397 which describes supporting Ruby 3.1 in precompiled native gem releases.


**Have you included adequate test coverage?**

Yes!


**Does this change affect the behavior of either the C or the Java implementations?**

No behavioral changes.