### PR TITLE
fix: regression in XSLT.quote_params handling non-strings (backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## 1.13.1 / unreleased
+
+### Fixed
+
+* Fix `Nokogiri::XSLT.quote_params` regression in v1.13.0 which raised an exception when non-string stylesheet parameters were passed. Non-string parameters (e.g., integers and symbols) are now explicitly supported and both keys and values will be stringified with `#to_s`. [[#2418](https://github.com/sparklemotion/nokogiri/issues/2418)]
+
+
 ## 1.13.0 / 2022-01-06
 
 ### Notes

--- a/lib/nokogiri/xslt.rb
+++ b/lib/nokogiri/xslt.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 module Nokogiri
@@ -34,22 +35,28 @@ module Nokogiri
         end
       end
 
-      ###
-      # Quote parameters in +params+ for stylesheet safety
+      # :call-seq:
+      #   quote_params(params) → Array
+      #
+      # Quote parameters in +params+ for stylesheet safety.
+      # See Nokogiri::XSLT::Stylesheet.transform for example usage.
+      #
+      # [Parameters]
+      # - +params+ (Hash, Array) XSLT parameters (key->value, or tuples of [key, value])
+      #
+      # [Returns] Array of string parameters, with quotes correctly escaped for use with XSLT::Stylesheet.transform
+      #
       def quote_params(params)
-        parray = (params.instance_of?(Hash) ? params.to_a.flatten : params).dup
-        parray.each_with_index do |v, i|
-          parray[i] = if i % 2 > 0
-            if /'/.match?(v)
-              "concat('#{v.gsub(/'/, %q{', "'", '})}')"
-            else
-              "'#{v}'"
-            end
+        params.flatten.each_slice(2).each_with_object([]) do |kv, quoted_params|
+          key, value = kv.map(&:to_s)
+          value = if /'/.match?(value)
+            "concat('#{value.gsub(/'/, %q{', "'", '})}')"
           else
-            v.to_s
+            "'#{value}'"
           end
+          quoted_params << key
+          quoted_params << value
         end
-        parray.flatten
       end
     end
   end


### PR DESCRIPTION
Backport #2420 to v1.13.x.

Closes #2418.
