### PR TITLE
fix: clearer error message on glibc incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## 1.14.0 / unreleased
+
+#### Faster, more reliable installation: Native Gem for ARM64 Linux
+
+This version of Nokogiri ships full native gem support for the `aarch64-linux` platform, which should support AWS Graviton and other ARM Linux platforms. Please note that glibc >= 2.29 is required for aarch64-linux systems, see [Supported Platforms](https://nokogiri.org/#supported-platforms) for more information.
+
+
 ## 1.13.1 / 2022-01-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -119,9 +119,12 @@ Requirements:
 
 Nokogiri ships pre-compiled, "native" gems for the following platforms:
 
-- Linux: `x86-linux` and `x86_64-linux` (req: `glibc >= 2.17`), including musl platforms like Alpine
+- Linux:
+  - `x86-linux` and `x86_64-linux` (req: `glibc >= 2.17`)
+  - `aarch64-linux` (req: `glibc >= 2.29`)
+  - Note that musl platforms like Alpine are supported
 - Darwin/MacOS: `x86_64-darwin` and `arm64-darwin`
-- Windows: `x86-mingw32` and `x64-mingw32`
+- Windows: `x86-mingw32`, `x64-mingw32`, and `x64-mingw-ucrt`
 - Java: any platform running JRuby 9.3 or higher
 
 To determine whether your system supports one of these gems, look at the output of `bundle platform` or `ruby -e 'puts Gem::Platform.local.to_s'`.

--- a/lib/nokogiri/extension.rb
+++ b/lib/nokogiri/extension.rb
@@ -9,7 +9,8 @@ rescue LoadError => e
   if /GLIBC/.match?(e.message)
     warn(<<~EOM)
 
-      ERROR: It looks like you're trying to use Nokogiri as a precompiled native gem on a system with glibc < 2.17:
+      ERROR: It looks like you're trying to use Nokogiri as a precompiled native gem on a system
+             with an unsupported version of glibc.
 
         #{e.message}
 


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Closes #2427, providing a clearer error message on glibc incompatibility.

Also add aarch64-linux to the set of supported platforms, and note the
version of glibc required.

**Have you included adequate test coverage?**

No


**Does this change affect the behavior of either the C or the Java implementations?**

No