### PR TITLE
ext(package): update to rake-compiler 1.1.8

### DIFF
--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -326,7 +326,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest", "~> 5.15")
   spec.add_development_dependency("minitest-reporters", "~> 1.4")
   spec.add_development_dependency("rake", "~> 13.0")
-  spec.add_development_dependency("rake-compiler", "= 1.1.7")
+  spec.add_development_dependency("rake-compiler", "= 1.1.8")
   spec.add_development_dependency("rake-compiler-dock", "~> 1.2")
   spec.add_development_dependency("rdoc", "~> 6.3")
   spec.add_development_dependency("rexical", "~> 1.0.7")

--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -405,15 +405,6 @@ else
       spec.files.reject! { |path| File.fnmatch?("gumbo-parser/**/*", path) }
       spec.dependencies.reject! { |dep| dep.name == "mini_portile2" }
 
-      # I would like rake-compiler to do this, but can't quite figure it out right now
-      supported_rubies = CROSS_RUBIES.select { |c| spec.platform =~ c.platform }
-        .map { |c| Gem::Version.new(c.ver) }
-        .sort
-      spec.required_ruby_version = [
-        ">= #{supported_rubies.first.to_s.split(".").take(2).join(".")}",
-        "< #{supported_rubies.last.to_s.split(".").take(2).join(".").succ}.dev",
-      ]
-
       # when pre-compiling a native gem, package all the C headers sitting in ext/nokogiri/include
       # which were copied there in the $INSTALLFILES section of extconf.rb.
       # (see scripts/test-gem-file-contents and scripts/test-gem-installation for tests)


### PR DESCRIPTION

**What problem is this PR intended to solve?**

update to rake-compiler 1.1.8 which contains https://github.com/rake-compiler/rake-compiler/pull/199, and remove the workaround for ruby required versions


**Have you included adequate test coverage?**

Test coverage was originally introduced in 56b89d9 when the workaround was introduced.

**Does this change affect the behavior of either the C or the Java implementations?**

No.