### PR TITLE
Correctly serialize UTF-16 documents that are longer than libxml2's internal string buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ## 1.14.0 / unreleased
 
+### Notes
+
 #### Faster, more reliable installation: Native Gem for ARM64 Linux
 
 This version of Nokogiri ships full native gem support for the `aarch64-linux` platform, which should support AWS Graviton and other ARM Linux platforms. Please note that glibc >= 2.29 is required for aarch64-linux systems, see [Supported Platforms](https://nokogiri.org/#supported-platforms) for more information.
@@ -14,6 +16,11 @@ This version of Nokogiri ships full native gem support for the `aarch64-linux` p
 #### Maven-managed JRuby dependencies
 
 This version of Nokogiri uses [`jar-dependencies`](https://github.com/mkristian/jar-dependencies) to manage most of the vendored Java dependencies. `nokogiri -v` now outputs maven metadata for all Java dependencies, and `Nokogiri::VERSION_INFO` also contains this metadata. [[#2432](https://github.com/sparklemotion/nokogiri/issues/2432)]
+
+
+### Fixed
+
+* [CRuby] UTF-16-encoded documents longer than ~4000 code points now serialize properly. Previously the serialized document was corrupted when it exceeded the length of libxml2's internal string buffer. [[#752](https://github.com/sparklemotion/nokogiri/issues/752)]
 
 
 ## 1.13.1 / 2022-01-13

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -49,7 +49,7 @@ void noko_init_html_sax_push_parser(void);
 void noko_init_gumbo(void);
 void noko_init_test_global_handlers(void);
 
-static ID id_read, id_write;
+static ID id_read, id_write, id_external_encoding;
 
 
 #ifndef HAVE_VASPRINTF
@@ -135,9 +135,10 @@ noko_io_write(void *io, char *c_buffer, int c_buffer_len)
 {
   VALUE rb_args[2], rb_n_bytes_written;
   VALUE rb_io = (VALUE)io;
+  rb_encoding *io_encoding = rb_to_encoding(rb_funcall(rb_io, id_external_encoding, 0));
 
   rb_args[0] = rb_io;
-  rb_args[1] = rb_str_new(c_buffer, (long)c_buffer_len);
+  rb_args[1] = rb_enc_str_new(c_buffer, (long)c_buffer_len, io_encoding);
 
   rb_n_bytes_written = rb_rescue(noko_io_write_check, (VALUE)rb_args, noko_io_write_failed, 0);
   if (rb_n_bytes_written == Qundef) { return -1; }
@@ -277,4 +278,5 @@ Init_nokogiri()
 
   id_read = rb_intern("read");
   id_write = rb_intern("write");
+  id_external_encoding = rb_intern("external_encoding");
 }

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -1188,12 +1188,11 @@ module Nokogiri
           }
         end
 
-        encoding = options[:encoding] || document.encoding
-        options[:encoding] = encoding
+        options[:encoding] ||= document.encoding
+        encoding = Encoding.find(options[:encoding] || "UTF-8")
 
-        outstring = +""
-        outstring.force_encoding(Encoding.find(encoding || "utf-8"))
-        io = StringIO.new(outstring)
+        io = StringIO.new(String.new(encoding: encoding), "wb:#{encoding}:#{encoding}")
+
         write_to(io, options, &block)
         io.string
       end

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -491,14 +491,6 @@ module Nokogiri
           assert_equal(xml.root.to_s, xml.root.to_s)
         end
 
-        def test_encoding=
-          xml.encoding = "UTF-8"
-          assert_match("UTF-8", xml.to_xml)
-
-          xml.encoding = "EUC-JP"
-          assert_match("EUC-JP", xml.to_xml)
-        end
-
         def test_namespace_should_not_exist
           assert_raises(NoMethodError) do
             xml.namespace

--- a/test/xml/test_document_encoding.rb
+++ b/test/xml/test_document_encoding.rb
@@ -5,28 +5,44 @@ require "helper"
 module Nokogiri
   module XML
     class TestDocumentEncoding < Nokogiri::TestCase
-      def setup
-        super
-        @xml = Nokogiri::XML(File.read(SHIFT_JIS_XML), SHIFT_JIS_XML)
-      end
+      describe "Nokogiri::XML::Document encoding" do
+        let(:shift_jis_document) { Nokogiri::XML(File.read(SHIFT_JIS_XML), SHIFT_JIS_XML) }
+        let(:ascii_document) { Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE) }
 
-      def test_url
-        assert_equal("UTF-8", @xml.url.encoding.name)
-      end
+        describe "#encoding" do
+          it "describes the document's encoding correctly" do
+            assert_equal("Shift_JIS", shift_jis_document.encoding)
+          end
 
-      def test_encoding
-        assert_equal("UTF-8", @xml.encoding.encoding.name)
-      end
+          it "applies the specified encoding even if on empty documents" do
+            encoding = "Shift_JIS"
+            assert_equal(encoding, Nokogiri::XML(nil, nil, encoding).encoding)
+          end
+        end
 
-      def test_dotted_version
-        skip_unless_libxml2
-        assert_equal("UTF-8", Nokogiri::LIBXML_COMPILED_VERSION.encoding.name)
-        assert_equal("UTF-8", Nokogiri::LIBXSLT_COMPILED_VERSION.encoding.name)
-      end
+        describe "#encoding=" do
+          it "determines the document's encoding when serialized" do
+            ascii_document.encoding = "UTF-8"
+            assert_match("encoding=\"UTF-8\"", ascii_document.to_xml)
 
-      def test_empty_doc_encoding
-        encoding = "US-ASCII"
-        assert_equal(encoding, Nokogiri::XML(nil, nil, encoding).encoding)
+            ascii_document.encoding = "EUC-JP"
+            assert_match("encoding=\"EUC-JP\"", ascii_document.to_xml)
+          end
+        end
+
+        it "encodes the URL as UTF-8" do
+          assert_equal("UTF-8", shift_jis_document.url.encoding.name)
+        end
+
+        it "encodes the encoding name as UTF-8" do
+          assert_equal("UTF-8", shift_jis_document.encoding.encoding.name)
+        end
+
+        it "encodes the library versions as UTF-8" do
+          skip_unless_libxml2
+          assert_equal("UTF-8", Nokogiri::LIBXML_COMPILED_VERSION.encoding.name)
+          assert_equal("UTF-8", Nokogiri::LIBXSLT_COMPILED_VERSION.encoding.name)
+        end
       end
     end
   end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#752 reported a bug in serializing long UTF-16 documents.

The serialized document was corrupted when we were not being careful to use the document encoding while collecting multiple libxml2 buffer flushes. As a result, an incorrect number of bytes were written, including some garbage, as well as incorrect BOMs appearing in the middle of the serialized document.

This fix works by setting the external encoding on the StringIO object used to collecting the serialized stream, and then using that encoding when constructing intermediate strings from libxml2's buffer.


**Have you included adequate test coverage?**

Yes!


**Does this change affect the behavior of either the C or the Java implementations?**

This fixes the CRuby/libxml2 behavior which now matches the JRuby behavior.