### PR TITLE
refactor: simplify fix from 2e260f5 / #2434

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -1191,7 +1191,7 @@ module Nokogiri
         options[:encoding] ||= document.encoding
         encoding = Encoding.find(options[:encoding] || "UTF-8")
 
-        io = StringIO.new(String.new(encoding: encoding), "wb:#{encoding}:#{encoding}")
+        io = StringIO.new(String.new(encoding: encoding))
 
         write_to(io, options, &block)
         io.string

--- a/test/xml/test_document_encoding.rb
+++ b/test/xml/test_document_encoding.rb
@@ -50,7 +50,7 @@ module Nokogiri
 
           # the document needs to be large enough to trigger a libxml2 buffer flush. the buffer size
           # is determined by MINLEN in xmlIO.c, which is hardcoded to 4000 code points.
-          size = 4000
+          size = 8000
           input = String.new(<<~XML, encoding: "UTF-16")
             <?xml version="1.0" encoding="UTF-16"?>
             <root>


### PR DESCRIPTION
**What problem is this PR intended to solve?**

This PR simplifies the fix submitted in #2434, there's no need to explicitly specify the encoding in the IO open mode string.

**Have you included adequate test coverage?**

It's a refactor, existing test coverage is fine. Note in particular the test added in #2434.

**Does this change affect the behavior of either the C or the Java implementations?**

No.