### PR TITLE
Correctly handle text in form elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This version of Nokogiri uses [`jar-dependencies`](https://github.com/mkristian/
 ### Fixed
 
 * [CRuby] UTF-16-encoded documents longer than ~4000 code points now serialize properly. Previously the serialized document was corrupted when it exceeded the length of libxml2's internal string buffer. [[#752](https://github.com/sparklemotion/nokogiri/issues/752)]
-
+* [HTML5] The Gumbo parser now correctly handles text at the end of `form` elements.
 
 ## 1.13.1 / 2022-01-13
 

--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -3057,6 +3057,9 @@ static void handle_in_body(GumboParser* parser, GumboToken* token) {
         ignore_token(parser);
         return;
       }
+      // Since we remove the form node without popping, we need to make sure
+      // that we flush any text nodes at the end of the form.
+      maybe_flush_text_node_buffer(parser);
       // This differs from implicitly_close_tags because we remove *only* the
       // <form> element; other nodes are left in scope.
       generate_implied_end_tags(parser, GUMBO_TAG_LAST, NULL);

--- a/gumbo-parser/test/parser.cc
+++ b/gumbo-parser/test/parser.cc
@@ -1285,6 +1285,31 @@ TEST_F(GumboParserTest, MisnestedFormInTable) {
   ASSERT_EQ(0, GetChildCount(form2));
 }
 
+TEST_F(GumboParserTest, TextInForm) {
+  Parse("<form>text</form>");
+  GumboNode* html = GetChild(root_, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, html->type);
+  EXPECT_EQ(GUMBO_TAG_HTML, GetTag(html));
+  EXPECT_EQ(GUMBO_INSERTION_BY_PARSER | GUMBO_INSERTION_IMPLICIT_END_TAG |
+                GUMBO_INSERTION_IMPLIED,
+      html->parse_flags);
+  ASSERT_EQ(2, GetChildCount(html));
+
+  GumboNode* body = GetChild(html, 1);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, body->type);
+  EXPECT_EQ(GUMBO_TAG_BODY, GetTag(body));
+  ASSERT_EQ(1, GetChildCount(body));
+
+  GumboNode* form = GetChild(body, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, form->type);
+  EXPECT_EQ(GUMBO_TAG_FORM, GetTag(form));
+  ASSERT_EQ(1, GetChildCount(form));
+
+  GumboNode* text = GetChild(form, 0);
+  ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
+  EXPECT_STREQ("text", text->v.text.text);
+}
+
 TEST_F(GumboParserTest, NestedRawtextTags) {
   Parse(
       "<noscript><noscript jstag=false>"


### PR DESCRIPTION
In the usual course of events, a `</form>` tag does _not_ pop all of the
nodes off the stack of open elements until a `form` element is popped.
Instead, it only removes the `form` element itself. Popping in the
normal fashion will flush any text node that is in the process of being
constructed.

This commit adds that flushing when `</form>` is encountered as well.

Fixes: #2450

**What problem is this PR intended to solve?**

#2450 

**Have you included adequate test coverage?**

Yes. The Gumbo parser's test suite was updated to test for this.

**Does this change affect the behavior of either the C or the Java implementations?**

It affects the C implementation's HTML5.
