### PR TITLE
ci: Change Ruby setup to standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,12 +244,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
+      - uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: "${{matrix.ruby}}"
           mingw: "libxml2 libxslt"
           bundler-cache: true
-          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -113,11 +113,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
+      - uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: "3.1"
           mingw: "libxml2 libxslt"
-          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
       - uses: actions/download-artifact@v2
         with:
           name: cruby-gem
@@ -289,10 +288,9 @@ jobs:
         ruby: ["3.1"]
     runs-on: windows-2022
     steps:
-      - uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
+      - uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: "${{matrix.ruby}}"
-          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
       - uses: actions/download-artifact@v2
         with:
           name: cruby-x64-mingw-ucrt-gem

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -83,13 +83,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: MSP-Greg/setup-ruby-pkgs@ucrt
+      - uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: "head"
           apt-get: "libxml2-dev libxslt1-dev pkg-config"
           mingw: "_upgrade_ libxml2 libxslt pkgconf"
           bundler-cache: true
-          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/00-win-ucrt
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Currently, Actions CI is using non-standard branches for Ruby setup.  When the branches were used, changes had not been merged to the various actions repos (MSP-Greg/setup-ruby-pkgs, ruby/setup-ruby).  Updates have been merged.

**Have you included adequate test coverage?**

When tested in my fork, updated CI workflows ran as they do in main

**Does this change affect the behavior of either the C or the Java implementations?**

na, as only workflow files have been changed