### PR TITLE
ci: test ruby 3.1 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,8 +34,8 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: 30
-    - ruby_version: 30
+    - ruby_version: 31
+    - ruby_version: 31
       INSTALL_PACKAGES: "mingw-w64-i686-libxslt"
       EXTCONF_PARAMS: "--use-system-libraries"
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

We use Appveyor to test 32-bit windows, and it wasn't previously updated to test Ruby 3.1.


**Have you included adequate test coverage?**

Yes.


**Does this change affect the behavior of either the C or the Java implementations?**

No functional changes.