### PR TITLE
Run "upstream" CI periodically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.6", "2.7", "3.0", "3.1", "mingw", "head"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "mingw"]
     runs-on: windows-2022
     steps:
       - name: configure git crlf

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -4,16 +4,6 @@ concurrency:
   cancel-in-progress: true
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - v*.*.x
-    tags:
-      - v*.*.*
-  pull_request:
-    types: [opened, synchronize]
-    branches:
-      - '*'
   schedule:
     - cron: "0 8 * * 1,3,5" # At 08:00 on Monday, Wednesday, and Friday # https://crontab.guru/#0_8_*_*_1,3,5
 

--- a/scripts/compile-against-libxml2-source
+++ b/scripts/compile-against-libxml2-source
@@ -17,7 +17,7 @@ fi
 if [[ $clean_p -gt 0 ]] ; then
   make clean || true
 
-  ./configure --prefix="${PREFIX}" --without-python --without-readline --with-c14n --with-debug --with-threads --with-iconv=yes --host=x86_64-pc-linux-gnu CFLAGS="-O2 -g"
+  ./configure --prefix="${PREFIX}" --without-python --without-readline --with-c14n --with-debug --with-threads --with-iconv=yes --host=x86_64-pc-linux-gnu CFLAGS="-O2 -g -std=c89 -D_XOPEN_SOURCE=700"
 fi
 
 make install


### PR DESCRIPTION
**What problem is this PR intended to solve?**

As discussed in #2449, there's little value to running the "upstream" CI jobs on every commit or pull request. This PR moves them to run a few times a week on a timer.
