### PR TITLE
style(rubocop): newline after guard clause

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -382,6 +382,7 @@ def iconv_configure_flags
   ["iconv", "opt"].each do |target|
     config = preserving_globals { dir_config(target) }
     next unless config.any? && try_link_iconv("--with-#{target}-* flags") { dir_config(target) }
+
     idirs, ldirs = config.map do |dirs|
       Array(dirs).flat_map do |dir|
         dir.split(File::PATH_SEPARATOR)

--- a/lib/nokogiri/css/parser_extras.rb
+++ b/lib/nokogiri/css/parser_extras.rb
@@ -24,12 +24,14 @@ module Nokogiri
         # Get the css selector in +string+ from the cache
         def [](string)
           return nil unless cache_on?
+
           @mutex.synchronize { @cache[string] }
         end
 
         # Set the css selector in +string+ in the cache to +value+
         def []=(string, value)
           return value unless cache_on?
+
           @mutex.synchronize { @cache[string] = value }
         end
 

--- a/lib/nokogiri/html4/document.rb
+++ b/lib/nokogiri/html4/document.rb
@@ -241,6 +241,7 @@ module Nokogiri
 
           def start_element(name, attrs = [])
             return unless name == "meta"
+
             attr = Hash[attrs]
             (charset = attr["charset"]) &&
               (@encoding = charset)

--- a/lib/nokogiri/html4/sax/parser.rb
+++ b/lib/nokogiri/html4/sax/parser.rb
@@ -30,6 +30,7 @@ module Nokogiri
         def parse_memory(data, encoding = "UTF-8")
           raise ArgumentError unless data
           return if data.empty?
+
           ctx = ParserContext.memory(data, encoding)
           yield ctx if block_given?
           ctx.parse_with(self)
@@ -51,6 +52,7 @@ module Nokogiri
           raise ArgumentError unless filename
           raise Errno::ENOENT unless File.exist?(filename)
           raise Errno::EISDIR if File.directory?(filename)
+
           ctx = ParserContext.file(filename, encoding)
           yield ctx if block_given?
           ctx.parse_with(self)

--- a/lib/nokogiri/html5.rb
+++ b/lib/nokogiri/html5.rb
@@ -361,6 +361,7 @@ module Nokogiri
       # :nodoc:
       def prepend_newline?(node)
         return false unless ["pre", "textarea", "listing"].include?(node.name) && !node.children.empty?
+
         first_child = node.children[0]
         first_child.text? && first_child.content.start_with?("\n")
       end

--- a/lib/nokogiri/html5/document.rb
+++ b/lib/nokogiri/html5/document.rb
@@ -40,16 +40,19 @@ module Nokogiri
           unless string_or_io.respond_to?(:read) || string_or_io.respond_to?(:to_str)
             raise ArgumentError, "not a string or IO object"
           end
+
           do_parse(string_or_io, url, encoding, options)
         end
 
         def read_io(io, url = nil, encoding = nil, **options)
           raise ArgumentError, "io object doesn't respond to :read" unless io.respond_to?(:read)
+
           do_parse(io, url, encoding, options)
         end
 
         def read_memory(string, url = nil, encoding = nil, **options)
           raise ArgumentError, "string object doesn't respond to :to_str" unless string.respond_to?(:to_str)
+
           do_parse(string, url, encoding, options)
         end
 

--- a/lib/nokogiri/html5/node.rb
+++ b/lib/nokogiri/html5/node.rb
@@ -27,6 +27,7 @@ module Nokogiri
     module Node
       def inner_html(options = {})
         return super(options) unless document.is_a?(HTML5::Document)
+
         result = options[:preserve_newline] && HTML5.prepend_newline?(self) ? +"\n" : +""
         result << children.map { |child| child.to_html(options) }.join
         result
@@ -34,6 +35,7 @@ module Nokogiri
 
       def write_to(io, *options)
         return super(io, *options) unless document.is_a?(HTML5::Document)
+
         options = options.first.is_a?(Hash) ? options.shift : {}
         encoding = options[:encoding] || options[0]
         if Nokogiri.jruby?
@@ -64,6 +66,7 @@ module Nokogiri
 
       def fragment(tags)
         return super(tags) unless document.is_a?(HTML5::Document)
+
         DocumentFragment.new(document, tags, self)
       end
 
@@ -76,6 +79,7 @@ module Nokogiri
       # actually create the xml namespace if it doesn't exist already.
       def add_child_node_and_reparent_attrs(node)
         return super(node) unless document.is_a?(HTML5::Document)
+
         # I'm not sure what this method is supposed to do. Reparenting
         # namespaces is handled by libxml2, including child namespaces which
         # this method wouldn't handle.

--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -193,6 +193,7 @@ module Nokogiri
   def self.uses_libxml?(requirement = nil)
     return false unless VersionInfo.instance.libxml2?
     return true unless requirement
+
     Gem::Requirement.new(requirement).satisfied_by?(VersionInfo.instance.loaded_libxml_version)
   end
 

--- a/lib/nokogiri/xml.rb
+++ b/lib/nokogiri/xml.rb
@@ -27,6 +27,7 @@ module Nokogiri
         if string_or_io.respond_to?(:read)
           return Reader.from_io(string_or_io, url, encoding, options.to_i)
         end
+
         Reader.from_memory(string_or_io, url, encoding, options.to_i)
       end
 

--- a/lib/nokogiri/xml/builder.rb
+++ b/lib/nokogiri/xml/builder.rb
@@ -363,6 +363,7 @@ module Nokogiri
 
         @parent.ancestors.each do |a|
           next if a == doc
+
           @ns = a.namespace_definitions.find { |x| x.prefix == ns.to_s }
           return self if @ns
         end
@@ -407,6 +408,7 @@ module Nokogiri
             if node.namespace.nil?
               raise ArgumentError, "Namespace #{@ns[:pending]} has not been defined"
             end
+
             @ns = nil
           end
 

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -331,6 +331,7 @@ module Nokogiri
       # the document or +nil+ when there is no DTD.
       def validate
         return nil unless internal_subset
+
         internal_subset.validate(self)
       end
 
@@ -363,8 +364,10 @@ module Nokogiri
       # Apply any decorators to +node+
       def decorate(node)
         return unless @decorators
+
         @decorators.each do |klass, list|
           next unless node.is_a?(klass)
+
           list.each { |moodule| node.extend(moodule) }
         end
       end
@@ -390,9 +393,11 @@ module Nokogiri
 
       def add_child(node_or_tags)
         raise "A document may not have multiple root nodes." if (root && root.name != "nokogiri_text_wrapper") && !(node_or_tags.comment? || node_or_tags.processing_instruction?)
+
         node_or_tags = coerce(node_or_tags)
         if node_or_tags.is_a?(XML::NodeSet)
           raise "A document may not have multiple root nodes." if node_or_tags.size > 1
+
           super(node_or_tags.first)
         else
           super

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -163,6 +163,7 @@ module Nokogiri
         if (first = children.first)
           # Mimic the error add_child would raise.
           raise "Document already has a root node" if document? && !(node_or_tags.comment? || node_or_tags.processing_instruction?)
+
           first.__send__(:add_sibling, :previous, node_or_tags)
         else
           add_child(node_or_tags)
@@ -1072,6 +1073,7 @@ module Nokogiri
       # nil on XML documents and on unknown tags.
       def description
         return nil if document.xml?
+
         Nokogiri::HTML4::ElementDescription[name]
       end
 
@@ -1119,6 +1121,7 @@ module Nokogiri
 
         while parents.last.respond_to?(:parent)
           break unless (ctx_parent = parents.last.parent)
+
           parents << ctx_parent
         end
 
@@ -1150,6 +1153,7 @@ module Nokogiri
       def ==(other)
         return false unless other
         return false unless other.respond_to?(:pointer_id)
+
         pointer_id == other.pointer_id
       end
 
@@ -1159,6 +1163,7 @@ module Nokogiri
       def <=>(other)
         return nil unless other.is_a?(Nokogiri::XML::Node)
         return nil unless document == other.document
+
         compare(other)
       end
 

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -27,6 +27,7 @@ module Nokogiri
       # Get the first element of the NodeSet.
       def first(n = nil)
         return self[0] unless n
+
         list = []
         [n, length].min.times { |i| list << self[i] }
         list
@@ -302,6 +303,7 @@ module Nokogiri
       # the set is empty
       def pop
         return nil if length == 0
+
         delete(last)
       end
 
@@ -310,6 +312,7 @@ module Nokogiri
       # +nil+ if the set is empty.
       def shift
         return nil if length == 0
+
         delete(first)
       end
 
@@ -320,6 +323,7 @@ module Nokogiri
       def ==(other)
         return false unless other.is_a?(Nokogiri::XML::NodeSet)
         return false unless length == other.length
+
         each_with_index do |node, i|
           return false unless node == other[i]
         end

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -89,6 +89,7 @@ module Nokogiri
 
       constants.each do |constant|
         next if constant.to_sym == :STRICT
+
         class_eval %{
           def #{constant.downcase}
             @options |= #{constant}

--- a/lib/nokogiri/xml/sax/parser.rb
+++ b/lib/nokogiri/xml/sax/parser.rb
@@ -101,6 +101,7 @@ module Nokogiri
           raise ArgumentError unless filename
           raise Errno::ENOENT unless File.exist?(filename)
           raise Errno::EISDIR if File.directory?(filename)
+
           ctx = ParserContext.file(filename)
           yield ctx if block_given?
           ctx.parse_with(self)

--- a/lib/nokogiri/xml/syntax_error.rb
+++ b/lib/nokogiri/xml/syntax_error.rb
@@ -64,6 +64,7 @@ module Nokogiri
 
       def location_to_s
         return nil if nil_or_zero?(line) && nil_or_zero?(column)
+
         "#{line}:#{column}"
       end
     end

--- a/scripts/test-exported-symbols
+++ b/scripts/test-exported-symbols
@@ -45,6 +45,7 @@ symbols.to_a.sort.each do |symbol|
   next if symbol == "Init_nokogiri"
   next if /^Nokogiri_/.match?(symbol)
   next if /^noko_/.match?(symbol)
+
   puts "- #{symbol}"
 end
 

--- a/scripts/test-gem-file-contents
+++ b/scripts/test-gem-file-contents
@@ -38,6 +38,7 @@ gemfile_contents = Dir.mktmpdir do |dir|
     unless system("tar -xf #{gemfile} data.tar.gz")
       raise "could not unpack gem #{gemfile}"
     end
+
     %x(tar -ztf data.tar.gz).split("\n")
   end
 end
@@ -47,6 +48,7 @@ gemspec = Dir.mktmpdir do |dir|
     unless system("tar -xf #{gemfile} metadata.gz")
       raise "could not unpack gem #{gemfile}"
     end
+
     YAML.safe_load(
       %x(gunzip -c metadata.gz),
       permitted_classes: [Gem::Specification, Gem::Version, Gem::Dependency, Gem::Requirement, Time, Symbol]
@@ -75,6 +77,7 @@ describe File.basename(gemfile) do
     File.read(cross_rubies_path).split("\n").map do |line|
       ver, plat = line.split(":")
       next if plat != gemspec.platform.to_s
+
       ver.split(".").take(2).join(".") # ugh
     end.compact.uniq.sort
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -162,6 +162,7 @@ module Nokogiri
       if File.directory?(patch_dir) && !File.exist?(File.join(patch_dir, patch_name))
         raise("checking for nonexistent patch file #{patch_name.inspect}")
       end
+
       unless Nokogiri.libxml2_patches.include?(patch_name)
         skip("this test needs libxml2 patched with #{patch_name}")
       end
@@ -217,6 +218,7 @@ module Nokogiri
 
     def pending_if(msg, pend_eh, &block)
       return yield unless pend_eh
+
       pending(msg, &block)
     end
 

--- a/test/html4/test_document_encoding.rb
+++ b/test/html4/test_document_encoding.rb
@@ -138,6 +138,7 @@ class TestNokogiriHtmlDocument < Nokogiri::TestCase
             assert_equal(evil, ary_from_string)
 
             next unless !Nokogiri.uses_libxml? || Nokogiri::VersionInfo.instance.libxml2_has_iconv?
+
             # libxml2 without iconv does not pass this test
             assert_equal(evil, ary_from_file_enc)
             assert_equal(evil, ary_from_file)

--- a/test/html4/test_node.rb
+++ b/test/html4/test_node.rb
@@ -171,6 +171,7 @@ module Nokogiri
 
       def test_to_html_does_not_contain_entities
         return unless defined?(NKF) # NKF is not implemented on Rubinius as of 2009-11-23
+
         html = NKF.nkf("-e --msdos", <<-EOH)
         <html><body>
         <p> test paragraph

--- a/test/html5/test_tree-construction.rb
+++ b/test/html5/test_tree-construction.rb
@@ -82,6 +82,7 @@ if Nokogiri.uses_gumbo?
       elsif node_text.start_with?("<!-- ")
         loop do
           break if lines[index].end_with?(" -->")
+
           index += 1
           node_text << "\n" + lines[index]
         end
@@ -214,6 +215,7 @@ if Nokogiri.uses_gumbo?
         compare_nodes(exp_child, act_child)
         children[-1] = child_index + 1
         next unless exp_child.key?(:children)
+
         exp_nodes << exp_child
         act_nodes << act_child
         children << 0
@@ -272,6 +274,7 @@ if Nokogiri.uses_gumbo?
     klass = Class.new(TestHtml5TreeConstructionBase) do
       tests.each_with_index do |test, index|
         next if test[:script] == :on
+
         define_method "test_#{index}".to_sym do
           @test = test
           @index = index

--- a/test/test_memory_leak.rb
+++ b/test/test_memory_leak.rb
@@ -206,6 +206,7 @@ class TestMemoryLeak < Nokogiri::TestCase
         100_001.times do |j|
           Nokogiri::XML::RelaxNG.from_document(Nokogiri::XML::Document.parse(File.read(ADDRESS_SCHEMA_FILE)))
           next unless j % 10_000 == 0
+
           curr_rss = MemInfo.rss
           diff_rss = curr_rss - prev_rss
           printf("\n(iter %d) %d", j, curr_rss)
@@ -232,6 +233,7 @@ class TestMemoryLeak < Nokogiri::TestCase
       if STATM_FOUND
         return (File.read(STATM_PATH).split(" ")[1].to_i * PAGE_SIZE) / 1024
       end
+
       0
     end
   end

--- a/test/xml/test_parse_options.rb
+++ b/test/xml/test_parse_options.rb
@@ -17,6 +17,7 @@ module Nokogiri
 
       ParseOptions.constants.each do |constant|
         next if constant == "STRICT"
+
         class_eval %{
           def test_predicate_#{constant.downcase}
             options = ParseOptions.new(ParseOptions::#{constant})

--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -521,6 +521,7 @@ module Nokogiri
 
         reader.each do |node|
           next unless node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+
           if node.name == "link"
             assert_nil(node.base_uri)
           end

--- a/test/xml/test_reader_encoding.rb
+++ b/test/xml/test_reader_encoding.rb
@@ -44,6 +44,7 @@ module Nokogiri
       def test_attribute_at
         @reader.each do |node|
           next unless (attribute = node.attribute_at(0))
+
           assert_equal(@reader.encoding, attribute.encoding.name)
         end
       end
@@ -66,6 +67,7 @@ module Nokogiri
         reader = Nokogiri::XML::Reader(xml, nil, "UTF-8")
         reader.each do |node|
           next unless (attribute = node.attribute("awesome"))
+
           assert_equal(reader.encoding, attribute.encoding.name)
         end
       end
@@ -73,6 +75,7 @@ module Nokogiri
       def test_xml_version
         @reader.each do |node|
           next unless (version = node.xml_version)
+
           assert_equal(@reader.encoding, version.encoding.name)
         end
       end
@@ -88,6 +91,7 @@ module Nokogiri
         reader = Nokogiri::XML::Reader(xml, nil, "UTF-8")
         reader.each do |node|
           next unless (lang = node.lang)
+
           assert_equal(reader.encoding, lang.encoding.name)
         end
       end
@@ -96,6 +100,7 @@ module Nokogiri
         called = false
         @reader.each do |node|
           next unless (value = node.value)
+
           assert_equal(@reader.encoding, value.encoding.name)
           called = true
         end
@@ -111,6 +116,7 @@ module Nokogiri
         reader = Nokogiri::XML::Reader(xml, nil, "UTF-8")
         reader.each do |node|
           next unless (prefix = node.prefix)
+
           assert_equal(reader.encoding, prefix.encoding.name)
         end
       end
@@ -124,6 +130,7 @@ module Nokogiri
         reader = Nokogiri::XML::Reader(xml, nil, "UTF-8")
         reader.each do |node|
           next unless (uri = node.namespace_uri)
+
           assert_equal(reader.encoding, uri.encoding.name)
         end
       end
@@ -137,6 +144,7 @@ module Nokogiri
         reader = Nokogiri::XML::Reader(xml, nil, "UTF-8")
         reader.each do |node|
           next unless (lname = node.local_name)
+
           assert_equal(reader.encoding, lname.encoding.name)
         end
       end
@@ -144,6 +152,7 @@ module Nokogiri
       def test_name
         @reader.each do |node|
           next unless (name = node.name)
+
           assert_equal(@reader.encoding, name.encoding.name)
         end
       end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Pass ruby-style-guide 2.5.0 tests
