### PR TITLE
C: Check whether memory allocation was successful

### DIFF
--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -195,7 +195,7 @@ NOKOPUBFUN VALUE Nokogiri_wrap_xml_document(VALUE klass,
 #define NOKOGIRI_SAX_SELF(_ctxt) ((nokogiriSAXTuplePtr)(_ctxt))->self
 #define NOKOGIRI_SAX_CTXT(_ctxt) ((nokogiriSAXTuplePtr)(_ctxt))->ctxt
 #define NOKOGIRI_SAX_TUPLE_NEW(_ctxt, _self) nokogiri_sax_tuple_new(_ctxt, _self)
-#define NOKOGIRI_SAX_TUPLE_DESTROY(_tuple) free(_tuple)
+#define NOKOGIRI_SAX_TUPLE_DESTROY(_tuple) ruby_xfree(_tuple)
 
 #define DISCARD_CONST_QUAL(t, v) ((t)(uintptr_t)(v))
 #define DISCARD_CONST_QUAL_XMLCHAR(v) DISCARD_CONST_QUAL(xmlChar *, v)
@@ -214,7 +214,7 @@ static inline
 nokogiriSAXTuplePtr
 nokogiri_sax_tuple_new(xmlParserCtxtPtr ctxt, VALUE self)
 {
-  nokogiriSAXTuplePtr tuple = malloc(sizeof(nokogiriSAXTuple));
+  nokogiriSAXTuplePtr tuple = ruby_xmalloc(sizeof(nokogiriSAXTuple));
   tuple->self = self;
   tuple->ctxt = ctxt;
   return tuple;

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -72,7 +72,7 @@ dealloc(xmlDocPtr doc)
   st_foreach(node_hash, dealloc_node_i, (st_data_t)doc);
   st_free_table(node_hash);
 
-  free(doc->_private);
+  ruby_xfree(doc->_private);
 
   /* When both Nokogiri and libxml-ruby are loaded, make sure that all nodes
    * have their _private pointers cleared. This is to avoid libxml-ruby's
@@ -569,7 +569,7 @@ rb_xml_document_canonicalize(int argc, VALUE *argv, VALUE self)
     c_namespaces = NULL;
   } else {
     long ns_len = RARRAY_LEN(rb_namespaces);
-    c_namespaces = calloc((size_t)ns_len + 1, sizeof(xmlChar *));
+    c_namespaces = ruby_xcalloc((size_t)ns_len + 1, sizeof(xmlChar *));
     for (int j = 0 ; j < ns_len ; j++) {
       VALUE entry = rb_ary_entry(rb_namespaces, j);
       c_namespaces[j] = (xmlChar *)StringValueCStr(entry);
@@ -582,7 +582,7 @@ rb_xml_document_canonicalize(int argc, VALUE *argv, VALUE self)
                  (int)RTEST(rb_comments_p),
                  c_obuf);
 
-  free(c_namespaces);
+  ruby_xfree(c_namespaces);
   xmlOutputBufferClose(c_obuf);
 
   return rb_funcall(rb_io, rb_intern("string"), 0);
@@ -600,7 +600,7 @@ noko_xml_document_wrap_with_init_args(VALUE klass, xmlDocPtr c_document, int arg
 
   rb_document = Data_Wrap_Struct(klass, mark, dealloc, c_document);
 
-  tuple = (nokogiriTuplePtr)malloc(sizeof(nokogiriTuple));
+  tuple = (nokogiriTuplePtr)ruby_xmalloc(sizeof(nokogiriTuple));
   tuple->doc = rb_document;
   tuple->unlinkedNodes = st_init_numtable_with_size(128);
   tuple->node_cache = rb_ary_new();

--- a/ext/nokogiri/xml_sax_parser.c
+++ b/ext/nokogiri/xml_sax_parser.c
@@ -261,14 +261,14 @@ static void
 deallocate(xmlSAXHandlerPtr handler)
 {
   NOKOGIRI_DEBUG_START(handler);
-  free(handler);
+  ruby_xfree(handler);
   NOKOGIRI_DEBUG_END(handler);
 }
 
 static VALUE
 allocate(VALUE klass)
 {
-  xmlSAXHandlerPtr handler = calloc((size_t)1, sizeof(xmlSAXHandler));
+  xmlSAXHandlerPtr handler = ruby_xcalloc((size_t)1, sizeof(xmlSAXHandler));
 
   handler->startDocument = start_document;
   handler->endDocument = end_document;

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -195,7 +195,7 @@ Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr ctx, i
   assert(ctx->context->doc);
   assert(DOC_RUBY_OBJECT_TEST(ctx->context->doc));
 
-  argv = (VALUE *)calloc((size_t)nargs, sizeof(VALUE));
+  argv = (VALUE *)ruby_xcalloc((size_t)nargs, sizeof(VALUE));
   for (int j = 0 ; j < nargs ; ++j) {
     rb_gc_register_address(&argv[j]);
   }
@@ -216,7 +216,7 @@ Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr ctx, i
   for (int j = 0 ; j < nargs ; ++j) {
     rb_gc_unregister_address(&argv[j]);
   }
-  free(argv);
+  ruby_xfree(argv);
 
   switch (TYPE(result)) {
     case T_FLOAT:

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -17,7 +17,7 @@ dealloc(nokogiriXsltStylesheetTuple *wrapper)
   xsltFreeStylesheet(doc); /* commented out for now. */
   NOKOGIRI_DEBUG_END(doc);
 
-  free(wrapper);
+  ruby_xfree(wrapper);
 }
 
 static void

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -248,7 +248,7 @@ transform(int argc, VALUE *argv, VALUE self)
   Data_Get_Struct(self, nokogiriXsltStylesheetTuple, wrapper);
 
   param_len = RARRAY_LEN(paramobj);
-  params = calloc((size_t)param_len + 1, sizeof(char *));
+  params = ruby_xcalloc((size_t)param_len + 1, sizeof(char *));
   for (j = 0 ; j < param_len ; j++) {
     VALUE entry = rb_ary_entry(paramobj, j);
     const char *ptr = StringValueCStr(entry);
@@ -261,7 +261,7 @@ transform(int argc, VALUE *argv, VALUE self)
   xmlSetGenericErrorFunc((void *)errstr, xslt_generic_error_handler);
 
   result = xsltApplyStylesheet(wrapper->ss, xml, params);
-  free(params);
+  ruby_xfree(params);
 
   xsltSetGenericErrorFunc(NULL, NULL);
   xmlSetGenericErrorFunc(NULL, NULL);


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

The C extension didn't check whether memory allocations were successful (= `malloc`/`calloc` return a value other than `NULL`). In the rare case, that memory allocation fails, this leads to undefined behavior, which usually results in a segmentation fault.

This problem was discovered using the [static analyzer](https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html) (`-fanalyzer`) of GCC.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

There is no easy way to test this behavior, hence I omitted test cases.

**Does this change affect the behavior of either the C or the Java implementations?**

If no more memory is available `rb_eNoMemError` is raised. As far as I can tell, it is not necessary to change the Java implementation, since Java would automatically raise an `OutOfMemoryError` exception.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
