### PR TITLE
Use Ruby allocators for `vasprintf`

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -966,8 +966,6 @@ have_func("xmlRelaxNGSetValidStructuredErrors") # introduced in libxml 2.6.21
 have_func("xmlSchemaSetValidStructuredErrors") # introduced in libxml 2.6.23
 have_func("xmlSchemaSetParserStructuredErrors") # introduced in libxml 2.6.23
 
-have_func("vasprintf")
-
 other_library_versions_string = OTHER_LIBRARY_VERSIONS.map { |k, v| [k, v].join(":") }.join(",")
 append_cppflags(%[-DNOKOGIRI_OTHER_LIBRARY_VERSIONS="\\\"#{other_library_versions_string}\\\""])
 

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -52,12 +52,11 @@ void noko_init_test_global_handlers(void);
 static ID id_read, id_write, id_external_encoding;
 
 
-#ifndef HAVE_VASPRINTF
 /*
  * Thank you Geoffroy Couprie for this implementation of vasprintf!
  */
 int
-vasprintf(char **strp, const char *fmt, va_list ap)
+noko_vasprintf(char **strp, const char *fmt, va_list ap)
 {
   /* Mingw32/64 have a broken vsnprintf implementation that fails when
    * using a zero-byte limit in order to retrieve the required size for malloc.
@@ -65,14 +64,10 @@ vasprintf(char **strp, const char *fmt, va_list ap)
    */
   char tmp[1];
   int len = vsnprintf(tmp, 1, fmt, ap) + 1;
-  char *res = (char *)malloc((unsigned int)len);
-  if (res == NULL) {
-    return -1;
-  }
+  char *res = (char *)ruby_xmalloc((unsigned int)len);
   *strp = res;
   return vsnprintf(res, (unsigned int)len, fmt, ap);
 }
-#endif
 
 
 static VALUE

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -63,7 +63,11 @@ noko_vasprintf(char **strp, const char *fmt, va_list ap)
    * So we use a one byte buffer instead.
    */
   char tmp[1];
-  int len = vsnprintf(tmp, 1, fmt, ap) + 1;
+  va_list tmp_ap;
+  va_copy(tmp_ap, ap);
+  int len = vsnprintf(tmp, 1, fmt, tmp_ap) + 1;
+  va_end(tmp_ap);
+
   char *res = (char *)ruby_xmalloc((unsigned int)len);
   *strp = res;
   return vsnprintf(res, (unsigned int)len, fmt, ap);

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -162,7 +162,7 @@ typedef struct _nokogiriXsltStylesheetTuple {
   VALUE func_instances;
 } nokogiriXsltStylesheetTuple;
 
-int vasprintf(char **strp, const char *fmt, va_list ap);
+int noko_vasprintf(char **strp, const char *fmt, va_list ap);
 void noko_xml_document_pin_node(xmlNodePtr);
 void noko_xml_document_pin_namespace(xmlNsPtr, xmlDocPtr);
 

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -195,7 +195,7 @@ NOKOPUBFUN VALUE Nokogiri_wrap_xml_document(VALUE klass,
 #define NOKOGIRI_SAX_SELF(_ctxt) ((nokogiriSAXTuplePtr)(_ctxt))->self
 #define NOKOGIRI_SAX_CTXT(_ctxt) ((nokogiriSAXTuplePtr)(_ctxt))->ctxt
 #define NOKOGIRI_SAX_TUPLE_NEW(_ctxt, _self) nokogiri_sax_tuple_new(_ctxt, _self)
-#define NOKOGIRI_SAX_TUPLE_DESTROY(_tuple) free(_tuple)
+#define NOKOGIRI_SAX_TUPLE_DESTROY(_tuple) ruby_xfree(_tuple)
 
 #define DISCARD_CONST_QUAL(t, v) ((t)(uintptr_t)(v))
 #define DISCARD_CONST_QUAL_XMLCHAR(v) DISCARD_CONST_QUAL(xmlChar *, v)
@@ -214,7 +214,7 @@ static inline
 nokogiriSAXTuplePtr
 nokogiri_sax_tuple_new(xmlParserCtxtPtr ctxt, VALUE self)
 {
-  nokogiriSAXTuplePtr tuple = malloc(sizeof(nokogiriSAXTuple));
+  nokogiriSAXTuplePtr tuple = ruby_xmalloc(sizeof(nokogiriSAXTuple));
   tuple->self = self;
   tuple->ctxt = ctxt;
   return tuple;

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -72,7 +72,7 @@ dealloc(xmlDocPtr doc)
   st_foreach(node_hash, dealloc_node_i, (st_data_t)doc);
   st_free_table(node_hash);
 
-  free(doc->_private);
+  ruby_xfree(doc->_private);
 
   /* When both Nokogiri and libxml-ruby are loaded, make sure that all nodes
    * have their _private pointers cleared. This is to avoid libxml-ruby's
@@ -569,7 +569,7 @@ rb_xml_document_canonicalize(int argc, VALUE *argv, VALUE self)
     c_namespaces = NULL;
   } else {
     long ns_len = RARRAY_LEN(rb_namespaces);
-    c_namespaces = calloc((size_t)ns_len + 1, sizeof(xmlChar *));
+    c_namespaces = ruby_xcalloc((size_t)ns_len + 1, sizeof(xmlChar *));
     for (int j = 0 ; j < ns_len ; j++) {
       VALUE entry = rb_ary_entry(rb_namespaces, j);
       c_namespaces[j] = (xmlChar *)StringValueCStr(entry);
@@ -582,7 +582,7 @@ rb_xml_document_canonicalize(int argc, VALUE *argv, VALUE self)
                  (int)RTEST(rb_comments_p),
                  c_obuf);
 
-  free(c_namespaces);
+  ruby_xfree(c_namespaces);
   xmlOutputBufferClose(c_obuf);
 
   return rb_funcall(rb_io, rb_intern("string"), 0);
@@ -600,7 +600,7 @@ noko_xml_document_wrap_with_init_args(VALUE klass, xmlDocPtr c_document, int arg
 
   rb_document = Data_Wrap_Struct(klass, mark, dealloc, c_document);
 
-  tuple = (nokogiriTuplePtr)malloc(sizeof(nokogiriTuple));
+  tuple = (nokogiriTuplePtr)ruby_xmalloc(sizeof(nokogiriTuple));
   tuple->doc = rb_document;
   tuple->unlinkedNodes = st_init_numtable_with_size(128);
   tuple->node_cache = rb_ary_new();

--- a/ext/nokogiri/xml_sax_parser.c
+++ b/ext/nokogiri/xml_sax_parser.c
@@ -261,14 +261,14 @@ static void
 deallocate(xmlSAXHandlerPtr handler)
 {
   NOKOGIRI_DEBUG_START(handler);
-  free(handler);
+  ruby_xfree(handler);
   NOKOGIRI_DEBUG_END(handler);
 }
 
 static VALUE
 allocate(VALUE klass)
 {
-  xmlSAXHandlerPtr handler = calloc((size_t)1, sizeof(xmlSAXHandler));
+  xmlSAXHandlerPtr handler = ruby_xcalloc((size_t)1, sizeof(xmlSAXHandler));
 
   handler->startDocument = start_document;
   handler->endDocument = end_document;

--- a/ext/nokogiri/xml_sax_parser.c
+++ b/ext/nokogiri/xml_sax_parser.c
@@ -205,11 +205,11 @@ warning_func(void *ctx, const char *msg, ...)
 
   va_list args;
   va_start(args, msg);
-  vasprintf(&message, msg, args);
+  noko_vasprintf(&message, msg, args);
   va_end(args);
 
   ruby_message = NOKOGIRI_STR_NEW2(message);
-  free(message);
+  ruby_xfree(message);
   rb_funcall(doc, id_warning, 1, ruby_message);
 }
 
@@ -223,11 +223,11 @@ error_func(void *ctx, const char *msg, ...)
 
   va_list args;
   va_start(args, msg);
-  vasprintf(&message, msg, args);
+  noko_vasprintf(&message, msg, args);
   va_end(args);
 
   ruby_message = NOKOGIRI_STR_NEW2(message);
-  free(message);
+  ruby_xfree(message);
   rb_funcall(doc, id_error, 1, ruby_message);
 }
 

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -195,7 +195,7 @@ Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr ctx, i
   assert(ctx->context->doc);
   assert(DOC_RUBY_OBJECT_TEST(ctx->context->doc));
 
-  argv = (VALUE *)calloc((size_t)nargs, sizeof(VALUE));
+  argv = (VALUE *)ruby_xcalloc((size_t)nargs, sizeof(VALUE));
   for (int j = 0 ; j < nargs ; ++j) {
     rb_gc_register_address(&argv[j]);
   }
@@ -216,7 +216,7 @@ Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr ctx, i
   for (int j = 0 ; j < nargs ; ++j) {
     rb_gc_unregister_address(&argv[j]);
   }
-  free(argv);
+  ruby_xfree(argv);
 
   switch (TYPE(result)) {
     case T_FLOAT:

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -297,7 +297,7 @@ xpath_generic_exception_handler(void *ctx, const char *msg, ...)
 
   va_list args;
   va_start(args, msg);
-  vasprintf(&message, msg, args);
+  noko_vasprintf(&message, msg, args);
   va_end(args);
 
   rb_raise(rb_eRuntimeError, "%s", message);

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -27,12 +27,12 @@ xslt_generic_error_handler(void *ctx, const char *msg, ...)
 
   va_list args;
   va_start(args, msg);
-  vasprintf(&message, msg, args);
+  noko_vasprintf(&message, msg, args);
   va_end(args);
 
   rb_str_cat2((VALUE)ctx, message);
 
-  free(message);
+  ruby_xfree(message);
 }
 
 VALUE

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -17,7 +17,7 @@ dealloc(nokogiriXsltStylesheetTuple *wrapper)
   xsltFreeStylesheet(doc); /* commented out for now. */
   NOKOGIRI_DEBUG_END(doc);
 
-  free(wrapper);
+  ruby_xfree(wrapper);
 }
 
 static void

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -248,7 +248,7 @@ transform(int argc, VALUE *argv, VALUE self)
   Data_Get_Struct(self, nokogiriXsltStylesheetTuple, wrapper);
 
   param_len = RARRAY_LEN(paramobj);
-  params = calloc((size_t)param_len + 1, sizeof(char *));
+  params = ruby_xcalloc((size_t)param_len + 1, sizeof(char *));
   for (j = 0 ; j < param_len ; j++) {
     VALUE entry = rb_ary_entry(paramobj, j);
     const char *ptr = StringValueCStr(entry);
@@ -261,7 +261,7 @@ transform(int argc, VALUE *argv, VALUE self)
   xmlSetGenericErrorFunc((void *)errstr, xslt_generic_error_handler);
 
   result = xsltApplyStylesheet(wrapper->ss, xml, params);
-  free(params);
+  ruby_xfree(params);
 
   xsltSetGenericErrorFunc(NULL, NULL);
   xmlSetGenericErrorFunc(NULL, NULL);


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

This is a follow-up PR for #2480, which implements `vasprintf` with Ruby allocators.
Unfortunately, the current implementation results in a segmentation fault. I would highly appreciate it if somebody with more experience with the Ruby API could have a look at this since it looks like it might be a bug in the Ruby implementation of `vsnprintf`.