### PR TITLE
Hoist loads and sink store in hot loop

### DIFF
--- a/gumbo-parser/src/string_buffer.c
+++ b/gumbo-parser/src/string_buffer.c
@@ -72,10 +72,13 @@ void gumbo_string_buffer_append_codepoint (
     prefix = 0xf0;
   }
   maybe_resize_string_buffer(num_bytes + 1, output);
-  output->data[output->length++] = prefix | (c >> (num_bytes * 6));
+  size_t length = output->length;
+  char* data = output->data;
+  data[length++] = prefix | (c >> (num_bytes * 6));
   for (int i = num_bytes - 1; i >= 0; --i) {
-    output->data[output->length++] = 0x80 | (0x3f & (c >> (i * 6)));
+    data[length++] = 0x80 | (0x3f & (c >> (i * 6)));
   }
+  output->length = length;
 }
 
 void gumbo_string_buffer_append_string (


### PR DESCRIPTION
This is from @sebpop's [PR](https://github.com/google/gumbo-parser/pull/403/).

Since `char *` can alias with everything, the compiler is unable to
prove that `output->data` doesn't alias with `output->length` and
`output` itself which forces a load of `output->data` and
`output->length` and a store to `output->length` in each iteration of
the loop. By hoisting the two loads and sinking the store out of the
loop, we're left with a loop containing just a single store to
`data[length]`.

<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

https://github.com/google/gumbo-parser/pull/403

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

There should be no observable changes other than this should be slightly faster so no tests were included.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

No.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

---

I think this change is fine (the tests pass), but it's not clear that the performance gain (which I suspect to be very slight) overcomes the (also quite slight) degradation in readability. Worth testing.
