### PR TITLE
test: add coverage for some css pseudo-classes

### DIFF
--- a/test/css/test_css_integration.rb
+++ b/test/css/test_css_integration.rb
@@ -6,7 +6,7 @@ class TestNokogiriCssIntegration < Nokogiri::TestCase
   describe "CSS integration tests" do
     let(:subject) do
       subject_class.parse(<<~HTML)
-        <html>
+        <html><body>
           <table>
             <tr><td>row1 </td></tr>
             <tr><td>row2 </td></tr>
@@ -64,7 +64,7 @@ class TestNokogiriCssIntegration < Nokogiri::TestCase
 
           <p class='empty'></p>
           <p class='not-empty'><b></b></p>
-        </html>
+        </body></html>
       HTML
     end
 
@@ -341,6 +341,14 @@ class TestNokogiriCssIntegration < Nokogiri::TestCase
             nested.at_css(".nested-child.indirect b"),
           ].flatten
           assert_equal(expected, result.to_a)
+        end
+
+        it "selects using contains" do
+          assert_equal(14, subject.css("td:contains('row')").length)
+          assert_equal(6, subject.css("td:contains('row1')").length)
+          assert_equal(4, subject.css("h1:contains('header')").length)
+          assert_equal(4, subject.css("div :contains('header')").length)
+          assert_equal(9, subject.css(":contains('header')").length) # 9 = 4xh1 + 3xdiv + body + html
         end
 
         it "selects class_attr_selector" do

--- a/test/css/test_xpath_visitor.rb
+++ b/test/css/test_xpath_visitor.rb
@@ -383,6 +383,21 @@ class TestNokogiri < Nokogiri::TestCase
         assert_xpath("//script//comment()", parser.parse("script comment()"))
       end
 
+      it "handles contains() (non-standard)" do
+        # https://api.jquery.com/contains-selector/
+        assert_xpath(%{//div[contains(.,"youtube")]}, parser.parse(%{div:contains("youtube")}))
+      end
+
+      it "handles gt() (non-standard)" do
+        # https://api.jquery.com/gt-selector/
+        assert_xpath("//td[position()>3]", parser.parse("td:gt(3)"))
+      end
+
+      it "handles self()" do
+        # TODO: it's unclear how this is useful and we should consider deprecating it
+        assert_xpath("//self::div", parser.parse("self(div)"))
+      end
+
       it "supports custom functions" do
         visitor = Class.new(Nokogiri::CSS::XPathVisitor) do
           attr_accessor :awesome


### PR DESCRIPTION

**What problem is this PR intended to solve?**

#2492 asked about support for the CSS pseudo-class `:contains()`

This PR adds missing test coverage for that selector as well as `:gt()`.

/cc @walterdavis

**Have you included adequate test coverage?**

Ya


**Does this change affect the behavior of either the C or the Java implementations?**

No behavior change