### PR TITLE
ext: systems missing libiconv will see a relevant error message

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -400,8 +400,8 @@ def iconv_configure_flags
     return ["--with-iconv=yes"]
   end
 
-  config = preserving_globals { have_package_configuration("libiconv") }
-  if config && try_link_iconv("pkg-config libiconv") { have_package_configuration("libiconv") }
+  config = preserving_globals { pkg_config("libiconv") }
+  if config && try_link_iconv("pkg-config libiconv") { pkg_config("libiconv") }
     cflags, ldflags, libs = config
 
     return [


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Fixes #2487

systems missing libiconv will see a relevant error message instead of a syntax error from extconf.rb


**Have you included adequate test coverage?**

I have only reproduced the issue on OpenBSD systems, for which we do not have test coverage today. If someone familiar with OpenBSD and Github Actions would like to submit a PR to do so, I would consider it.


**Does this change affect the behavior of either the C or the Java implementations?**

No behavioral changes.