### PR TITLE
test: pend the LIBXML_LOADED_VERSION test on freebsd

### DIFF
--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -66,7 +66,13 @@ module TestVersionInfoTests
     major = Regexp.last_match(1).to_i
     minor = Regexp.last_match(2).to_i
     bug = Regexp.last_match(3).to_i
-    assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxml"]["loaded"])
+    if RbConfig::CONFIG["target_os"].include?("freebsd13") && Nokogiri::VersionInfo.instance.libxml2_using_system?
+      pending("https://github.com/sparklemotion/nokogiri/issues/2506") do
+        assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxml"]["loaded"])
+      end
+    else
+      assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxml"]["loaded"])
+    end
 
     assert(version_info["libxml"].key?("iconv_enabled"))
     assert(version_info["libxslt"].key?("datetime_enabled"))


### PR DESCRIPTION
**What problem is this PR intended to solve?**

pend the LIBXML_LOADED_VERSION test on freebsd

see #2506 for more context
