### PR TITLE
improve encoding reader performance (backport to v1.13.x)

### DIFF
--- a/lib/nokogiri/html4/document.rb
+++ b/lib/nokogiri/html4/document.rb
@@ -268,7 +268,7 @@ module Nokogiri
         end
 
         def self.detect_encoding(chunk)
-          (m = chunk.match(/\A(<\?xml[ \t\r\n]+[^>]*>)/)) &&
+          (m = chunk.match(/\A(<\?xml[ \t\r\n][^>]*>)/)) &&
             (return Nokogiri.XML(m[1]).encoding)
 
           if Nokogiri.jruby?

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -123,7 +123,7 @@ module Nokogiri
       # [Yields] Nokogiri::XML::Node
       # [Returns] Nokogiri::XML::Node
       #
-      def initialize(name, document)
+      def initialize(name, document) # rubocop:disable Style/RedundantInitialize
         # This is intentionally empty.
       end
 

--- a/lib/nokogiri/xml/processing_instruction.rb
+++ b/lib/nokogiri/xml/processing_instruction.rb
@@ -3,7 +3,7 @@
 module Nokogiri
   module XML
     class ProcessingInstruction < Node
-      def initialize(document, name, content)
+      def initialize(document, name, content) # rubocop:disable Style/RedundantInitialize
       end
     end
   end

--- a/test/html4/test_document_encoding.rb
+++ b/test/html4/test_document_encoding.rb
@@ -155,6 +155,18 @@ class TestNokogiriHtmlDocument < Nokogiri::TestCase
             end
           end
         end
+
+        it "does not start backtracking during detection of XHTML encoding" do
+          # this test is a quick and dirty version
+          # of the more complete perf test that is on main.
+          n = 40_000
+          redos_string = "<?xml " + (" " * n)
+          redos_string.encode!("ASCII-8BIT")
+          start_time = Time.now
+          Nokogiri::HTML4(redos_string)
+          elapsed_time = Time.now - start_time
+          assert_operator(elapsed_time, :<, 1)
+        end
       end
     end
   end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

HTML4 document encoding detection improvements.


**Have you included adequate test coverage?**

Yes, there is a quick-and-dirty test for the `v1.13.x` branch, see #2448 for a more complete perf testing approach that's on `main`.


**Does this change affect the behavior of either the C or the Java implementations?**

No.