### PR TITLE
ext: declare gnu_printf format attribute for some functions

### DIFF
--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -83,11 +83,19 @@ xmlNodePtr xmlLastElementChild(xmlNodePtr parent);
 #  define NOKOGIRI_DEBUG_END(p)
 #endif
 
-#ifndef NORETURN
+#ifndef NORETURN_DECL
 #  if defined(__GNUC__)
-#    define NORETURN(name) __attribute__((noreturn)) name
+#    define NORETURN_DECL __attribute__ ((noreturn))
 #  else
-#    define NORETURN(name) name
+#    define NORETURN_DECL
+#  endif
+#endif
+
+#ifndef PRINTFLIKE_DECL
+#  if defined(__GNUC__)
+#    define PRINTFLIKE_DECL(stringidx, argidx) __attribute__ ((format(printf,stringidx,argidx)))
+#  else
+#    define PRINTFLIKE_DECL(stringidx, argidx)
 #  endif
 #endif
 
@@ -205,7 +213,7 @@ void Nokogiri_structured_error_func_save_and_set(libxmlStructuredErrorHandlerSta
 void Nokogiri_structured_error_func_restore(libxmlStructuredErrorHandlerState *handler_state);
 VALUE Nokogiri_wrap_xml_syntax_error(xmlErrorPtr error);
 void Nokogiri_error_array_pusher(void *ctx, xmlErrorPtr error);
-NORETURN(void Nokogiri_error_raise(void *ctx, xmlErrorPtr error));
+NORETURN_DECL void Nokogiri_error_raise(void *ctx, xmlErrorPtr error);
 void Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr ctx, int nargs, VALUE handler,
     const char *function_name) ;
 

--- a/ext/nokogiri/xml_sax_parser.c
+++ b/ext/nokogiri/xml_sax_parser.c
@@ -195,6 +195,7 @@ comment_func(void *ctx, const xmlChar *value)
   rb_funcall(doc, id_comment, 1, str);
 }
 
+PRINTFLIKE_DECL(2,3)
 static void
 warning_func(void *ctx, const char *msg, ...)
 {
@@ -210,6 +211,7 @@ warning_func(void *ctx, const char *msg, ...)
   rb_funcall(doc, id_warning, 1, rb_message);
 }
 
+PRINTFLIKE_DECL(2,3)
 static void
 error_func(void *ctx, const char *msg, ...)
 {

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -289,7 +289,8 @@ lookup(void *ctx,
   return NULL;
 }
 
-NORETURN(static void xpath_generic_exception_handler(void *ctx, const char *msg, ...));
+PRINTFLIKE_DECL(2,3)
+NORETURN_DECL
 static void
 xpath_generic_exception_handler(void *ctx, const char *msg, ...)
 {

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -20,6 +20,7 @@ dealloc(nokogiriXsltStylesheetTuple *wrapper)
   ruby_xfree(wrapper);
 }
 
+PRINTFLIKE_DECL(2,3)
 static void
 xslt_generic_error_handler(void *ctx, const char *msg, ...)
 {


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Commit 3831a00 replaced `vasprintf` calls with `rb_vsprintf`, however that caused gcc to start emitting warnings because of the `-Wsuggest-attribute=format` flag.

This PR introduces a `PRINTFLIKE_DECL` macro to declare the gnu_printf format attribute for some functions to quash those warnings.

It also replaces the `NORETURN` macro (which will come from ruby.h`) with `NORETURN_DECL` that doesn't take an argument, because that syntax is easier to combine with `PRINTFLIKE_DECL` IMHO.


**Have you included adequate test coverage?**

No tests necessary.


**Does this change affect the behavior of either the C or the Java implementations?**

No behavior change.