### PR TITLE
test/helper.rb: ignore GC compaction on unsupported platforms

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -154,6 +154,16 @@ module Nokogiri
       else
         defined?(GC.compact) ? "compact" : "major"
       end
+      if ["compact", "verify"].include?(@@gc_level)
+        # the only way of detecting an unsupported platform is actually
+        # trying GC compaction
+        begin
+          GC.compact
+        rescue NotImplementedError
+          @@gc_level = "normal"
+          warn("#{__FILE__}:#{__LINE__}: GC compaction not suppport by platform")
+        end
+      end
       warn("#{__FILE__}:#{__LINE__}: NOKOGIRI_TEST_GC_LEVEL: #{@@gc_level}")
     end
 


### PR DESCRIPTION
For example, ruby 3.0 on Debian ppc64el architecture does not support GC
compaction. When running the tests, every 20th test crashes like this:

> ```
> Error:
> Minitest::Result#test_parsing_attribute_namespace:
> NotImplementedError: Compaction isn't available on this platform
>     <internal:gc>:213:in `compact'
>     /home/terceiro/ruby-nokogiri-1.13.5+dfsg/test/helper.rb:123:in `teardown'
> ```