### PR TITLE
arm-linux native gem support

### DIFF
--- a/.cross_rubies
+++ b/.cross_rubies
@@ -1,4 +1,5 @@
 2.6.0:aarch64-linux
+2.6.0:arm-linux
 2.6.0:arm64-darwin
 2.6.0:x64-mingw32
 2.6.0:x86-linux
@@ -6,6 +7,7 @@
 2.6.0:x86_64-darwin
 2.6.0:x86_64-linux
 2.7.0:aarch64-linux
+2.7.0:arm-linux
 2.7.0:arm64-darwin
 2.7.0:x64-mingw32
 2.7.0:x86-linux
@@ -13,6 +15,7 @@
 2.7.0:x86_64-darwin
 2.7.0:x86_64-linux
 3.0.0:aarch64-linux
+3.0.0:arm-linux
 3.0.0:arm64-darwin
 3.0.0:x64-mingw32
 3.0.0:x86-linux
@@ -20,6 +23,7 @@
 3.0.0:x86_64-darwin
 3.0.0:x86_64-linux
 3.1.0:aarch64-linux
+3.1.0:arm-linux
 3.1.0:arm64-darwin
 3.1.0:x64-mingw-ucrt
 3.1.0:x86-linux

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -133,6 +133,7 @@ jobs:
       matrix:
         plat:
           - "aarch64-linux"
+          - "arm-linux"
           # - "arm64-darwin" # github actions does not support this as of 2022-01
           - "x64-mingw-ucrt"
           - "x64-mingw32"
@@ -200,6 +201,28 @@ jobs:
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           docker run --rm -v "$(pwd):/nokogiri" -w /nokogiri \
             --platform=linux/arm64/v8 \
+            ruby:${{matrix.ruby}} \
+            ./scripts/test-gem-install gems
+
+  cruby-arm-linux-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-arm-linux-gem
+          path: gems
+      - run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker run --rm -v "$(pwd):/nokogiri" -w /nokogiri \
+            --platform=linux/arm/v7 \
             ruby:${{matrix.ruby}} \
             ./scripts/test-gem-install gems
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ### Notes
 
-#### Faster, more reliable installation: Native Gem for ARM64 Linux
+#### Faster, more reliable installation: Native Gem for `aarch64-linux` (aka `linux/arm64/v8`)
 
-This version of Nokogiri ships full native gem support for the `aarch64-linux` platform, which should support AWS Graviton and other ARM Linux platforms. Please note that glibc >= 2.29 is required for aarch64-linux systems, see [Supported Platforms](https://nokogiri.org/#supported-platforms) for more information.
+This version of Nokogiri ships official native gem support for the `aarch64-linux` platform, which should support AWS Graviton and other ARM64 Linux platforms. Please note that glibc >= 2.29 is required for aarch64-linux systems, see [Supported Platforms](https://nokogiri.org/#supported-platforms) for more information.
+
+
+#### Faster, more reliable installation: Native Gem for `arm-linux` (aka `linux/arm/v7`)
+
+This version of Nokogiri ships experimental native gem support for the `arm-linux` platform. Please note that glibc >= 2.29 is required for arm-linux systems, see [Supported Platforms](https://nokogiri.org/#supported-platforms) for more information.
 
 
 #### Maven-managed JRuby dependencies

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Nokogiri ships pre-compiled, "native" gems for the following platforms:
 
 - Linux:
   - `x86-linux` and `x86_64-linux` (req: `glibc >= 2.17`)
-  - `aarch64-linux` (req: `glibc >= 2.29`)
-  - Note that musl platforms like Alpine are supported
+  - `aarch64-linux` and `arm-linux` (req: `glibc >= 2.29`)
+  - Note that musl platforms like Alpine **are** supported
 - Darwin/MacOS: `x86_64-darwin` and `arm64-darwin`
 - Windows: `x86-mingw32`, `x64-mingw32`, and `x64-mingw-ucrt`
 - Java: any platform running JRuby 9.3 or higher

--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -9,7 +9,8 @@ CrossRuby = Struct.new(:version, :platform) do
   MINGW32_PLATFORM_REGEX = /mingw32/
   LINUX_PLATFORM_REGEX = /linux/
   X86_LINUX_PLATFORM_REGEX = /x86.*linux/
-  ARM_LINUX_PLATFORM_REGEX = /aarch.*linux/
+  AARCH_LINUX_PLATFORM_REGEX = /aarch.*linux/
+  ARM_LINUX_PLATFORM_REGEX = /arm-linux/
   DARWIN_PLATFORM_REGEX = /darwin/
 
   def windows?
@@ -80,6 +81,8 @@ CrossRuby = Struct.new(:version, :platform) do
        "x86_64-apple-darwin-"
      when "arm64-darwin"
        "aarch64-apple-darwin-"
+     when "arm-linux"
+       "arm-linux-gnueabihf-"
      else
        raise "CrossRuby.tool: unmatched platform: #{platform}"
      end) + name
@@ -101,6 +104,8 @@ CrossRuby = Struct.new(:version, :platform) do
       "Mach-O 64-bit x86-64" # hmm
     when "arm64-darwin"
       "Mach-O arm64"
+    when "arm-linux"
+      "elf32-littlearm"
     else
       raise "CrossRuby.target_file_format: unmatched platform: #{platform}"
     end
@@ -165,7 +170,7 @@ CrossRuby = Struct.new(:version, :platform) do
       ].tap do |dlls|
         dlls << "libpthread.so.0" if ver < "2.6.0"
       end
-    when ARM_LINUX_PLATFORM_REGEX
+    when AARCH_LINUX_PLATFORM_REGEX
       [
         "libm.so.6",
         "libc.so.6",
@@ -180,6 +185,13 @@ CrossRuby = Struct.new(:version, :platform) do
         "/usr/lib/liblzma.5.dylib",
         "/usr/lib/libobjc.A.dylib",
       ]
+    when ARM_LINUX_PLATFORM_REGEX
+      [
+        "libm.so.6",
+        "libdl.so.2",
+        "libc.so.6",
+        "ld-linux-armhf.so.3",
+      ]
     else
       raise "CrossRuby.allowed_dlls: unmatched platform: #{platform}"
     end
@@ -189,7 +201,7 @@ CrossRuby = Struct.new(:version, :platform) do
     case platform
     when X86_LINUX_PLATFORM_REGEX
       { "GLIBC" => "2.17" }
-    when ARM_LINUX_PLATFORM_REGEX
+    when AARCH_LINUX_PLATFORM_REGEX, ARM_LINUX_PLATFORM_REGEX
       { "GLIBC" => "2.29" }
     else
       raise "CrossRuby.dll_ref_versions: unmatched platform: #{platform}"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Recently https://github.com/sparklemotion/nokogiri/issues/2466 described the installation experience of a user on the arm/v7 platform, which compiles from source. The user compared this experience against the precompiled native gem experience on other platforms.

rake-compiler-dock supports this architecture since v1.2.0, so this PR adds it as an experimental platform

This PR also adds a CI job to test the native gem under qemu.

Closes #2467

**Have you included adequate test coverage?**

Yes

**Does this change affect the behavior of either the C or the Java implementations?**

No behavior change
