### PR TITLE
fix: Document#canonicalize raises exception for incompatible modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This version of Nokogiri uses [`jar-dependencies`](https://github.com/mkristian/
 
 ### Improved
 
+* `Document#canonicalize` now raises an exception if `inclusive_namespaces` is non-nil and the mode is inclusive, i.e. XML_C14N_1_0 or XML_C14N_1_1. `inclusive_namespaces` can only be passed with exclusive modes, and previously this silently failed.
 * Compare `Encoding` objects rather than compare their names. This is a slight performance improvement and is future-proof. [[#2454](https://github.com/sparklemotion/nokogiri/issues/2454)] (Thanks, [@casperisfine](https://github.com/casperisfine)!)
 * Avoid compile-time conflict with system-installed `gumbo.h` on OpenBSD. [[#2464](https://github.com/sparklemotion/nokogiri/issues/2464)]
 * Remove calls to `vasprintf` in favor of platform-independent `rb_vsprintf`

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -681,11 +681,9 @@ public class XmlDocument extends XmlNode
         result = canonicalizer.canonicalizeSubtree(startingNode.getNode(), inclusive_namespace, filter);
       }
       return RubyString.newString(context.runtime, new ByteList(result, UTF8Encoding.INSTANCE));
-    } catch (CanonicalizationException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
+    } catch (Exception e) {
+      throw context.getRuntime().newRuntimeError(e.getMessage());
     }
-    return context.nil;
   }
 
   private XmlNode


### PR DESCRIPTION

**What problem is this PR intended to solve?**

`Document#canonicalize` now raises an exception if `inclusive_namespaces` is non-nil and the mode is inclusive, i.e. XML_C14N_1_0 or XML_C14N_1_1.

`inclusive_namespaces` can only be passed with exclusive modes, and previously this silently failed.

**Have you included adequate test coverage?**

Yes, coverage has been added in this PR.

**Does this change affect the behavior of either the C or the Java implementations?**

Both the C and Java implementations have been updated.