### PR TITLE
dev: lock rubocop-shopify dependency for now

### DIFF
--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -349,7 +349,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("rubocop-minitest", "~> 0.17")
   spec.add_development_dependency("rubocop-performance", "~> 1.12")
   spec.add_development_dependency("rubocop-rake", "~> 0.6")
-  spec.add_development_dependency("rubocop-shopify", "~> 2.3")
+  spec.add_development_dependency("rubocop-shopify", "= 2.5.0") # TODO: loosen this after dropping support for Ruby 2.6
   spec.add_development_dependency("ruby_memcheck", "~> 1.0")
   spec.add_development_dependency("simplecov", "~> 0.21")
 


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Lock the version of the development dependency `rubocop-shopify`, because

a) we can't generate the ruby 2.6 ci image with the latest version of the gem (which dropped support for ruby <2.7).
b) we kept getting CI breaks from eager updating, anyway

At some point, I'd like to move all our development dependencies into the Gemfile, tighten the dependencies, and have dependabot send PRs for updates.

**Have you included adequate test coverage?**

N/A

**Does this change affect the behavior of either the C or the Java implementations?**

N/A
