### PR TITLE
Use `body` as the context element for `Document#fragment`

### DIFF
--- a/lib/nokogiri/html5/document.rb
+++ b/lib/nokogiri/html5/document.rb
@@ -112,9 +112,20 @@ module Nokogiri
         @url = nil
       end
 
-      # Parse a HTML5 document fragment from +tags+, returning a HTML5::DocumentFragment.
-      def fragment(tags = nil)
-        DocumentFragment.new(self, tags, nil)
+      # :call-seq:
+      #   fragment() → Nokogiri::HTML5::DocumentFragment
+      #   fragment(markup) → Nokogiri::HTML5::DocumentFragment
+      #
+      # Parse a HTML5 document fragment from +markup+, returning a Nokogiri::HTML5::DocumentFragment.
+      #
+      # [Properties]
+      # - +markup+ (String) The HTML5 markup fragment to be parsed
+      #
+      # [Returns]
+      #   Nokogiri::HTML5::DocumentFragment. This object's children will be empty if `markup` is not passed, is empty, or is `nil`.
+      #
+      def fragment(markup = nil)
+        DocumentFragment.new(self, markup)
       end
 
       def to_xml(options = {}, &block) # :nodoc:

--- a/lib/nokogiri/html5/document.rb
+++ b/lib/nokogiri/html5/document.rb
@@ -114,7 +114,7 @@ module Nokogiri
 
       # Parse a HTML5 document fragment from +tags+, returning a HTML5::DocumentFragment.
       def fragment(tags = nil)
-        DocumentFragment.new(self, tags, root)
+        DocumentFragment.new(self, tags, nil)
       end
 
       def to_xml(options = {}, &block) # :nodoc:

--- a/test/html5/test_api.rb
+++ b/test/html5/test_api.rb
@@ -193,6 +193,13 @@ class TestHtml5API < Nokogiri::TestCase
     refute_predicate(doc, :xml?)
   end
 
+  def test_document_fragment
+    doc = Nokogiri.HTML5("x")
+    # This calls fragment on the document rather than on an element.
+    frag = doc.fragment("z")
+    assert_equal("z", frag.to_s)
+  end
+
   describe Nokogiri::HTML5::Document do
     describe "subclassing" do
       let(:klass) do

--- a/test/html5/test_api.rb
+++ b/test/html5/test_api.rb
@@ -193,14 +193,21 @@ class TestHtml5API < Nokogiri::TestCase
     refute_predicate(doc, :xml?)
   end
 
-  def test_document_fragment
-    doc = Nokogiri.HTML5("x")
-    # This calls fragment on the document rather than on an element.
-    frag = doc.fragment("z")
-    assert_equal("z", frag.to_s)
-  end
-
   describe Nokogiri::HTML5::Document do
+    describe "#fragment" do
+      it "parses text nodes in a `body` context" do
+        doc = Nokogiri.HTML5("x")
+        frag = doc.fragment("z")
+        assert_equal("z", frag.to_s)
+      end
+
+      it "drops tags that are not appropriate in a `body` context" do
+        doc = Nokogiri.HTML5("x")
+        frag = doc.fragment("<head></head>")
+        assert_empty(frag.children)
+      end
+    end
+
     describe "subclassing" do
       let(:klass) do
         Class.new(Nokogiri::HTML5::Document) do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes: #2551

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

It changes the C HTML5 visible behavior (but not implementation) to match the C HTML4 implementation. I don't know what the Java implementation does.
