### PR TITLE
Added new method process_text for extract text

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -128,6 +128,28 @@ module Nokogiri
       end
 
       ###
+      # The method is necessary in order to correctly join the received text
+      # (the text is not stuck together and without unnecessary spaces).
+      def process_text
+        result = self.children.map { |child| child.process_text }.compact
+        result.any? ? result.join(' ') : nil
+      end
+
+      ###
+      # Similar to process_text except that if no text was found, it will return raise(NoFoundText.new).
+      def process_text!
+        process_text || raise(NoFoundText.new)
+      end
+
+      ###
+      # Empty text processing class.
+      class NoFoundText < RuntimeError
+        def message
+          "Text wasn't found in the node"
+        end
+      end
+
+      ###
       # Decorate this node with the decorators set up in this node's Document
       def decorate!
         document.decorate(self)

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -24,6 +24,28 @@ module Nokogiri
       end
 
       ###
+      # The method is necessary in order to correctly join the received text
+      # (the text is not stuck together and without unnecessary spaces).
+      def process_text
+        result = self.map { |node| node.process_text }.compact
+        result.any? ? result.join(' ') : nil
+      end
+
+      ###
+      # Similar to process_text except that if no text was found, it will return raise(NoFoundText.new).
+      def process_text!
+        process_text || raise(NoFoundText.new)
+      end
+
+      ###
+      # Empty text processing class.
+      class NoFoundText < RuntimeError
+        def message
+          "Text wasn't found in the node"
+        end
+      end
+
+      ###
       # Get the first element of the NodeSet.
       def first(n = nil)
         return self[0] unless n

--- a/lib/nokogiri/xml/text.rb
+++ b/lib/nokogiri/xml/text.rb
@@ -6,6 +6,28 @@ module Nokogiri
       def content=(string)
         self.native_content = string.to_s
       end
+
+      ###
+      # The method is required to remove double spaces, leading and trailing whitespace.
+      # Returns nil if the text was not found
+      def process_text
+        result = self.text.gsub(/[[:space:]]+/, ' ').strip
+        result.empty? ? nil : result
+      end
+
+      ###
+      # Similar to process_text except that if no text was found, it will return raise(NoFoundText.new).
+      def process_text!
+        process_text || raise(NoFoundText.new)
+      end
+
+      ###
+      # Empty text processing class.
+      class NoFoundText < RuntimeError
+        def message
+          "Text wasn't found in the node"
+        end
+      end
     end
   end
 end

--- a/test/xml/test_process_text.rb
+++ b/test/xml/test_process_text.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "helper"
+
+module Nokogiri
+  module XML
+    class TestProcessText < Nokogiri::TestCase
+
+      def doc
+        Nokogiri::HTML(<<EOT)
+    <div class="b-comment-reply__main">
+        <div class="b-comment-reply__row">
+            <div class="b-comment-reply__body">
+                <bbb>1<bbb>2</bbb>3</bbb>
+                <bbb>4</bbb>
+            </div>
+        </div>
+    </div>
+EOT
+      end
+
+      def test_process_text_for_0_node
+        node_for_xpath = doc.xpath("//div[@class='b-comment-reply__body']/fff")
+        node_for_at = doc.at("//div[@class='b-comment-reply__body']/fff")
+
+        assert_equal(nil, node_for_xpath.process_text)
+        assert_equal(nil, node_for_at&.process_text)
+      end
+
+      def test_process_text_for_1_node
+        node_for_xpath = doc.xpath("//div[@class='b-comment-reply__body']")
+        node_for_at = doc.at("//div[@class='b-comment-reply__body']")
+
+        assert_equal("1 2 3 4", node_for_xpath.process_text)
+        assert_equal("1 2 3 4", node_for_at&.process_text)
+      end
+
+      def test_process_text_for_2_node
+        node_for_xpath = doc.xpath("//div[@class='b-comment-reply__body']/bbb")
+        node_for_at = doc.at("//div[@class='b-comment-reply__body']/bbb")
+
+        assert_equal("1 2 3 4", node_for_xpath.process_text)
+        assert_equal("1 2 3", node_for_at&.process_text)
+      end
+
+      def test_process_text_and_text
+        node_for_xpath = doc.xpath("//div[@class='b-comment-reply__body']/bbb")
+
+        assert_equal("1 2 3 4", node_for_xpath.process_text)
+        assert_equal("1234", node_for_xpath.text)
+      end
+
+      def test_process_text_for_raise
+        node_for_xpath = doc.xpath("//div[@class='b-comment-reply__body']/fff")
+
+        assert_raises do
+          node_for_xpath.process_text!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why was the new method implemented**

In some cases, the HTML markup structure does not allow the text method to get data, similar to displaying them on the site.

**Ex1:**

```
doc = Nokogiri::HTML(<<EOT)
	<tr>
	    <th class="a-color-secondary a-size-base prodDetSectionEntry"> Best Sellers Rank</th>
	    <td><span>  <span>#133 in Video Games</span> <br>  <span>#2 in <a
	            href="/gp/bestsellers/videogames/402051011/ref=pd_zg_hrsr_videogames">PC Gaming<br>Keyboards</a></span> <br>  </span>
	    </td>
	</tr>
EOT
```

method **text**:
`doc.xpath("//tr/td").text.strip`

output:
`"#133 in Video Games   #2 in PC GamingKeyboards"`

method **process_text**:
`doc.xpath("//tr/td").process_text`

output:
`"#133 in Video Games #2 in PC Gaming Keyboards"`

**Ex2:**

```
doc = Nokogiri::HTML(<<EOT)
    <div class="b-comment-reply__main">
        <div class="b-comment-reply__row">
            <div class="b-comment-reply__body"><bbb>1<bbb>2</bbb>3</bbb><bbb>4</bbb>
            </div>
        </div>
    </div>
EOT
```

method **text**:
`doc.xpath("//div[@class='b-comment-reply__body']/bbb").text.strip`

output:
`"1 2 3 4"`

method **process_text**:
`doc.xpath("//div[@class='b-comment-reply__body']/bbb").process_text`

output:
`"1234"`

For this reason, the method process_text was implemented

**How the method works**

The work of the method is to recursively pass from node_set to text.

In the nodeset and node classes, join by space is implemented:

`result.join(' ')`

In the text class, the removal of double spaces and spaces from thel eading and trailing whitespace:

`self.text.gsub(/[[:space:]]+/, ' ').strip`

Method **process_text** return **nil** if text not found.

The **process_text!** method was also implemented which returns raise if the text was not found

**Error handler class:**

```
  class NoFoundText < RuntimeError
    def message
      "Text wasn't found in the node"
    end
  end
```

**Examples of using:**

```
doc = Nokogiri::HTML(<<EOT)
    <div class="b-comment-reply__main">
        <div class="b-comment-reply__row">
            <div class="b-comment-reply__body"><bbb>1<bbb>2</bbb>3</bbb><bbb>4</bbb>
            </div>
        </div>
    </div>
EOT


# '0 node'
doc.xpath("//div[@class='b-comment-reply__body']/fff").process_text 
output: nil

doc.at("//div[@class='b-comment-reply__body']/fff")&.process_text
output: nil

# '0 node raise'
doc.xpath("//div[@class='b-comment-reply__body']/fff").process_text!
output: Text wasn't found in the node (Nokogiri::XML::NodeSet::NoFoundText)

# '1 node'
doc.xpath("//div[@class='b-comment-reply__body']").process_text
output: "1 2 3 4"
doc.at("//div[@class='b-comment-reply__body']")&.process_text
output: "1 2 3 4"

# '2 nodes'
doc.xpath("//div[@class='b-comment-reply__body']/bbb").process_text
output: "1 2 3 4"
doc.at("//div[@class='b-comment-reply__body']/bbb")&.process_text
output: "1 2 3"
```
