### PR TITLE
Remove deprecated constant

### DIFF
--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -313,7 +313,7 @@ parse_args_mark(void *parse_args)
 static VALUE
 wrap_parse_args(ParseArgs *args)
 {
-  return Data_Wrap_Struct(rb_cData, parse_args_mark, RUBY_NEVER_FREE, args);
+  return Data_Wrap_Struct(rb_cObject, parse_args_mark, RUBY_NEVER_FREE, args);
 }
 
 // Returnsd the underlying ParseArgs wrapped by wrap_parse_args.


### PR DESCRIPTION
rb_cData has been deprecated for a long time and it's finally removed on
Ruby trunk. This fixes compilation with Ruby trunk.

https://github.com/ruby/ruby/commit/60e9aa57339a0b4e28f252674f2f033ae1a90888
