### PR TITLE
Remove rbconfig require

### DIFF
--- a/lib/nokogiri.rb
+++ b/lib/nokogiri.rb
@@ -1,8 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
 
-require "rbconfig"
-
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
   require_relative "nokogiri/jruby/dependencies"
 end


### PR DESCRIPTION
I don't think we need to require `rbconfig` anymore.  Looks like it was
introduced in 544b431e5ac6a12369ddc6fb01d2a4b06dbd534d so that we could
check the host's OS back when we were using FFI with Nokogiri.  That
check got removed in 6eae89695cf875fbe15fe57241ba387dd79d91c8, so I
think we can remove this require now.