### PR TITLE
ext: rename the extension file to `nokogiri_ext`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,11 @@
 /ext/nokogiri/**/nokogiri.dll
 /ext/nokogiri/include
 /gems/
-/lib/nokogiri/**/nokogiri.bundle
-/lib/nokogiri/**/nokogiri.so
-/lib/nokogumbo/**/nokogumbo.bundle
-/lib/nokogumbo/**/nokogumbo.so
-/lib/nokogiri/nokogiri.jar
+/lib/nokogiri/**/nokogiri_ext.bundle
+/lib/nokogiri/**/nokogiri_ext.so
+/lib/nokogumbo/**/nokogumbo_ext.bundle
+/lib/nokogumbo/**/nokogumbo_ext.so
+/lib/nokogiri/nokogiri_ext.jar
 /pkg/
 /ports/
 /tmp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,7 +325,7 @@ Run `scripts/build-gems` which will package gems for all supported platforms, an
 
 ## Other utilities
 
-`scripts/test-exported-symbols` checks the compiled `nokogiri.so` library for surprising exported symbols. This script likely only works on Linux, sorry.
+`scripts/test-exported-symbols` checks the compiled `nokogiri_ext.so` library for surprising exported symbols. This script likely only works on Linux, sorry.
 
 `scripts/test-nokogumbo-compatibility` is used by CI to ensure that Nokogumbo installs correctly against the currently-installed version of Nokogiri. Nokogumbo receives this extra care because it compiles against Nokogiri's and libxml2's header files, and makes assumptions about what symbols are exported by Nokogiri's extension library.
 

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -554,7 +554,7 @@ def do_clean
     message("Cleaning files only used during build.\n")
 
     # (root + 'tmp') cannot be removed at this stage because
-    # nokogiri.so is yet to be copied to lib.
+    # nokogiri_ext.so is yet to be copied to lib.
 
     # clean the ports build directory
     Pathname.glob(pwd.join("tmp", "*", "ports")) do |dir|
@@ -990,7 +990,7 @@ unless config_system_libraries?
   end
 end
 
-create_makefile("nokogiri/nokogiri")
+create_makefile("nokogiri/nokogiri_ext")
 
 if config_clean?
   # Do not clean if run in a development work tree.

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -132,7 +132,7 @@ noko_io_close(void *io)
 
 
 void
-Init_nokogiri()
+Init_nokogiri_ext()
 {
   mNokogiri         = rb_define_module("Nokogiri");
   mNokogiriGumbo    = rb_define_module_under(mNokogiri, "Gumbo");

--- a/lib/nokogiri/extension.rb
+++ b/lib/nokogiri/extension.rb
@@ -4,7 +4,7 @@
 begin
   # native precompiled gems package shared libraries in <gem_dir>/lib/nokogiri/<ruby_version>
   ::RUBY_VERSION =~ /(\d+\.\d+)/
-  require_relative "#{Regexp.last_match(1)}/nokogiri"
+  require_relative "#{Regexp.last_match(1)}/nokogiri_ext"
 rescue LoadError => e
   if /GLIBC/.match?(e.message)
     warn(<<~EOM)
@@ -28,5 +28,5 @@ rescue LoadError => e
   # use "require" instead of "require_relative" because non-native gems will place C extension files
   # in Gem::BasicSpecification#extension_dir after compilation (during normal installation), which
   # is in $LOAD_PATH but not necessarily relative to this file (see #2300)
-  require "nokogiri/nokogiri"
+  require "nokogiri/nokogiri_ext"
 end

--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -107,13 +107,13 @@ module Nokogiri
               cppflags << "-I#{File.join(header_directory, "include/libxml2").shellescape}"
 
               if windows?
-                # on windows, nokogumbo needs to link against nokogiri.so to resolve symbols. see #2167
+                # on windows, nokogumbo needs to link against nokogiri_ext.so to resolve symbols. see #2167
                 lib_directory = File.expand_path(File.join(File.dirname(__FILE__), "../#{ruby_minor}"))
                 unless File.exist?(lib_directory)
                   lib_directory = File.expand_path(File.join(File.dirname(__FILE__), ".."))
                 end
                 ldflags << "-L#{lib_directory.shellescape}"
-                ldflags << "-l:nokogiri.so"
+                ldflags << "-l:nokogiri_ext.so"
               end
             end
 

--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -364,7 +364,7 @@ end
 
 if java?
   require "rake/javaextensiontask"
-  Rake::JavaExtensionTask.new("nokogiri", NOKOGIRI_SPEC.dup) do |ext|
+  Rake::JavaExtensionTask.new("nokogiri_ext", NOKOGIRI_SPEC.dup) do |ext|
     # Keep the extension C files because they have docstrings (and Java files don't)
     ext.gem_spec.files.reject! { |path| File.fnmatch?("ext/nokogiri/*.h", path) }
     ext.gem_spec.files.reject! { |path| File.fnmatch?("gumbo-parser/**/*", path) }
@@ -428,7 +428,8 @@ else
     end
   end
 
-  Rake::ExtensionTask.new("nokogiri", NOKOGIRI_SPEC.dup) do |ext|
+  Rake::ExtensionTask.new("nokogiri_ext", NOKOGIRI_SPEC.dup) do |ext|
+    ext.ext_dir = "ext/nokogiri"
     ext.source_pattern = "*.{c,cc,cpp,h}"
     ext.gem_spec.files.reject! { |path| File.fnmatch?("**/*.{java,jar}", path, File::FNM_EXTGLOB) }
 

--- a/scripts/test-exported-symbols
+++ b/scripts/test-exported-symbols
@@ -4,7 +4,7 @@
 #
 #  examine the nokogiri dll for external symbols that shouldn't be there
 #
-#  this assumes that we're on a linux machine, and that nokogiri.so, libxml2.a, libxslt.a, and
+#  this assumes that we're on a linux machine, and that nokogiri_ext.so, libxml2.a, libxslt.a, and
 #  libexslt.a exist and can be found under the pwd.
 #
 
@@ -28,7 +28,7 @@ def local_symbols(archive)
   find_symbols(archive, "t")
 end
 
-noko_so = find_that_file("lib/**/nokogiri.so")
+noko_so = find_that_file("lib/**/nokogiri_ext.so")
 libxml2_archive = find_that_file("ports/**/libxml2.a")
 libxslt_archive = find_that_file("ports/**/libxslt.a")
 libexslt_archive = find_that_file("ports/**/libexslt.a")

--- a/scripts/test-gem-file-contents
+++ b/scripts/test-gem-file-contents
@@ -269,7 +269,7 @@ describe File.basename(gemfile) do
     end
 
     it "contains the java jar files" do
-      assert_includes(gemfile_contents, "lib/nokogiri/nokogiri.jar")
+      assert_includes(gemfile_contents, "lib/nokogiri/nokogiri_ext.jar")
 
       actual_jars = gemfile_contents.grep(/.*\.jar$/)
       expected_jars = [

--- a/scripts/test-gem-installation
+++ b/scripts/test-gem-installation
@@ -120,7 +120,7 @@ describe gemspec.full_name do
             else
               assert_includes(ldflags, "-L#{nokogiri_lib_dir}")
             end
-            assert_includes(ldflags, "-l:nokogiri.so")
+            assert_includes(ldflags, "-l:nokogiri_ext.so")
           else
             assert_empty(ldflags)
           end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

I keep running into problems with some Ruby 3.1 environments
where the extension is loaded when I `require "nokogiri"` because of
the file name collision.

I imagine this is a path problem of some kind, and so I'm hesitant to fix it here, but I did at least want to have this ready.

**Have you included adequate test coverage?**

Yes, existing tests.


**Does this change affect the behavior of either the C or the Java implementations?**

No behavioral changes.
