### PR TITLE
ci: ensure pipeline uses the RCD IMAGE_VERSION for containers

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -16,11 +16,25 @@ on:
       - '*'
 
 jobs:
+  rcd_image_version:
+    runs-on: ubuntu-latest
+    outputs:
+      rcd_image_version: ${{steps.rcd_image_version.outputs.rcd_image_version}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - id: rcd_image_version
+        run: bundle exec ruby -e 'require "rake_compiler_dock"; puts "::set-output name=rcd_image_version::#{RakeCompilerDock::IMAGE_VERSION}"'
+
   cruby-package:
+    needs: ["rcd_image_version"]
     name: "cruby-package"
     runs-on: ubuntu-latest
     container:
-      image: "larskanis/rake-compiler-dock-mri-x86_64-linux:1.2.2"
+      image: "larskanis/rake-compiler-dock-mri-x86_64-linux:${{needs.rcd_image_version.outputs.rcd_image_version}}"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -127,6 +141,7 @@ jobs:
           nokogiri -v
 
   cruby-native-package:
+    needs: ["rcd_image_version"]
     name: "cruby-native-package"
     strategy:
       fail-fast: false
@@ -152,7 +167,7 @@ jobs:
           key: tarballs-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - run: |
           docker run --rm -v "$(pwd):/nokogiri" -w /nokogiri \
-            larskanis/rake-compiler-dock-mri-${{matrix.plat}}:1.2.2 \
+            larskanis/rake-compiler-dock-mri-${{matrix.plat}}:${{needs.rcd_image_version.outputs.rcd_image_version}} \
             ./scripts/test-gem-build gems ${{matrix.plat}}
       - uses: actions/upload-artifact@v2
         with:
@@ -324,10 +339,11 @@ jobs:
           nokogiri -v
 
   jruby-package:
+    needs: ["rcd_image_version"]
     name: "jruby-package"
     runs-on: ubuntu-latest
     container:
-      image: "larskanis/rake-compiler-dock-jruby:1.2.2"
+      image: "larskanis/rake-compiler-dock-jruby:${{needs.rcd_image_version.outputs.rcd_image_version}}"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -342,7 +342,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest-reporters", "~> 1.4")
   spec.add_development_dependency("rake", "~> 13.0")
   spec.add_development_dependency("rake-compiler", "= 1.2.0")
-  spec.add_development_dependency("rake-compiler-dock", "~> 1.2", ">= 1.2.2")
+  spec.add_development_dependency("rake-compiler-dock", "= 1.2.2")
   spec.add_development_dependency("rdoc", "~> 6.3")
   spec.add_development_dependency("rexical", "~> 1.0.7")
   spec.add_development_dependency("rubocop", "~> 1.30.1")

--- a/scripts/test-gem-build
+++ b/scripts/test-gem-build
@@ -22,8 +22,7 @@ if [[ "${BUILD_NATIVE_GEM}" == "java" ]] ; then
   gem install misc/ruby-maven-*.gem --no-document
 fi
 bundle
-bundle list
-bundle list --paths
+
 bundle exec rake set-version-to-timestamp
 
 if [[ "${BUILD_NATIVE_GEM}" == "ruby" ]] ; then


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Recently, while trying to release v1.13.7, I had to debug an issue that ended up being caused by the bug fixed in https://github.com/rake-compiler/rake-compiler-dock/pull/67/files

Despite using rake-compiler-dock v1.2.2 in the Gemfile, the CI pipeline was still using the OCI image tagged `1.2.0` which still contained that bug.

This PR will make sure the CI pipeline is always using the same version as the Gemfile/gemspec. Additionally let's make sure we're pinned to a specific version of rake-compiler-dock to ensure we opt into any new behavior.


**Have you included adequate test coverage?**

N/A


**Does this change affect the behavior of either the C or the Java implementations?**

N/A