### PR TITLE
ci: add xmlsec to the downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -45,6 +45,10 @@ jobs:
           - url: https://github.com/pythonicrubyist/creek
             name: creek
             command: "bundle exec rake spec"
+          - url: https://github.com/instructure/nokogiri-xmlsec-instructure
+            name: nokogiri-xmlsec-instructure
+            precommand: "apt install -y libxmlsec1-dev"
+            command: "bundle exec rake compile rspec"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
@@ -56,6 +60,8 @@ jobs:
         with:
           path: ports
           key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+      - if: matrix.precommand
+        run: ${{matrix.precommand}}
       - run: gem install bundler -v ">= 2.3.22" # for "add --path"
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#2594 points out downstream breakage in the `nokogiri-xmlsec-instructure` gem.

Let's add it to the CI suite to prevent regression.
