### PR TITLE
Implement HTML 5 serialization in C

### DIFF
--- a/lib/nokogiri/html5/node.rb
+++ b/lib/nokogiri/html5/node.rb
@@ -28,7 +28,7 @@ module Nokogiri
       def inner_html(options = {})
         return super(options) unless document.is_a?(HTML5::Document)
 
-        result = options[:preserve_newline] && HTML5.prepend_newline?(self) ? +"\n" : +""
+        result = options[:preserve_newline] && prepend_newline? ? +"\n" : +""
         result << children.map { |child| child.to_html(options) }.join
         result
       end
@@ -56,11 +56,9 @@ module Nokogiri
           native_write_to(io, encoding, indent_string, config_options)
         else
           # Serialize including the current node.
+          html = html_standard_serialize(options[:preserve_newline] || false)
           encoding ||= document.encoding || Encoding::UTF_8
-          internal_ops = {
-            preserve_newline: options[:preserve_newline] || false,
-          }
-          HTML5.serialize_node_internal(self, io, encoding, internal_ops)
+          io << html.encode(encoding, fallback: lambda { |c| "&\#x#{c.ord.to_s(16)};" })
         end
       end
 

--- a/test/html5/test_serialize.rb
+++ b/test/html5/test_serialize.rb
@@ -504,4 +504,10 @@ class TestHtml5Serialize < Nokogiri::TestCase
       assert_equal test_data[3].gsub("%void", tag), test_data[1].call(tag).serialize
     end
   end
+
+  def test_serializing_html5_fragment
+    fragment = Nokogiri::HTML5.fragment("<div>hello</div>goodbye")
+    refute(fragment.send(:prepend_newline?))
+    assert_equal("<div>hello</div>goodbye", fragment.to_html)
+  end
 end if Nokogiri.uses_gumbo?


### PR DESCRIPTION
HTML 5 serialization was previously done entirely in Ruby.
The Ruby code is slow. This reimplements the serialization in C.

Reencoding happens after UTF-8 serialization.

Fixes: #2569

**What problem is this PR intended to solve?**

#2569

**Have you included adequate test coverage?**

Not yet.

**Does this change affect the behavior of either the C or the Java implementations?**

It should speed up the serialization of HTML 5 without a change in behavior.
