### PR TITLE
fix: XML::Reader XML::Attr garbage collection (backport to v1.13.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,12 +282,12 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: vmactions/freebsd-vm@v0.1.5
+      - uses: vmactions/freebsd-vm@v0.2.0
         with:
           usesh: true
           prepare: pkg install -y ruby devel/ruby-gems pkgconf libxml2 libxslt

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,67 @@
+name: downstream
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1,3,5" # At 08:00 on Monday, Wednesday, and Friday # https://crontab.guru/#0_8_*_*_1,3,5
+  push:
+    branches:
+      - main
+      - v*.*.x
+    tags:
+      - v*.*.*
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - '*'
+
+jobs:
+  downstream:
+    name: downstream-${{matrix.name}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - url: https://github.com/flavorjones/loofah
+            name: loofah
+            command: "bundle exec rake test"
+          - url: https://github.com/rails/rails-html-sanitizer
+            name: rails-html-sanitizer
+            command: "bundle exec rake test"
+          - url: https://github.com/rgrove/sanitize
+            name: sanitize
+            command: "bundle exec rake test"
+          - url: https://github.com/ebeigarts/signer
+            name: signer
+            command: "bundle exec rake spec"
+          - url: https://github.com/WinRb/Viewpoint
+            name: viewpoint
+            command: "bundle exec rspec spec"
+          - url: https://github.com/rails/rails
+            name: xmlmini
+            command: "cd activesupport && bundle exec rake test TESTOPTS=-n/XmlMini/"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: ports
+          key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+      - run: bundle install --local || bundle install
+      - run: bundle exec rake compile
+      - run: |
+          git clone --depth=1 ${{matrix.url}} ${{matrix.name}}
+          cd ${{matrix.name}}
+          if grep nokogiri Gemfile ; then
+            sed -i 's/\(.*nokogiri.*\)/\1, path: ".."/' Gemfile
+          else
+            echo "gem 'nokogiri', path: '..'" >> Gemfile
+          fi
+          bundle install --local || bundle install
+          ${{matrix.command}}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -42,6 +42,9 @@ jobs:
           - url: https://github.com/rails/rails
             name: xmlmini
             command: "cd activesupport && bundle exec rake test TESTOPTS=-n/XmlMini/"
+          - url: https://github.com/pythonicrubyist/creek
+            name: creek
+            command: "bundle exec rake spec"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
@@ -62,6 +65,9 @@ jobs:
             sed -i 's/\(.*nokogiri.*\)/\1, path: ".."/' Gemfile
           else
             echo "gem 'nokogiri', path: '..'" >> Gemfile
+          fi
+          if egrep "add_development_dependency.*\bbundler\b" *gemspec ; then
+            sed -i 's/.*add_development_dependency.*\bbundler\b.*//' *gemspec
           fi
           bundle install --local || bundle install
           ${{matrix.command}}

--- a/ext/java/nokogiri/XmlReader.java
+++ b/ext/java/nokogiri/XmlReader.java
@@ -141,6 +141,7 @@ public class XmlReader extends RubyObject
   public IRubyObject
   attribute_nodes(ThreadContext context)
   {
+    context.runtime.getWarnings().warn("Reader#attribute_nodes is deprecated and will be removed in a future version of Nokogiri. Please use Reader#attribute_hash instead.");
     return currentNode().getAttributesNodes();
   }
 

--- a/ext/java/nokogiri/XmlReader.java
+++ b/ext/java/nokogiri/XmlReader.java
@@ -144,6 +144,13 @@ public class XmlReader extends RubyObject
     return currentNode().getAttributesNodes();
   }
 
+  @JRubyMethod
+  public IRubyObject
+  attribute_hash(ThreadContext context)
+  {
+    return currentNode().getAttributes(context);
+  }
+
   @JRubyMethod(name = "attributes?")
   public IRubyObject
   attributes_p(ThreadContext context)

--- a/ext/java/nokogiri/internals/ReaderNode.java
+++ b/ext/java/nokogiri/internals/ReaderNode.java
@@ -112,9 +112,10 @@ public abstract class ReaderNode
   getAttributes(ThreadContext context)
   {
     final Ruby runtime = context.runtime;
-    if (attributeList == null) { return runtime.getNil(); }
     RubyHash hash = RubyHash.newHash(runtime);
+    if (attributeList == null) { return hash; }
     for (int i = 0; i < attributeList.length; i++) {
+      if (isNamespace(attributeList.names.get(i))) { continue; }
       IRubyObject k = stringOrBlank(runtime, attributeList.names.get(i));
       IRubyObject v = stringOrBlank(runtime, attributeList.values.get(i));
       hash.fastASetCheckString(runtime, k, v); // hash.op_aset(context, k, v)
@@ -150,8 +151,8 @@ public abstract class ReaderNode
   getNamespaces(ThreadContext context)
   {
     final Ruby runtime = context.runtime;
-    if (namespaces == null) { return runtime.getNil(); }
     RubyHash hash = RubyHash.newHash(runtime);
+    if (namespaces == null) { return hash; }
     for (Map.Entry<String, String> entry : namespaces.entrySet()) {
       IRubyObject k = stringOrBlank(runtime, entry.getKey());
       IRubyObject v = stringOrBlank(runtime, entry.getValue());

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -974,6 +974,7 @@ have_func("xmlRelaxNGSetValidStructuredErrors") # introduced in libxml 2.6.21
 have_func("xmlSchemaSetValidStructuredErrors") # introduced in libxml 2.6.23
 have_func("xmlSchemaSetParserStructuredErrors") # introduced in libxml 2.6.23
 have_func("rb_gc_location") # introduced in Ruby 2.7
+have_func("rb_category_warning") # introduced in Ruby 3.0
 
 have_func("vasprintf")
 

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -202,6 +202,12 @@ NOKOPUBFUN VALUE Nokogiri_wrap_xml_document(VALUE klass,
 #define DISCARD_CONST_QUAL(t, v) ((t)(uintptr_t)(v))
 #define DISCARD_CONST_QUAL_XMLCHAR(v) DISCARD_CONST_QUAL(xmlChar *, v)
 
+#if HAVE_RB_CATEGORY_WARNING
+#  define NOKO_WARN_DEPRECATION(message) rb_category_warning(RB_WARN_CATEGORY_DEPRECATED, message)
+#else
+#  define NOKO_WARN_DEPRECATION(message) rb_warning(message)
+#endif
+
 void Nokogiri_structured_error_func_save(libxmlStructuredErrorHandlerState *handler_state);
 void Nokogiri_structured_error_func_save_and_set(libxmlStructuredErrorHandlerState *handler_state, void *user_data,
     xmlStructuredErrorFunc handler);

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1806,7 +1806,7 @@ rb_xml_node_new(int argc, VALUE *argv, VALUE klass)
   }
   if (!rb_obj_is_kind_of(rb_document_node, cNokogiriXmlDocument)) {
     // TODO: deprecate allowing Node
-    rb_warn("Passing a Node as the second parameter to Node.new is deprecated. Please pass a Document instead, or prefer an alternative constructor like Node#add_child. This will become an error in a future release of Nokogiri.");
+    NOKO_WARN_DEPRECATION("Passing a Node as the second parameter to Node.new is deprecated. Please pass a Document instead, or prefer an alternative constructor like Node#add_child. This will become an error in a future release of Nokogiri.");
   }
   Noko_Node_Get_Struct(rb_document_node, xmlNode, c_document_node);
 

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -151,7 +151,11 @@ namespaces(VALUE self)
 /*
   :call-seq: attribute_nodes() → Array<Nokogiri::XML::Attr>
 
-  Get the attributes of the current node as an Array of Attr
+  Get the attributes of the current node as an Array of XML:Attr
+
+  ⚠ This method is deprecated and unsafe to use. It will be removed in a future version of Nokogiri.
+
+  See related: #attribute_hash, #attributes
  */
 static VALUE
 rb_xml_reader_attribute_nodes(VALUE rb_reader)
@@ -160,6 +164,10 @@ rb_xml_reader_attribute_nodes(VALUE rb_reader)
   xmlNodePtr c_node;
   VALUE attr_nodes;
   int j;
+
+  // TODO: deprecated, remove in Nokogiri v1.15, see https://github.com/sparklemotion/nokogiri/issues/2598
+  // After removal, we can also remove all the "node_has_a_document" special handling from xml_node.c
+  NOKO_WARN_DEPRECATION("Reader#attribute_nodes is deprecated and will be removed in a future version of Nokogiri. Please use Reader#attribute_hash instead.");
 
   Data_Get_Struct(rb_reader, xmlTextReader, c_reader);
 

--- a/lib/nokogiri/xml/reader.rb
+++ b/lib/nokogiri/xml/reader.rb
@@ -87,12 +87,7 @@ module Nokogiri
       #
       # [Returns] (Hash<String, String>) Attribute names and values
       def attributes
-        attrs_hash = attribute_nodes.each_with_object({}) do |node, hash|
-          hash[node.name] = node.to_s
-        end
-        ns = namespaces
-        attrs_hash.merge!(ns) if ns
-        attrs_hash
+        attribute_hash.merge(namespaces)
       end
 
       ###

--- a/lib/nokogiri/xml/reader.rb
+++ b/lib/nokogiri/xml/reader.rb
@@ -83,9 +83,12 @@ module Nokogiri
       end
       private :initialize
 
-      # Get the attributes of the current node as a Hash
+      # Get the attributes and namespaces of the current node as a Hash.
       #
-      # [Returns] (Hash<String, String>) Attribute names and values
+      # This is the union of Reader#attribute_hash and Reader#namespaces
+      #
+      # [Returns]
+      #   (Hash<String, String>) Attribute names and values, and namespace prefixes and hrefs.
       def attributes
         attribute_hash.merge(namespaces)
       end

--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -472,7 +472,9 @@ module Nokogiri
 
           reader = Nokogiri::XML::Reader.from_memory(xml)
           reader.each do |element|
-            attribute_nodes += element.attribute_nodes
+            assert_output(nil, /Reader#attribute_nodes is deprecated/) do
+              attribute_nodes += element.attribute_nodes
+            end
           end
         end
 
@@ -489,7 +491,9 @@ module Nokogiri
         eoxml
         attr_ns = []
         while reader.read
-          if reader.node_type == Nokogiri::XML::Node::ELEMENT_NODE
+          next unless reader.node_type == Nokogiri::XML::Node::ELEMENT_NODE
+
+          assert_output(nil, /Reader#attribute_nodes is deprecated/) do
             reader.attribute_nodes.each { |attr| attr_ns << (attr.namespace.nil? ? nil : attr.namespace.prefix) }
           end
         end
@@ -593,14 +597,17 @@ module Nokogiri
       end
 
       def test_large_document_smoke_test
-        #  simply run on a large document to verify that there no GC issues
-        xml = []
-        xml << "<elements>"
-        10000.times { |j| xml << "<element id=\"#{j}\"/>" }
-        xml << "</elements>"
-        xml = xml.join("\n")
+        skip_unless_libxml2("valgrind tests should only run with libxml2")
 
-        Nokogiri::XML::Reader.from_memory(xml).each(&:attributes)
+        refute_valgrind_errors do
+          xml = []
+          xml << "<elements>"
+          10000.times { |j| xml << "<element id=\"#{j}\"/>" }
+          xml << "</elements>"
+          xml = xml.join("\n")
+
+          Nokogiri::XML::Reader.from_memory(xml).each(&:attributes)
+        end
       end
 
       def test_correct_outer_xml_inclusion

--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -228,21 +228,59 @@ module Nokogiri
           reader.map(&:attributes?))
       end
 
-      def test_attributes
-        reader = Nokogiri::XML::Reader.from_memory(<<-eoxml)
-        <x xmlns:tenderlove='http://tenderlovemaking.com/'
-           xmlns='http://mothership.connection.com/'
-           >
-          <tenderlove:foo awesome='true'>snuggles!</tenderlove:foo>
-        </x>
-        eoxml
+      def test_reader_attributes
+        reader = Nokogiri::XML::Reader.from_memory(<<~XML)
+          <x xmlns:tenderlove='http://tenderlovemaking.com/' xmlns='http://mothership.connection.com/'>
+            <tenderlove:foo awesome='true'>snuggles!</tenderlove:foo>
+          </x>
+        XML
         assert_empty(reader.attributes)
         assert_equal([{ "xmlns:tenderlove" => "http://tenderlovemaking.com/",
                         "xmlns" => "http://mothership.connection.com/", },
-                      {}, { "awesome" => "true" }, {}, { "awesome" => "true" }, {},
+                      {},
+                      { "awesome" => "true" },
+                      {},
+                      { "awesome" => "true" },
+                      {},
                       { "xmlns:tenderlove" => "http://tenderlovemaking.com/",
                         "xmlns" => "http://mothership.connection.com/", },],
           reader.map(&:attributes))
+      end
+
+      def test_reader_attributes_hash
+        reader = Nokogiri::XML::Reader.from_memory(<<~XML)
+          <x xmlns:tenderlove='http://tenderlovemaking.com/' xmlns='http://mothership.connection.com/'>
+            <tenderlove:foo awesome='true'>snuggles!</tenderlove:foo>
+          </x>
+        XML
+        assert_empty(reader.attribute_hash)
+        assert_equal([{},
+                      {},
+                      { "awesome" => "true" },
+                      {},
+                      { "awesome" => "true" },
+                      {},
+                      {},],
+          reader.map(&:attribute_hash))
+      end
+
+      def test_reader_namespaces
+        reader = Nokogiri::XML::Reader.from_memory(<<~XML)
+          <x xmlns:tenderlove='http://tenderlovemaking.com/' xmlns='http://mothership.connection.com/'>
+            <tenderlove:foo awesome='true'>snuggles!</tenderlove:foo>
+          </x>
+        XML
+        assert_empty(reader.namespaces)
+        assert_equal([{ "xmlns:tenderlove" => "http://tenderlovemaking.com/",
+                        "xmlns" => "http://mothership.connection.com/", },
+                      {},
+                      {},
+                      {},
+                      {},
+                      {},
+                      { "xmlns:tenderlove" => "http://tenderlovemaking.com/",
+                        "xmlns" => "http://mothership.connection.com/", },],
+          reader.map(&:namespaces))
       end
 
       def test_attribute_roundtrip


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Closes #2598.

Backport of #2599 to v1.13.x for a patch release. See that issue for details.

