### PR TITLE
ci: fix development dependency breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           ruby-version: "3.0" # OK for now, until ruby 3.1 CI is stable
           bundler-cache: true
+          bundler: latest
       - run: bundle exec rake gumbo:test
 
   basic:
@@ -219,6 +220,7 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
+          bundler: latest
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
@@ -248,6 +250,7 @@ jobs:
           ruby-version: "${{matrix.ruby}}"
           mingw: "libxml2 libxslt"
           bundler-cache: true
+          bundler: latest
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
@@ -271,6 +274,7 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
+          bundler: latest
       - run: bundle exec rake compile
       - run: bundle exec rake test
       - run: bundle exec rake test:bench

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           ruby-version: "3.1"
           bundler-cache: true
+          bundler: latest
       - id: rcd_image_version
         run: bundle exec ruby -e 'require "rake_compiler_dock"; puts "::set-output name=rcd_image_version::#{RakeCompilerDock::IMAGE_VERSION}"'
 

--- a/.github/workflows/generate-ci-images.yml
+++ b/.github/workflows/generate-ci-images.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           ruby-version: "3.1"
           bundler-cache: true
+          bundler: latest
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -83,6 +83,7 @@ jobs:
           apt-get: "libxml2-dev libxslt1-dev pkg-config"
           mingw: "_upgrade_ libxml2 libxslt pkgconf"
           bundler-cache: true
+          bundler: latest
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
@@ -107,6 +108,7 @@ jobs:
           ruby-version: "head"
           apt-get: "libxml2-dev libxslt1-dev pkg-config valgrind"
           bundler-cache: true
+          bundler: latest
       - uses: actions/cache@v2
         if: matrix.sys == 'disable'
         with:
@@ -125,6 +127,7 @@ jobs:
         with:
           ruby-version: "jruby-head"
           bundler-cache: true
+          bundler: latest
       - run: bundle exec rake compile
       - run: bundle exec rake test
 

--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -321,7 +321,10 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
 
   if java_p
-    spec.add_development_dependency("jar-dependencies", "~> 0.4.1")
+    # loosen after jruby fixes https://github.com/jruby/jruby/issues/7262
+    # also see https://github.com/mkristian/jar-dependencies/commit/006fb254
+    spec.add_development_dependency("jar-dependencies", "= 0.4.1")
+
     spec.require_paths << "lib/nokogiri/jruby" # where we install the jars, see the :vendor_jars rake task
     spec.requirements << "jar isorelax, isorelax, 20030108" # https://search.maven.org/artifact/isorelax/isorelax
     spec.requirements << "jar org.nokogiri, nekodtd, 0.1.11.noko1"

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -65,6 +65,7 @@ module DockerHelper
                 with:
                   ruby-version: "3.1"
                   bundler-cache: true
+                  bundler: latest
               - uses: docker/setup-buildx-action@v1
               - uses: docker/login-action@v1
                 with:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Because of https://github.com/jruby/jruby/issues/7262 let's pin jar-dependencies to 0.4.1

Because of https://github.com/ruby/setup-ruby/issues/358 let's explicitly opt into latest bundler in all CI jobs
