### PR TITLE
dep: update libxslt to v1.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This version of Nokogiri uses [`jar-dependencies`](https://github.com/mkristian/
 ### Dependencies
 
 * [CRuby] Vendored libxml2 is updated to [v2.10.0](https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.0.news).
+* [CRuby] Vendored libxslt is updated to [v1.1.36](https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.36).
 * [JRuby] HTML parsing is now provided `net.sourceforge.htmlunit:neko-htmlunit:2.61.0` (previously was a fork of `org.cyberneko.html:nekohtml`)
 * [JRuby] Vendored Jing is updated from `com.thaiopensource:jing:20091111` to `nu.validator:jing:20200702VNU`.
 * [JRuby] New dependency on `net.sf.saxon:Saxon-HE:9.6.0-4` (via `nu.validator:jing:20200702VNU`).

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -4,9 +4,9 @@ libxml2:
   # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.0.sha256sum
 
 libxslt:
-  version: "1.1.35"
-  sha256: "8247f33e9a872c6ac859aa45018bc4c4d00b97e2feac9eebc10c93ce1f34dd79"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.35.sha256sum
+  version: "1.1.36"
+  sha256: "12848f0a4408f65b530d3962cd9ff670b6ae796191cfeff37522b5772de8dc8e"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.36.sha256sum
 
 zlib:
   version: "1.2.12"

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -838,6 +838,11 @@ else
       recipe.configure_options += ["RANLIB=/usr/bin/ranlib", "AR=/usr/bin/ar"]
     end
 
+    if windows?
+      cflags = concat_flags(cflags, "-ULIBXSLT_STATIC", "-DIN_LIBXSLT")
+      cflags = concat_flags(cflags, "-ULIBEXSLT_STATIC", "-DIN_LIBEXSLT")
+    end
+
     recipe.configure_options << if source_dir
       "--config-cache"
     else

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -859,9 +859,13 @@ else
   $libs = $libs.shellsplit.tap do |libs|
     [libxml2_recipe, libxslt_recipe].each do |recipe|
       libname = recipe.name[/\Alib(.+)\z/, 1]
-      File.join(recipe.path, "bin", "#{libname}-config").tap do |config|
+      config_basename = "#{libname}-config"
+      File.join(recipe.path, "bin", config_basename).tap do |config|
         # call config scripts explicit with 'sh' for compat with Windows
-        $CPPFLAGS = %x(sh #{config} --cflags).strip << " " << $CPPFLAGS
+        cflags = %x(sh #{config} --cflags).strip
+        message("#{config_basename} cflags: #{cflags}\n")
+        $CPPFLAGS = concat_flags(cflags, $CPPFLAGS) # prepend
+
         %x(sh #{config} --libs).strip.shellsplit.each do |arg|
           case arg
           when /\A-L(.+)\z/

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -903,6 +903,9 @@ else
         # xslt-config does not have a flag to emit options including
         # -lexslt, so add it manually.
         libs.unshift("-lexslt")
+
+        # see https://gitlab.gnome.org/GNOME/libxslt/-/issues/73 in libxslt 1.1.36
+        append_cppflags("-DLIBXSLT_STATIC -DLIBEXSLT_STATIC") if windows?
       end
     end
   end.shelljoin


### PR DESCRIPTION
**What problem is this PR intended to solve?**

libxslt just release v1.1.36. Full change log is at https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.36. This was a lockstep release with libxml 2.10.0 (see https://github.com/sparklemotion/nokogiri/pull/2625) and contains performance improvements and bugfixes.


**Have you included adequate test coverage?**

Existing coverage should be adequate.


**Does this change affect the behavior of either the C or the Java implementations?**

Potentially could change behavior in the CRuby implementation, but tests should provide coverage. We've been [regularly running CI against upstream master](https://github.com/sparklemotion/nokogiri/actions/workflows/upstream.yml).
