### PR TITLE
test: pending test for JRuby schema validation issue

### DIFF
--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -196,6 +196,15 @@ module Nokogiri
         assert_raises(ArgumentError) { @xsd.validate(string) }
       end
 
+      def test_validate_empty_document
+        doc = Nokogiri::XML("")
+        assert(errors = @xsd.validate(doc))
+
+        pending_if("https://github.com/sparklemotion/nokogiri/issues/783", Nokogiri.jruby?) do
+          assert_equal(1, errors.length)
+        end
+      end
+
       def test_valid?
         valid_doc = Nokogiri::XML(File.read(PO_XML_FILE))
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#783 describes an issue with JRuby schema validation when passed a blank document.

This introduces a test that's marked "pending" for JRuby to capture the issue.
