### PR TITLE
feat(cruby): custom XPath functions support `nokogiri` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This version of Nokogiri uses [`jar-dependencies`](https://github.com/mkristian/
 ### Added
 
 * [CRuby] The HTML5 parser handles the [new `search` element](https://github.com/whatwg/html/pull/7320). [#2566](https://github.com/sparklemotion/nokogiri/issues/2566)
+* [CRuby] Invocation of custom XPath or CSS handler functions may now use the `nokogiri` namespace prefix. Historically, the JRuby implementation _required_ this namespace but the CRuby implementation did not support it. It's recommended that all XPath and CSS queries use the `nokogiri` namespace going forward. Invocation without the namespace is planned for deprecation in v1.15.0 and removal in a future release. [[#2147](https://github.com/sparklemotion/nokogiri/issues/2147)]
 
 
 ### Fixed

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -6,6 +6,8 @@ VALUE cNokogiriXmlXpathContext;
  * these constants have matching declarations in
  * ext/java/nokogiri/internals/NokogiriNamespaceContext.java
  */
+static const xmlChar *NOKOGIRI_PREFIX = (const xmlChar *)"nokogiri";
+static const xmlChar *NOKOGIRI_URI = (const xmlChar *)"http://www.nokogiri.org/default_ns/ruby/extensions_functions";
 static const xmlChar *NOKOGIRI_BUILTIN_PREFIX = (const xmlChar *)"nokogiri-builtin";
 static const xmlChar *NOKOGIRI_BUILTIN_URI = (const xmlChar *)"https://www.nokogiri.org/default_ns/ruby/builtins";
 
@@ -382,6 +384,7 @@ new (VALUE klass, VALUE nodeobj)
   ctx = xmlXPathNewContext(node->doc);
   ctx->node = node;
 
+  xmlXPathRegisterNs(ctx, NOKOGIRI_PREFIX, NOKOGIRI_URI);
   xmlXPathRegisterNs(ctx, NOKOGIRI_BUILTIN_PREFIX, NOKOGIRI_BUILTIN_URI);
   xmlXPathRegisterFuncNS(ctx, (const xmlChar *)"css-class", NOKOGIRI_BUILTIN_URI,
                          xpath_builtin_css_class);

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -156,6 +156,16 @@ module Nokogiri
         end
       end
 
+      def test_search_with_xpath_query_using_namespaced_custom_function
+        # Note that invocation with namespaces was not historically supported in CRuby.
+        # see https://github.com/sparklemotion/nokogiri/issues/2147 for more context.
+        set = @xml.xpath('//employee/address[nokogiri:my_filter(., "domestic", "Yes")]', @handler)
+        refute_empty(set)
+        set.each do |node|
+          assert_equal("Yes", node["domestic"])
+        end
+      end
+
       def test_pass_self_to_function
         set = if Nokogiri.uses_libxml?
           @xml.xpath('//employee/address[my_filter(., "domestic", "Yes")]', @handler)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See #2147 for context and deprecation roadmap.


**Have you included adequate test coverage?**

Yes.


**Does this change affect the behavior of either the C or the Java implementations?**

The CRuby implementation will now support the same XPath query syntax as JRuby.