### PR TITLE
[jruby] avoid relying on transformer internals

### DIFF
--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -179,13 +179,12 @@ public class XsltStylesheet extends RubyObject
 
   @JRubyMethod
   public IRubyObject
-  serialize(ThreadContext context, IRubyObject doc) throws IOException, TransformerException
+  serialize(ThreadContext context, IRubyObject doc) throws IOException
   {
     XmlDocument xmlDoc = (XmlDocument) doc;
-    Transformer transformer = this.sheet.newTransformer();
     ByteArrayOutputStream writer = new ByteArrayOutputStream();
 
-    Serializer serializer = SerializerFactory.getSerializer(transformer.getOutputProperties());
+    Serializer serializer = SerializerFactory.getSerializer(this.sheet.getOutputProperties());
     serializer.setOutputStream(writer);
     ((SerializationHandler) serializer).serialize(xmlDoc.getNode());
     return context.getRuntime().newString(writer.toString());

--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -23,8 +23,10 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import org.apache.xalan.transformer.TransformerImpl;
 import org.apache.xml.serializer.SerializationHandler;
+import org.apache.xml.serializer.Serializer;
+import org.apache.xml.serializer.SerializerFactory;
+
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
@@ -180,11 +182,12 @@ public class XsltStylesheet extends RubyObject
   serialize(ThreadContext context, IRubyObject doc) throws IOException, TransformerException
   {
     XmlDocument xmlDoc = (XmlDocument) doc;
-    TransformerImpl transformer = (TransformerImpl) this.sheet.newTransformer();
+    Transformer transformer = this.sheet.newTransformer();
     ByteArrayOutputStream writer = new ByteArrayOutputStream();
-    StreamResult streamResult = new StreamResult(writer);
-    SerializationHandler serializationHandler = transformer.createSerializationHandler(streamResult);
-    serializationHandler.serialize(xmlDoc.getNode());
+
+    Serializer serializer = SerializerFactory.getSerializer(transformer.getOutputProperties());
+    serializer.setOutputStream(writer);
+    ((SerializationHandler) serializer).serialize(xmlDoc.getNode());
     return context.getRuntime().newString(writer.toString());
   }
 


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Should unblock compilation issue with older Xalan versions (https://github.com/sparklemotion/nokogiri/pull/2632).

Using the `TransformerImpl` (internal) class from Xalan is avoided.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

Existing tests cover the serialization feature.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

JRuby only and should be considered a simple refactoring change - wout side-effects.