### PR TITLE
wip: use xmlsec's noxxe entity loader

### DIFF
--- a/LICENSE-DEPENDENCIES.md
+++ b/LICENSE-DEPENDENCIES.md
@@ -412,6 +412,36 @@ http://xmlsoft.org/libxslt/
     ----------------------------------------------------------------------
     
 
+### xmlsec
+
+MIT
+
+https://www.aleksey.com/xmlsec/
+
+      Copyright (C) 2002-2016 Aleksey Sanin <aleksey@aleksey.com>. All Rights Reserved.
+
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is fur-
+      nished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FIT-
+      NESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+      ALEKSEY SANIN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+      IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CON-
+      NECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+      Except as contained in this notice, the name of Aleksey Sanin shall not
+      be used in advertising or otherwise to promote the sale, use or other deal-
+      ings in this Software without prior written authorization from him.
+
+
 ### zlib
 
 zlib license

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -47,6 +47,7 @@ void noko_init_html_entity_lookup(void);
 void noko_init_html_sax_parser_context(void);
 void noko_init_html_sax_push_parser(void);
 void noko_init_gumbo(void);
+void noko_init_xmlsec(void);
 void noko_init_test_global_handlers(void);
 
 static ID id_read, id_write, id_external_encoding;
@@ -250,6 +251,7 @@ Init_nokogiri()
   noko_init_xml_document();
   noko_init_html_document();
   noko_init_gumbo();
+  noko_init_xmlsec();
 
   noko_init_test_global_handlers();
 

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -225,6 +225,8 @@ NORETURN_DECL void Nokogiri_error_raise(void *ctx, xmlErrorPtr error);
 void Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr ctx, int nargs, VALUE handler,
     const char *function_name) ;
 
+xmlParserInputPtr Nokogiri_xmlSecNoXxeExternalEntityLoader(const char *URL, const char *ID, xmlParserCtxtPtr ctxt);
+
 static inline
 nokogiriSAXTuplePtr
 nokogiri_sax_tuple_new(xmlParserCtxtPtr ctxt, VALUE self)

--- a/ext/nokogiri/xmlsec.c
+++ b/ext/nokogiri/xmlsec.c
@@ -1,0 +1,64 @@
+#include <nokogiri.h>
+
+/*
+ * This file contains code originally written as part of the xmlsec library.
+ *
+ * https://www.aleksey.com/xmlsec/
+ *
+ * Copyright (C) 2002-2022 Aleksey Sanin <aleksey@aleksey.com>. All Rights Reserved.
+ */
+
+/* --- taken from include/xmlsec/errors.h --- */
+/**
+ * xmlSecErrorsSafeString:
+ * @str:                the string.
+ *
+ * Macro. Returns @str if it is not NULL or pointer to "NULL" otherwise.
+ */
+#define xmlSecErrorsSafeString(str) \
+        (((str) != NULL) ? ((const char*)(str)) : (const char*)"NULL")
+
+
+/* --- taken from src/xmlsec.c --- */
+/*
+ * Custom external entity handler, denies all files except the initial
+ * document we're parsing (input_id == 1)
+ */
+/* default external entity loader, pointer saved during xmlInit */
+static xmlExternalEntityLoader
+xmlSecDefaultExternalEntityLoader = NULL;
+
+/*
+ * xmlSecNoXxeExternalEntityLoader:
+ * @URL:        the URL for the entity to load
+ * @ID:         public ID for the entity to load
+ * @ctxt:       XML parser context, or NULL
+ *
+ * See libxml2's xmlLoadExternalEntity and xmlNoNetExternalEntityLoader.
+ * This function prevents any external (file or network) entities from being loaded.
+ */
+xmlParserInputPtr
+Nokogiri_xmlSecNoXxeExternalEntityLoader(
+  const char *URL,
+  const char *ID,
+  xmlParserCtxtPtr ctxt
+)
+{
+  if (ctxt == NULL) {
+    return (NULL);
+  }
+  if (ctxt->input_id == 1) {
+    return xmlSecDefaultExternalEntityLoader((const char *) URL, ID, ctxt);
+  }
+  xmlParserError(ctxt, "NONET disallows external entity '%s'\n", xmlSecErrorsSafeString(URL));
+  return (NULL);
+}
+
+
+void
+noko_init_xmlsec()
+{
+  if (!xmlSecDefaultExternalEntityLoader) {
+    xmlSecDefaultExternalEntityLoader = xmlGetExternalEntityLoader();
+  }
+}


### PR DESCRIPTION
Draft PR to try to use xmlsec's noxxe entity loader.

See #1582 for context.

This branch segfaults with seed 12441 and I have not yet been able to track it down
