### PR TITLE
fix: namespace nodes behave with compaction

### DIFF
--- a/ext/nokogiri/html4_sax_parser_context.c
+++ b/ext/nokogiri/html4_sax_parser_context.c
@@ -5,13 +5,8 @@ VALUE cNokogiriHtml4SaxParserContext ;
 static void
 deallocate(xmlParserCtxtPtr ctxt)
 {
-  NOKOGIRI_DEBUG_START(ctxt);
-
   ctxt->sax = NULL;
-
   htmlFreeParserCtxt(ctxt);
-
-  NOKOGIRI_DEBUG_END(ctxt);
 }
 
 static VALUE

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -75,14 +75,6 @@ xmlNodePtr xmlLastElementChild(xmlNodePtr parent);
 #define NOKOGIRI_STR_NEW(str, len) rb_external_str_new_with_enc((const char *)(str), (long)(len), rb_utf8_encoding())
 #define RBSTR_OR_QNIL(_str) (_str ? NOKOGIRI_STR_NEW2(_str) : Qnil)
 
-#ifdef DEBUG
-#  define NOKOGIRI_DEBUG_START(p) if (getenv("NOKOGIRI_NO_FREE")) return ; if (getenv("NOKOGIRI_DEBUG")) fprintf(stderr,"nokogiri: %s:%d %p start\n", __FILE__, __LINE__, p);
-#  define NOKOGIRI_DEBUG_END(p) if (getenv("NOKOGIRI_DEBUG")) fprintf(stderr,"nokogiri: %s:%d %p end\n", __FILE__, __LINE__, p);
-#else
-#  define NOKOGIRI_DEBUG_START(p)
-#  define NOKOGIRI_DEBUG_END(p)
-#endif
-
 #ifndef NORETURN_DECL
 #  if defined(__GNUC__)
 #    define NORETURN_DECL __attribute__ ((noreturn))

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -173,6 +173,7 @@ int noko_io_write(void *ctx, char *buffer, int len);
 int noko_io_close(void *ctx);
 
 #define Noko_Node_Get_Struct(obj,type,sval) ((sval) = (type*)DATA_PTR(obj))
+#define Noko_Namespace_Get_Struct(obj,type,sval) ((sval) = (type*)DATA_PTR(obj))
 
 VALUE noko_xml_node_wrap(VALUE klass, xmlNodePtr node) ;
 VALUE noko_xml_node_wrap_node_set_result(xmlNodePtr node, VALUE node_set) ;

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -65,8 +65,6 @@ dealloc(xmlDocPtr doc)
 {
   st_table *node_hash;
 
-  NOKOGIRI_DEBUG_START(doc);
-
   node_hash  = DOC_UNLINKED_NODE_HASH(doc);
 
   st_foreach(node_hash, dealloc_node_i, (st_data_t)doc);
@@ -84,8 +82,6 @@ dealloc(xmlDocPtr doc)
   }
 
   xmlFreeDoc(doc);
-
-  NOKOGIRI_DEBUG_END(doc);
 }
 
 static void

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -100,7 +100,11 @@ recursively_remove_namespaces_from_node(xmlNodePtr node)
        (node->type == XML_XINCLUDE_START) ||
        (node->type == XML_XINCLUDE_END)) &&
       node->nsDef) {
-    xmlFreeNsList(node->nsDef);
+    xmlNsPtr curr = node->nsDef;
+    while (curr) {
+      noko_xml_document_pin_namespace(curr, node->doc);
+      curr = curr->next;
+    }
     node->nsDef = NULL;
   }
 

--- a/ext/nokogiri/xml_namespace.c
+++ b/ext/nokogiri/xml_namespace.c
@@ -31,7 +31,6 @@ dealloc_namespace(xmlNsPtr ns)
    * this deallocator is only used for namespace nodes that are part of an xpath
    * node set. see noko_xml_namespace_wrap().
    */
-  NOKOGIRI_DEBUG_START(ns) ;
   if (ns->href) {
     xmlFree(DISCARD_CONST_QUAL_XMLCHAR(ns->href));
   }
@@ -39,7 +38,6 @@ dealloc_namespace(xmlNsPtr ns)
     xmlFree(DISCARD_CONST_QUAL_XMLCHAR(ns->prefix));
   }
   xmlFree(ns);
-  NOKOGIRI_DEBUG_END(ns) ;
 }
 
 

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -9,11 +9,11 @@ static ID id_decorate, id_decorate_bang;
 
 typedef xmlNodePtr(*pivot_reparentee_func)(xmlNodePtr, xmlNodePtr);
 
-#define _xml_node_dealloc 0
-
 static void
-_xml_node_mark(xmlNodePtr node)
+_xml_node_mark(void *ptr)
 {
+  xmlNodePtr node = ptr;
+
   if (!DOC_RUBY_OBJECT_TEST(node->doc)) {
     return;
   }
@@ -30,24 +30,21 @@ _xml_node_mark(xmlNodePtr node)
 
 #ifdef HAVE_RB_GC_LOCATION
 static void
-_xml_node_update_references(xmlNodePtr node)
+_xml_node_update_references(void *ptr)
 {
+  xmlNodePtr node = ptr;
+
   if (node->_private) {
     node->_private = (void *)rb_gc_location((VALUE)node->_private);
   }
 }
+#else
+#  define _xml_node_update_references 0
 #endif
-
-typedef void (*gc_callback_t)(void *);
 
 static const rb_data_type_t nokogiri_node_type = {
   "Nokogiri/XMLNode",
-  {
-    (gc_callback_t)_xml_node_mark, (gc_callback_t)_xml_node_dealloc, 0,
-#ifdef HAVE_RB_GC_LOCATION
-    (gc_callback_t)_xml_node_update_references
-#endif
-  },
+  {_xml_node_mark, 0, 0, _xml_node_update_references},
   0, 0,
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
   RUBY_TYPED_FREE_IMMEDIATELY,

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1343,7 +1343,7 @@ set_namespace(VALUE self, VALUE namespace)
   Noko_Node_Get_Struct(self, xmlNode, node);
 
   if (!NIL_P(namespace)) {
-    Data_Get_Struct(namespace, xmlNs, ns);
+    Noko_Namespace_Get_Struct(namespace, xmlNs, ns);
   }
 
   xmlSetNs(node, ns);

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -9,16 +9,7 @@ static ID id_decorate, id_decorate_bang;
 
 typedef xmlNodePtr(*pivot_reparentee_func)(xmlNodePtr, xmlNodePtr);
 
-#ifdef DEBUG
-static void
-_xml_node_dealloc(xmlNodePtr x)
-{
-  NOKOGIRI_DEBUG_START(x)
-  NOKOGIRI_DEBUG_END(x)
-}
-#else
-#  define _xml_node_dealloc 0
-#endif
+#define _xml_node_dealloc 0
 
 static void
 _xml_node_mark(xmlNodePtr node)

--- a/ext/nokogiri/xml_node_set.c
+++ b/ext/nokogiri/xml_node_set.c
@@ -88,13 +88,11 @@ deallocate(xmlNodeSetPtr node_set)
    * For reasons outlined in xml_namespace.c, here we reproduce xmlXPathFreeNodeSet() except for the
    * offending call to xmlXPathNodeSetFreeNs().
    */
-  NOKOGIRI_DEBUG_START(node_set) ;
   if (node_set->nodeTab != NULL) {
     xmlFree(node_set->nodeTab);
   }
 
   xmlFree(node_set);
-  NOKOGIRI_DEBUG_END(node_set) ;
 }
 
 

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -5,9 +5,7 @@ VALUE cNokogiriXmlReader;
 static void
 dealloc(xmlTextReaderPtr reader)
 {
-  NOKOGIRI_DEBUG_START(reader);
   xmlFreeTextReader(reader);
-  NOKOGIRI_DEBUG_END(reader);
 }
 
 static int

--- a/ext/nokogiri/xml_relax_ng.c
+++ b/ext/nokogiri/xml_relax_ng.c
@@ -5,9 +5,7 @@ VALUE cNokogiriXmlRelaxNG;
 static void
 dealloc(xmlRelaxNGPtr schema)
 {
-  NOKOGIRI_DEBUG_START(schema);
   xmlRelaxNGFree(schema);
-  NOKOGIRI_DEBUG_END(schema);
 }
 
 /*

--- a/ext/nokogiri/xml_sax_parser.c
+++ b/ext/nokogiri/xml_sax_parser.c
@@ -268,9 +268,7 @@ processing_instruction(void *ctx, const xmlChar *name, const xmlChar *content)
 static void
 deallocate(xmlSAXHandlerPtr handler)
 {
-  NOKOGIRI_DEBUG_START(handler);
   ruby_xfree(handler);
-  NOKOGIRI_DEBUG_END(handler);
 }
 
 static VALUE

--- a/ext/nokogiri/xml_sax_parser_context.c
+++ b/ext/nokogiri/xml_sax_parser_context.c
@@ -7,13 +7,8 @@ static ID id_read;
 static void
 deallocate(xmlParserCtxtPtr ctxt)
 {
-  NOKOGIRI_DEBUG_START(ctxt);
-
   ctxt->sax = NULL;
-
   xmlFreeParserCtxt(ctxt);
-
-  NOKOGIRI_DEBUG_END(ctxt);
 }
 
 /*

--- a/ext/nokogiri/xml_sax_push_parser.c
+++ b/ext/nokogiri/xml_sax_push_parser.c
@@ -5,12 +5,10 @@ VALUE cNokogiriXmlSaxPushParser ;
 static void
 deallocate(xmlParserCtxtPtr ctx)
 {
-  NOKOGIRI_DEBUG_START(ctx);
   if (ctx != NULL) {
     NOKOGIRI_SAX_TUPLE_DESTROY(ctx->userData);
     xmlFreeParserCtxt(ctx);
   }
-  NOKOGIRI_DEBUG_END(ctx);
 }
 
 static VALUE

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -5,9 +5,7 @@ VALUE cNokogiriXmlSchema;
 static void
 dealloc(xmlSchemaPtr schema)
 {
-  NOKOGIRI_DEBUG_START(schema);
   xmlSchemaFree(schema);
-  NOKOGIRI_DEBUG_END(schema);
 }
 
 /*

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -14,9 +14,7 @@ static const xmlChar *NOKOGIRI_BUILTIN_URI = (const xmlChar *)"https://www.nokog
 static void
 xml_xpath_context_deallocate(xmlXPathContextPtr ctx)
 {
-  NOKOGIRI_DEBUG_START(ctx);
   xmlXPathFreeContext(ctx);
-  NOKOGIRI_DEBUG_END(ctx);
 }
 
 /* find a CSS class in an HTML element's `class` attribute */

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -12,11 +12,7 @@ static void
 dealloc(nokogiriXsltStylesheetTuple *wrapper)
 {
   xsltStylesheetPtr doc = wrapper->ss;
-
-  NOKOGIRI_DEBUG_START(doc);
-  xsltFreeStylesheet(doc); /* commented out for now. */
-  NOKOGIRI_DEBUG_END(doc);
-
+  xsltFreeStylesheet(doc);
   ruby_xfree(wrapper);
 }
 

--- a/rakelib/debug.rake
+++ b/rakelib/debug.rake
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-desc "Set environment variables to build and/or test with debug options"
-task :debug do
-  ENV["NOKOGIRI_DEBUG"] = "true"
-  ENV["CFLAGS"] ||= ""
-  ENV["CFLAGS"] += " -DDEBUG"
-end
-
 task :java_debug do # rubocop:disable Rake/Desc
   ENV["JRUBY_OPTS"] = "#{ENV["JRUBY_OPTS"]} --debug --dev"
   if ENV["JAVA_DEBUG"]

--- a/test/test_compaction.rb
+++ b/test/test_compaction.rb
@@ -39,5 +39,27 @@ describe "compaction" do
 
       doc.at_xpath("//root:first", "root" => "http://example.com/root").namespace_scopes.inspect
     end
+
+    it "remove_namespaces!" do
+      skip unless GC.respond_to?(:verify_compaction_references)
+
+      doc = Nokogiri::XML(<<~XML)
+        <root xmlns:a="http://a.flavorjon.es/" xmlns:b="http://b.flavorjon.es/">
+          <a:foo>hello from a</a:foo>
+          <b:foo>hello from b</b:foo>
+          <container xmlns:c="http://c.flavorjon.es/">
+            <c:foo c:attr='attr-value'>hello from c</c:foo>
+          </container>
+        </root>
+      XML
+
+      namespaces = doc.root.namespaces
+      namespaces.each(&:inspect)
+      doc.remove_namespaces!
+
+      GC.verify_compaction_references(double_heap: true, toward: :empty)
+
+      namespaces.each(&:inspect)
+    end
   end
 end

--- a/test/test_compaction.rb
+++ b/test/test_compaction.rb
@@ -3,19 +3,41 @@
 require "helper"
 
 describe "compaction" do
-  it "https://github.com/sparklemotion/nokogiri/pull/2579" do
-    skip unless GC.respond_to?(:verify_compaction_references)
+  describe Nokogiri::XML::Node do
+    it "compacts safely" do # https://github.com/sparklemotion/nokogiri/pull/2579
+      skip unless GC.respond_to?(:verify_compaction_references)
 
-    big_doc = "<root>" + ("a".."zz").map { |x| "<#{x}>#{x}</#{x}>" }.join + "</root>"
-    doc = Nokogiri.XML(big_doc)
+      big_doc = "<root>" + ("a".."zz").map { |x| "<#{x}>#{x}</#{x}>" }.join + "</root>"
+      doc = Nokogiri.XML(big_doc)
 
-    # ensure a bunch of node objects have been wrapped
-    doc.root.children.each(&:inspect)
+      # ensure a bunch of node objects have been wrapped
+      doc.root.children.each(&:inspect)
 
-    # compact the heap and try to get the node wrappers to move
-    GC.verify_compaction_references(double_heap: true, toward: :empty)
+      # compact the heap and try to get the node wrappers to move
+      GC.verify_compaction_references(double_heap: true, toward: :empty)
 
-    # access the node wrappers and make sure they didn't move
-    doc.root.children.each(&:inspect)
+      # access the node wrappers and make sure they didn't move
+      doc.root.children.each(&:inspect)
+    end
+  end
+
+  describe Nokogiri::XML::Namespace do
+    it "namespace_scopes" do
+      skip unless GC.respond_to?(:verify_compaction_references)
+
+      doc = Nokogiri::XML(<<~EOF)
+        <root xmlns="http://example.com/root" xmlns:bar="http://example.com/bar">
+          <first/>
+          <second xmlns="http://example.com/child"/>
+          <third xmlns:foo="http://example.com/foo"/>
+        </root>
+      EOF
+
+      doc.at_xpath("//root:first", "root" => "http://example.com/root").namespace_scopes.inspect
+
+      GC.verify_compaction_references(double_heap: true, toward: :empty)
+
+      doc.at_xpath("//root:first", "root" => "http://example.com/root").namespace_scopes.inspect
+    end
   end
 end

--- a/test/test_memory_leak.rb
+++ b/test/test_memory_leak.rb
@@ -183,6 +183,47 @@ class TestMemoryLeak < Nokogiri::TestCase
       end
     end
 
+    def test_document_remove_namespaces_with_ruby_objects
+      xml = <<~XML
+        <root xmlns:a="http://a.flavorjon.es/" xmlns:b="http://b.flavorjon.es/">
+          <a:foo>hello from a</a:foo>
+          <b:foo>hello from b</b:foo>
+          <container xmlns:c="http://c.flavorjon.es/">
+            <c:foo c:attr='attr-value'>hello from c</c:foo>
+          </container>
+        </root>
+      XML
+
+      20.times do
+        10_000.times do
+          doc = Nokogiri::XML::Document.parse(xml)
+          doc.namespaces.each(&:inspect)
+          doc.remove_namespaces!
+        end
+        puts MemInfo.rss
+      end
+    end
+
+    def test_document_remove_namespaces_without_ruby_objects
+      xml = <<~XML
+        <root xmlns:a="http://a.flavorjon.es/" xmlns:b="http://b.flavorjon.es/">
+          <a:foo>hello from a</a:foo>
+          <b:foo>hello from b</b:foo>
+          <container xmlns:c="http://c.flavorjon.es/">
+            <c:foo c:attr='attr-value'>hello from c</c:foo>
+          </container>
+        </root>
+      XML
+
+      20.times do
+        20_000.times do
+          doc = Nokogiri::XML::Document.parse(xml)
+          doc.remove_namespaces!
+        end
+        puts MemInfo.rss
+      end
+    end
+
     def test_xpath_namespaces
       xml = <<~XML
         <root xmlns:a="http://a.flavorjon.es/" xmlns:b="http://b.flavorjon.es/">

--- a/test/test_memory_leak.rb
+++ b/test/test_memory_leak.rb
@@ -89,14 +89,6 @@ class TestMemoryLeak < Nokogiri::TestCase
       puts "\ndike is not installed, skipping memory leak test"
     end
 
-    def test_node_set_namespace_mem_leak
-      xml = Nokogiri::XML("<foo></foo>")
-      ctx = Nokogiri::XML::XPathContext.new(xml)
-      loop do
-        ctx.evaluate("//namespace::*")
-      end
-    end
-
     def test_leak_on_node_replace
       loop do
         doc = Nokogiri.XML("<root><foo /></root>")
@@ -161,7 +153,7 @@ class TestMemoryLeak < Nokogiri::TestCase
       end
     end
 
-    def test_leaking_namespace_node_strings
+    def test_builder_namespace_node_strings_no_prefix
       # see https://github.com/sparklemotion/nokogiri/issues/1810 for memory leak report
       ns = { "xmlns" => "http://schemas.xmlsoap.org/soap/envelope/" }
       20.times do
@@ -176,7 +168,7 @@ class TestMemoryLeak < Nokogiri::TestCase
       end
     end
 
-    def test_leaking_namespace_node_strings_with_prefix
+    def test_builder_namespace_node_strings_with_prefix
       # see https://github.com/sparklemotion/nokogiri/issues/1810 for memory leak report
       ns = { "xmlns:foo" => "http://schemas.xmlsoap.org/soap/envelope/" }
       20.times do
@@ -186,6 +178,27 @@ class TestMemoryLeak < Nokogiri::TestCase
               xml.send(:Foobar, ns)
             end
           end
+        end
+        puts MemInfo.rss
+      end
+    end
+
+    def test_xpath_namespaces
+      xml = <<~XML
+        <root xmlns:a="http://a.flavorjon.es/" xmlns:b="http://b.flavorjon.es/">
+          <a:foo>hello from a</a:foo>
+          <b:foo>hello from b</b:foo>
+          <container xmlns:c="http://c.flavorjon.es/">
+            <c:foo c:attr='attr-value'>hello from c</c:foo>
+          </container>
+        </root>
+      XML
+      doc = Nokogiri::XML::Document.parse(xml)
+      ctx = Nokogiri::XML::XPathContext.new(doc)
+
+      20.times do
+        10_000.times do
+          ctx.evaluate("//namespace::*")
         end
         puts MemInfo.rss
       end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Under certain circumstances, GC compaction will cause a segfault when accessing wrapped `XML::Namespace` objects.

See previous similar work at #2579 

This fix, if merged, should be backported to v1.13.x and released as a bugfix.

**Have you included adequate test coverage?**

Yes, repro test is included thanks to @eightbitraptor and @peterzhu2118

**Does this change affect the behavior of either the C or the Java implementations?**

No functional behavior changes.