### PR TITLE
dep: update libxml2 to v2.10.3

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,7 +1,7 @@
 libxml2:
-  version: "2.10.2"
-  sha256: "d240abe6da9c65cb1900dd9bf3a3501ccf88b3c2a1cb98317d03f272dda5b265"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.2.sha256sum
+  version: "2.10.3"
+  sha256: "5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.3.sha256sum
 
 libxslt:
   version: "1.1.37"

--- a/test/xml/sax/test_parser.rb
+++ b/test/xml/sax/test_parser.rb
@@ -437,7 +437,12 @@ module Nokogiri
           parser = Nokogiri::XML::SAX::Parser.new(handler)
           parser.parse(xml)
 
-          assert_predicate(handler.errors, :empty?)
+          if Nokogiri.uses_libxml?(">=2.10.3")
+            # CVE-2022-40303 https://gitlab.gnome.org/GNOME/libxml2/-/commit/c846986
+            assert_match(/CData section too big/, handler.errors.first)
+          else
+            assert_predicate(handler.errors, :empty?)
+          end
         end
 
         it "does not resolve entities by default" do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

update libxml2 to v2.10.3 from v2.10.2

See https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.10.3

Related to #2665 

**Have you included adequate test coverage?**

Existing coverage is fine.


**Does this change affect the behavior of either the C or the Java implementations?**

Note the new libxml2 behavior around CDATA nodes longer than 10MB.
