### PR TITLE
Modernize rcd_image_version retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
           bundler-cache: true
           bundler: latest
       - id: rcd_image_version
-        run: bundle exec ruby -e 'require "rake_compiler_dock"; puts "::set-output name=rcd_image_version::#{RakeCompilerDock::IMAGE_VERSION}"'
+        run: bundle exec ruby -e 'require "rake_compiler_dock"; puts "rcd_image_version=#{RakeCompilerDock::IMAGE_VERSION}"' >> $GITHUB_OUTPUT
 
   generic-package:
     needs: ["rcd_image_version"]


### PR DESCRIPTION
GitHub is [deprecating the use of `set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), so this PR removes the warning by updating the same logic to the new sequence.