### PR TITLE
Remove GC.start required by ruby_memcheck

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,9 +13,6 @@
 # - NOKOGIRI_GC: read more in test/test_memory_leak.rb
 #
 
-# make sure we do one final major before the process exits (for valgrind)
-at_exit { GC.start(full_mark: true) } unless ::RUBY_PLATFORM == "java"
-
 require "simplecov"
 SimpleCov.start do
   add_filter "/test/"


### PR DESCRIPTION


<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

As of version 1.2.0, ruby_memcheck no longer needs the call to GC.start at exit. It will do it automatically.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

N/A.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

No.
