### PR TITLE
Fix loss of precision warnings

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -627,6 +627,13 @@ append_cflags("-Winline")
 # good to have no matter what Ruby was compiled with
 append_cflags("-Wmissing-noreturn")
 
+# check integer loss of precision
+if darwin?
+  append_cflags("-Wshorten-64-to-32")
+else
+  append_cflags("-Wconversion -Wno-sign-conversion")
+end
+
 # handle clang variations, see #1101
 if darwin?
   append_cflags("-Wno-error=unused-command-line-argument-hard-error-in-future")

--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -281,12 +281,12 @@ add_errors(const GumboOutput *output, VALUE rdoc, VALUE input, VALUE url)
       rb_iv_set(syntax_error, "@code", INT2NUM(1));   // XML_ERR_INTERNAL_ERROR
       rb_iv_set(syntax_error, "@level", INT2NUM(2));  // XML_ERR_ERROR
       rb_iv_set(syntax_error, "@file", url);
-      rb_iv_set(syntax_error, "@line", INT2NUM(position.line));
+      rb_iv_set(syntax_error, "@line", SIZET2NUM(position.line));
       rb_iv_set(syntax_error, "@str1", str1);
       rb_iv_set(syntax_error, "@str2", Qnil);
       rb_iv_set(syntax_error, "@str3", Qnil);
       rb_iv_set(syntax_error, "@int1", INT2NUM(0));
-      rb_iv_set(syntax_error, "@column", INT2NUM(position.column));
+      rb_iv_set(syntax_error, "@column", SIZET2NUM(position.column));
       rb_ary_push(rerrors, syntax_error);
     }
     rb_iv_set(rdoc, "@errors", rerrors);

--- a/ext/nokogiri/html4_document.c
+++ b/ext/nokogiri/html4_document.c
@@ -146,7 +146,7 @@ rb_html_document_type(VALUE self)
 {
   htmlDocPtr doc;
   Data_Get_Struct(self, xmlDoc, doc);
-  return INT2NUM((long)doc->type);
+  return INT2NUM(doc->type);
 }
 
 void

--- a/ext/nokogiri/html4_entity_lookup.c
+++ b/ext/nokogiri/html4_entity_lookup.c
@@ -20,7 +20,7 @@ get(VALUE _, VALUE rb_entity_name)
     return Qnil;
   }
 
-  rb_constructor_args[0] = INT2NUM((long)c_entity_desc->value);
+  rb_constructor_args[0] = UINT2NUM(c_entity_desc->value);
   rb_constructor_args[1] = NOKOGIRI_STR_NEW2(c_entity_desc->name);
   rb_constructor_args[2] = NOKOGIRI_STR_NEW2(c_entity_desc->desc);
 

--- a/ext/nokogiri/xml_attribute_decl.c
+++ b/ext/nokogiri/xml_attribute_decl.c
@@ -13,7 +13,7 @@ attribute_type(VALUE self)
 {
   xmlAttributePtr node;
   Noko_Node_Get_Struct(self, xmlAttribute, node);
-  return INT2NUM((long)node->atype);
+  return INT2NUM(node->atype);
 }
 
 /*

--- a/ext/nokogiri/xml_cdata.c
+++ b/ext/nokogiri/xml_cdata.c
@@ -29,7 +29,7 @@ new (int argc, VALUE *argv, VALUE klass)
 
   if (!NIL_P(content)) {
     content_str = (xmlChar *)StringValuePtr(content);
-    content_str_len = RSTRING_LEN(content);
+    content_str_len = RSTRING_LENINT(content);
   }
 
   node = xmlNewCDataBlock(xml_doc->doc, content_str, content_str_len);

--- a/ext/nokogiri/xml_element_content.c
+++ b/ext/nokogiri/xml_element_content.c
@@ -31,7 +31,7 @@ get_type(VALUE self)
   xmlElementContentPtr elem;
   Data_Get_Struct(self, xmlElementContent, elem);
 
-  return INT2NUM((long)elem->type);
+  return INT2NUM(elem->type);
 }
 
 /*
@@ -79,7 +79,7 @@ get_occur(VALUE self)
   xmlElementContentPtr elem;
   Data_Get_Struct(self, xmlElementContent, elem);
 
-  return INT2NUM((long)elem->ocur);
+  return INT2NUM(elem->ocur);
 }
 
 /*

--- a/ext/nokogiri/xml_element_decl.c
+++ b/ext/nokogiri/xml_element_decl.c
@@ -15,7 +15,7 @@ element_type(VALUE self)
 {
   xmlElementPtr node;
   Noko_Node_Get_Struct(self, xmlElement, node);
-  return INT2NUM((long)node->etype);
+  return INT2NUM(node->etype);
 }
 
 /*

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -799,7 +799,7 @@ rb_xml_node_pointer_id(VALUE self)
   xmlNodePtr node;
   Noko_Node_Get_Struct(self, xmlNode, node);
 
-  return INT2NUM((long)(node));
+  return rb_uint2inum((uintptr_t)(node));
 }
 
 /*
@@ -1499,7 +1499,7 @@ node_type(VALUE self)
 {
   xmlNodePtr node;
   Noko_Node_Get_Struct(self, xmlNode, node);
-  return INT2NUM((long)node->type);
+  return INT2NUM(node->type);
 }
 
 /*
@@ -2010,7 +2010,7 @@ rb_xml_node_line(VALUE rb_node)
   xmlNodePtr c_node;
   Noko_Node_Get_Struct(rb_node, xmlNode, c_node);
 
-  return INT2NUM(xmlGetLineNo(c_node));
+  return LONG2NUM(xmlGetLineNo(c_node));
 }
 
 /*
@@ -2113,7 +2113,7 @@ compare(VALUE self, VALUE _other)
   Noko_Node_Get_Struct(self, xmlNode, node);
   Noko_Node_Get_Struct(_other, xmlNode, other);
 
-  return INT2NUM((long)xmlXPathCmpNodes(other, node));
+  return INT2NUM(xmlXPathCmpNodes(other, node));
 }
 
 

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -300,7 +300,7 @@ attribute_count(VALUE self)
   count = xmlTextReaderAttributeCount(reader);
   if (count == -1) { return Qnil; }
 
-  return INT2NUM((long)count);
+  return INT2NUM(count);
 }
 
 /*
@@ -319,7 +319,7 @@ depth(VALUE self)
   depth = xmlTextReaderDepth(reader);
   if (depth == -1) { return Qnil; }
 
-  return INT2NUM((long)depth);
+  return INT2NUM(depth);
 }
 
 /*
@@ -492,7 +492,7 @@ state(VALUE self)
 {
   xmlTextReaderPtr reader;
   Data_Get_Struct(self, xmlTextReader, reader);
-  return INT2NUM((long)xmlTextReaderReadState(reader));
+  return INT2NUM(xmlTextReaderReadState(reader));
 }
 
 /*
@@ -506,7 +506,7 @@ node_type(VALUE self)
 {
   xmlTextReaderPtr reader;
   Data_Get_Struct(self, xmlTextReader, reader);
-  return INT2NUM((long)xmlTextReaderNodeType(reader));
+  return INT2NUM(xmlTextReaderNodeType(reader));
 }
 
 /*


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

There are multiple integer loss of precision warnings. 

There are three categories of warnings fixed.
1. Most are spurious warnings where we cast an `int` to a `long` and then use `INT2NUM` rather than just avoiding the cast);
2. With the HTML5 parser and a file containing an error on line number 2^31 or higher (or column number 2^31 or higher), the returned errors will have the wrong line (resp. column) number.
3. Node pointers are cast to a `int`s and used as ids for node comparison. Two different nodes could have the same least significant 32 bits in their pointers which would cause them to compare equal.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

I added no test coverage. The warnings in the first category are harmless. The ones in the second category require producing input with at least 2^31 bytes. This doesn't seem worth it. Testing the third category seems extremely difficult.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

Yes! It fixes the behavior of two different nodes possibly comparing equal in the C implementation. It also fixes incorrect line/column number for errors in pathological cases.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
