### PR TITLE
Fix crash when calling fragment on annotation-xml elements

### DIFF
--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -501,7 +501,8 @@ error:
     }
 
     // Encoding.
-    if (RSTRING_LEN(tag_name) == 14
+    if (ctx_ns == GUMBO_NAMESPACE_MATHML
+        && RSTRING_LEN(tag_name) == 14
         && !st_strcasecmp(ctx_tag, "annotation-xml")) {
       VALUE enc = rb_funcall(ctx, rb_intern_const("[]"),
                              1,

--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -504,6 +504,7 @@ error:
     if (RSTRING_LEN(tag_name) == 14
         && !st_strcasecmp(ctx_tag, "annotation-xml")) {
       VALUE enc = rb_funcall(ctx, rb_intern_const("[]"),
+                             1,
                              rb_utf8_str_new_static("encoding", 8));
       if (RTEST(enc)) {
         Check_Type(enc, T_STRING);

--- a/test/html5/test_api.rb
+++ b/test/html5/test_api.rb
@@ -187,6 +187,26 @@ class TestHtml5API < Nokogiri::TestCase
     assert_empty(frag.children)
   end
 
+  def test_fragment_with_annotation_xml_context
+    # An annotation-xml element with an encoding of text/html or application/xhtml+xml
+    # is an HTML integration point so its children are not in the MathML namespace.
+    # Other encodings are not HTML integration points so children are in the MathML namespace.
+    doc = Nokogiri.HTML5("<!DOCTYPE html><math><annotation-xml encoding='MathML-Presentation' /></math>")
+    a_xml = doc.xpath("//math:annotation-xml")[0]
+    frag = a_xml.fragment("<mi>x</mi>")
+    mi = frag.children[0]
+    assert_equal("mi", mi.name)
+    refute_nil(mi.namespace)
+    assert_equal("math", mi.namespace.prefix)
+
+    doc = Nokogiri.HTML5("<!DOCTYPE html><math><annotation-xml encoding='text/html' /></math>")
+    a_xml = doc.xpath("//math:annotation-xml")[0]
+    frag = a_xml.fragment("<mi>x</mi>")
+    mi = frag.children[0]
+    assert_equal("mi", mi.name)
+    assert_nil(mi.namespace)
+  end
+
   def test_html_eh
     doc = Nokogiri.HTML5("<html><body><div></div></body></html>")
     assert_predicate(doc, :html?)


### PR DESCRIPTION

<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Calling `fragment()` on an `annotation-xml` element crashes.

```ruby
require 'nokogiri'

doc = Nokogiri::HTML5.parse('<!DOCTYPE html><math><annotation-xml encoding="text/html" /></math>')
a_xml = doc.xpath('//math:annotation-xml')[0]
frag = a_xml.fragment('<p>')
```

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

Yes. This functionality was not previously exercised by tests. It is now.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

It fixes a crash that's only present in the C implementation.
