### PR TITLE
fix: include ruby/defines.h early to avoid _GNU_SOURCE confusion

### DIFF
--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -1,6 +1,8 @@
 #ifndef NOKOGIRI_NATIVE
 #define NOKOGIRI_NATIVE
 
+#include <ruby/defines.h> // https://github.com/sparklemotion/nokogiri/issues/2696
+
 #ifdef _MSC_VER
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
@@ -22,7 +24,6 @@
 #  define NOKOPUBFUN
 #  define NOKOPUBVAR extern
 #endif
-
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Fixes #2696

**Have you included adequate test coverage?**

Unfortunately there's no failing test, but #2696 makes the argument that this is an improvement, and existing native gem CI pipelines should make sure nothing breaks.

**Does this change affect the behavior of either the C or the Java implementations?**

No.