### PR TITLE
feat: {Node,NodeSet}#wrap accept a Node argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This version of Nokogiri uses [`jar-dependencies`](https://github.com/mkristian/
 
 ### Added
 
+* `Node#wrap` and `NodeSet#wrap` now also accept a `Node` type argument, which will be `dup`ed for each wrapper. For cases where many nodes are being wrapped, creating a `Node` once using `Document#create_element` and passing that `Node` multiple times is significantly faster than re-parsing markup on each call. [[#2657](https://github.com/sparklemotion/nokogiri/issues/2657)]
 * [CRuby] Invocation of custom XPath or CSS handler functions may now use the `nokogiri` namespace prefix. Historically, the JRuby implementation _required_ this namespace but the CRuby implementation did not support it. It's recommended that all XPath and CSS queries use the `nokogiri` namespace going forward. Invocation without the namespace is planned for deprecation in v1.15.0 and removal in a future release. [[#2147](https://github.com/sparklemotion/nokogiri/issues/2147)]
 
 
@@ -40,6 +41,7 @@ This version of Nokogiri uses [`jar-dependencies`](https://github.com/mkristian/
 
 * `SAX::Parser`'s `encoding` attribute will not be clobbered when an alternative encoding is passed into `SAX::Parser#parse_io`. [[#1942](https://github.com/sparklemotion/nokogiri/issues/1942)] (Thanks, [@kp666](https://github.com/kp666)!)
 * Serialized `HTML4::DocumentFragment` will now be properly encoded. Previously this empty string was encoded as `US-ASCII`. [[#2649](https://github.com/sparklemotion/nokogiri/issues/2649)]
+* `Node#wrap` now uses the parent as the context node for parsing wrapper markup, falling back to the document for unparented nodes. Previously the document was always used.
 * [CRuby] UTF-16-encoded documents longer than ~4000 code points now serialize properly. Previously the serialized document was corrupted when it exceeded the length of libxml2's internal string buffer. [[#752](https://github.com/sparklemotion/nokogiri/issues/752)]
 * [CRuby] The HTML5 parser now correctly handles text at the end of `form` elements.
 * [CRuby] `HTML5::Document#fragment` now always uses `body` as the parsing context. Previously, fragments were parsed in the context of the associated document's root node, which allowed for inconsistent parsing. [[#2553](https://github.com/sparklemotion/nokogiri/issues/2553)]

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 module Nokogiri
@@ -260,10 +261,73 @@ module Nokogiri
         collect { |j| j.inner_html(*args) }.join("")
       end
 
-      ###
-      # Wrap this NodeSet with +html+
-      def wrap(html)
-        map { |node| node.wrap(html) }
+      # :call-seq:
+      #   wrap(markup) -> self
+      #   wrap(node) -> self
+      #
+      # Wrap each member of this NodeSet with the node parsed from +markup+ or a dup of the +node+.
+      #
+      # [Parameters]
+      # - *markup* (String)
+      #   Markup that is parsed, once per member of the NodeSet, and used as the wrapper. Each
+      #   node's parent, if it exists, is used as the context node for parsing; otherwise the
+      #   associated document is used. If the parsed fragment has multiple roots, the first root
+      #   node is used as the wrapper.
+      # - *node* (Nokogiri::XML::Node)
+      #   An element that is `#dup`ed and used as the wrapper.
+      #
+      # [Returns] +self+, to support chaining.
+      #
+      # ⚠ Note that if a +String+ is passed, the markup will be parsed <b>once per node</b> in the
+      # NodeSet. You can avoid this overhead in cases where you know exactly the wrapper you wish to
+      # use by passing a +Node+ instead.
+      #
+      # Also see Node#wrap
+      #
+      # *Example* with a +String+ argument:
+      #
+      #   doc = Nokogiri::HTML5(<<~HTML)
+      #     <html><body>
+      #       <a>a</a>
+      #       <a>b</a>
+      #       <a>c</a>
+      #       <a>d</a>
+      #     </body></html>
+      #   HTML
+      #   doc.css("a").wrap("<div></div>")
+      #   doc.to_html
+      #   # => <html><head></head><body>
+      #   #      <div><a>a</a></div>
+      #   #      <div><a>b</a></div>
+      #   #      <div><a>c</a></div>
+      #   #      <div><a>d</a></div>
+      #   #    </body></html>
+      #
+      # *Example* with a +Node+ argument
+      #
+      # 💡 Note that this is faster than the equivalent call passing a +String+ because it avoids
+      # having to reparse the wrapper markup for each node.
+      #
+      #   doc = Nokogiri::HTML5(<<~HTML)
+      #     <html><body>
+      #       <a>a</a>
+      #       <a>b</a>
+      #       <a>c</a>
+      #       <a>d</a>
+      #     </body></html>
+      #   HTML
+      #   doc.css("a").wrap(doc.create_element("div"))
+      #   doc.to_html
+      #   # => <html><head></head><body>
+      #   #      <div><a>a</a></div>
+      #   #      <div><a>b</a></div>
+      #   #      <div><a>c</a></div>
+      #   #      <div><a>d</a></div>
+      #   #    </body></html>
+      #
+      def wrap(node_or_tags)
+        map { |node| node.wrap(node_or_tags) }
+        self
       end
 
       ###

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -1297,13 +1297,65 @@ module Nokogiri
           end
         end
 
-        def test_wrap
-          xml = '<root><thing><div class="title">important thing</div></thing></root>'
-          doc = Nokogiri::XML(xml)
-          thing = doc.at_css("thing")
-          thing.wrap("<wrapper/>")
-          assert_equal("wrapper", thing.parent.name)
-          assert_equal("thing", doc.at_css("wrapper").children.first.name)
+        describe "#wrap" do
+          let(:xml) { "<root><thing><div>important thing</div></thing></root>" }
+          let(:doc) { Nokogiri::XML(xml) }
+
+          describe "string markup argument" do
+            it "parses and wraps" do
+              thing = doc.at_css("thing")
+              rval = thing.wrap("<wrapper/>")
+              wrapper = doc.at_css("wrapper")
+
+              assert_equal(rval, thing)
+              assert_equal(wrapper, thing.parent)
+              assert_equal("root", wrapper.parent.name)
+              assert_equal(1, wrapper.children.length)
+              assert_equal("thing", wrapper.children.first.name)
+            end
+
+            it "wraps unparented nodes" do
+              thing = doc.create_element("thing")
+              thing.wrap("<wrapper/>")
+
+              assert_equal("wrapper", thing.parent.name)
+              assert_nil(thing.parent.parent)
+            end
+          end
+
+          describe "Node argument" do
+            it "wraps using a dup of the node" do
+              thing = doc.at_css("thing")
+              wrapper_template = doc.create_element("wrapper")
+              rval = thing.wrap(wrapper_template)
+              wrapper = doc.at_css("wrapper")
+
+              assert_equal(rval, thing)
+              refute_equal(wrapper, wrapper_template)
+              assert_equal(wrapper, thing.parent)
+              assert_equal("root", wrapper.parent.name)
+              assert_equal(1, wrapper.children.length)
+              assert_equal("thing", wrapper.children.first.name)
+            end
+
+            it "wraps unparented nodes" do
+              thing = doc.create_element("thing")
+              wrapper_template = doc.create_element("wrapper")
+              thing.wrap(wrapper_template)
+
+              refute_equal(wrapper_template, thing.parent)
+              assert_equal("wrapper", thing.parent.name)
+              assert_nil(thing.parent.parent)
+            end
+          end
+
+          it "raises an ArgumentError on other types" do
+            thing = doc.at_css("thing")
+
+            assert_raises(ArgumentError) do
+              thing.wrap(1)
+            end
+          end
         end
 
         describe "#line" do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Duplicating an instantiated Node is significantly faster than re-parsing a string for multiple invocations.

Closes #2657

Here's a benchmark:

```ruby
#! /usr/bin/env ruby

require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "benchmark-ips"
  gem "nokogiri", path: "."
end

require "nokogiri"
require "benchmark/ips"

HTML = "<body><section>" + ("<span>foo</span>" * 100) + "</section></body>"

def wrap
  doc = Nokogiri::HTML::Document.parse(HTML)
  doc.at_css("section").children.each do |child|
    child.wrap("<p>")
  end
  doc
end

def new_feature_reparent
  doc = Nokogiri::HTML::Document.parse(HTML)
  wrapper = doc.create_element("p")
  doc.at_css("section").children.each do |child|
    child.wrap(wrapper)
  end
  doc
end

Benchmark.ips do |x|
  x.warmup = 0

  x.report("wrap-a-string") do
    wrap
  end

  x.report("wrap-a-node") do
    new_feature_reparent
  end

  x.compare!
end
```

```
Calculating -------------------------------------
       wrap-a-string    454.065  (± 9.0%) i/s -      2.250k in   4.998124s
         wrap-a-node      1.862k (±17.5%) i/s -      8.938k in   4.992867s

Comparison:
         wrap-a-node:     1861.6 i/s
       wrap-a-string:      454.1 i/s - 4.10x  (± 0.00) slower
```

**Have you included adequate test coverage?**

Yes!

**Does this change affect the behavior of either the C or the Java implementations?**

No.
