### PR TITLE
update tests to handle upstream libxml2

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
-    env:
-      CI_UPSTREAM_XMLSOFT: t
     steps:
       - uses: actions/checkout@v3
         with:
@@ -39,8 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
-    env:
-      CI_UPSTREAM_XMLSOFT: t
     steps:
       - uses: actions/checkout@v3
         with:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -133,14 +133,6 @@ module Nokogiri
     @@test_count = 0 # rubocop:disable Style/ClassVars
     @@gc_level = nil # rubocop:disable Style/ClassVars
 
-    def self.upstream_xmlsoft?
-      ENV["CI_UPSTREAM_XMLSOFT"] || Nokogiri::LIBXML_LOADED_VERSION.include?("-GIT")
-    end
-
-    def upstream_xmlsoft?
-      self.class.upstream_xmlsoft?
-    end
-
     def initialize_nokogiri_test_gc_level
       return if Nokogiri.jruby?
       return if @@gc_level

--- a/test/html4/test_attributes.rb
+++ b/test/html4/test_attributes.rb
@@ -66,6 +66,11 @@ module Nokogiri
               #  assert that this attribute's serialization is unaffected.
               #
               assert_equal %{examp<!--" unsafeattr=unsafevalue()>-->le.com}, attributes.first.value
+            elsif Nokogiri.uses_libxml?(">= 2.11.0")
+              #
+              #  as of upstream 76d6b0d768d4e60a2d2844d in v2.11.0 (dev), quotes are no longer escaped.
+              #
+              assert_equal %{examp<!--"%20unsafeattr=unsafevalue()>-->le.com}, attributes.first.value
             else
               #
               #  let's match the behavior in libxml < 2.9.2.

--- a/test/html4/test_document.rb
+++ b/test/html4/test_document.rb
@@ -772,7 +772,7 @@ module Nokogiri
               doc = Nokogiri::HTML4.parse(input)
               body = doc.at_xpath("//body")
 
-              if Nokogiri.uses_libxml?("= 2.9.13") && !upstream_xmlsoft?
+              if Nokogiri.uses_libxml?("= 2.9.13")
                 # <body><div>this <div>second element</div></div></body>
                 assert_equal(1, body.children.length)
                 body.children.first.tap do |div|

--- a/test/html4/test_node.rb
+++ b/test/html4/test_node.rb
@@ -32,8 +32,8 @@ module Nokogiri
         element = @html.at("div")
         assert_equal("baz", element.get_attribute("class"))
         assert_equal("baz", element["class"])
-        element["href"] = "javascript:alert(\"AGGA-KA-BOO!\")"
-        assert_match(/%22AGGA-KA-BOO!%22/, element.to_html)
+        element["href"] = "https://nokogiri.org/"
+        assert_match(/nokogiri.org/, element.to_html)
       end
 
       # The HTML parser ignores namespaces, so even properly declared namespaces


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See https://gitlab.gnome.org/GNOME/libxml2/-/commit/76d6b0d768d4e60a2d2844d55def120257ab6c6e
    
As of that commit, serialized attributes no longer escape double quotes.


**Have you included adequate test coverage?**

Updating existing tests here to reflect the small underlying serialization behavior change.


**Does this change affect the behavior of either the C or the Java implementations?**

This is a test-only change to ensure we handle the upstream C implementation when it is released.