### PR TITLE
ci: update to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,7 +650,7 @@ jobs:
         ruby: ["2.6", "2.7", "3.0"]
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - uses: ruby/setup-ruby@v1
@@ -671,7 +671,7 @@ jobs:
         ruby: ["3.1"]
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Addressing Github Actions warnings about Node 12:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12

I had previously done this in #2669 (37325aa), but then accidentally re-introduced @v2 in #2659 (f0bf5d6).
