### PR TITLE
fix: XML::Reader error handling during xmlTextReaderExpand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ This version of Nokogiri uses [`jar-dependencies`](https://github.com/mkristian/
 * Prefer `ruby_xmalloc` to `malloc` within the C extension. [[#2480](https://github.com/sparklemotion/nokogiri/issues/2480)] (Thanks, [@Garfield96](https://github.com/Garfield96)!)
 * Installation from source on systems missing libiconv will once again generate a helpful error message (broken since v1.11.0). [[#2505](https://github.com/sparklemotion/nokogiri/issues/2505)]
 * Empty CSS selectors now raise a clearer `Nokogiri::CSS::SyntaxError` message, "empty CSS selector". Previously the exception raised from the bowels of `racc` was "unexpected '$' after ''". [[#2700](https://github.com/sparklemotion/nokogiri/issues/2700)]
+* [CRuby] `XML::Reader` parsing errors encountered during `Reader#attribute_hash` and `Reader#namespaces` now raise an `XML::SyntaxError`. Previously these methods would return `nil` and users would generally experience `NoMethodErrors` from elsewhere in the code.
 
 
 ### Deprecated


### PR DESCRIPTION
**What problem is this PR intended to solve?**

`XML::Reader` parsing errors encountered during `Reader#attribute_hash` and `Reader#namespaces` now raise an `XML::SyntaxError`.

Previously these methods would return `nil` and users would generally experience `NoMethodErrors` from elsewhere in the code.


**Have you included adequate test coverage?**

Test coverage added.


**Does this change affect the behavior of either the C or the Java implementations?**

The C and Java parsers differ in when they detect a syntax error in this case. libxml2 indicates an error when we try to expand a start tag that does not have a matching end tag, but xerces will defer the error until later. The tests reflect that difference.