### PR TITLE
fix: XML::Reader#attribute_hash returns nil on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## next / unreleased
+
+### Improvements
+
+* [CRuby] `XML::Reader#attribute_hash` now returns `nil` on parse errors. This restores the behavior of `#attributes` from v1.13.7 and earlier. [[#2715](https://github.com/sparklemotion/nokogiri/issues/2715)]
+
+
 ## 1.13.9 / 2022-10-18
 
 ### Security

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -212,6 +212,10 @@ rb_xml_reader_attribute_hash(VALUE rb_reader)
   }
 
   c_node = xmlTextReaderExpand(c_reader);
+  if (c_node == NULL) {
+    return Qnil;
+  }
+
   c_property = c_node->properties;
   while (c_property != NULL) {
     VALUE rb_name = NOKOGIRI_STR_NEW2(c_property->name);

--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -681,6 +681,38 @@ module Nokogiri
         reader.read # el
         assert_nil(reader.attribute("other"))
       end
+
+      def test_broken_markup_attribute_hash
+        xml = <<~XML
+          <root><foo bar="asdf" xmlns:quux="qwer">
+        XML
+        reader = Nokogiri::XML::Reader(xml)
+        reader.read # root
+        reader.read # foo
+
+        assert_equal("foo", reader.name)
+        if Nokogiri.jruby?
+          assert_equal({ "bar" => "asdf" }, reader.attribute_hash)
+        else
+          assert_nil(reader.attribute_hash)
+        end
+      end
+
+      def test_broken_markup_namespaces
+        xml = <<~XML
+          <root><foo bar="asdf" xmlns:quux="qwer">
+        XML
+        reader = Nokogiri::XML::Reader(xml)
+        reader.read # root
+        reader.read # foo
+
+        assert_equal("foo", reader.name)
+        if Nokogiri.jruby?
+          assert_equal({ "xmlns:quux" => "qwer" }, reader.namespaces)
+        else
+          assert_nil(reader.namespaces)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

`Reader#attribute_hash` does not behave the same way `Reader#attribute_nodes` behaved when parse errors are encountered.

For callers of `Reader#attributes` this restores the behavior from v1.13.7 before #2602.

See also the related change in #2714 which will land in v1.14.0 that raises a `SyntaxError` instead of returning `nil`.

**Have you included adequate test coverage?**

Yes, coverage added.


**Does this change affect the behavior of either the C or the Java implementations?**

The C and Java parsers differ in when they detect a syntax error in this case. libxml2 indicates an error when we try to expand a start tag that does not have a matching end tag, but xerces will defer the error until later. The tests reflect that difference.
