### PR TITLE
dep(dev): pin psych to v4 until v5 builds in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development do
   # documentation
   gem "hoe-markdown", "= 1.4.0"
   gem "rdoc", "= 6.4.0"
+  gem "psych", "~> 4.0" # psych 5 isn't building in places yet https://github.com/ruby/setup-ruby/issues/409
 
   # parser generator
   gem "rexical", "= 1.0.7"

--- a/test/xml/sax/test_parser.rb
+++ b/test/xml/sax/test_parser.rb
@@ -410,7 +410,7 @@ module Nokogiri
         end
 
         it :test_large_cdata_is_handled do
-          skip("see #2132 and https://gitlab.gnome.org/GNOME/libxml2/-/issues/200") if Nokogiri.uses_libxml?("<=2.9.10")
+          skip("see #2132 and https://gitlab.gnome.org/GNOME/libxml2/-/issues/200") if Nokogiri::VersionInfo.instance.libxml2_using_system?
 
           template = <<~EOF
             <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Getting CI green again, see https://github.com/ruby/setup-ruby/issues/409
