### PR TITLE
dep(dev): pin psych to v4 until v5 builds in CI (backport)

### DIFF
--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -325,6 +325,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("hoe-markdown", "~> 1.4")
   spec.add_development_dependency("minitest", "~> 5.15")
   spec.add_development_dependency("minitest-reporters", "~> 1.4")
+  spec.add_development_dependency("psych", "~> 4.0") # psych 5 isn't building in places yet https://github.com/ruby/setup-ruby/issues/409
   spec.add_development_dependency("rake", "~> 13.0")
   spec.add_development_dependency("rake-compiler", "= 1.1.7")
   spec.add_development_dependency("rake-compiler-dock", "= 1.2.2")

--- a/test/xml/sax/test_parser.rb
+++ b/test/xml/sax/test_parser.rb
@@ -402,7 +402,7 @@ class Nokogiri::SAX::TestCase
     end
 
     it :test_large_cdata_is_handled do
-      skip("see #2132 and https://gitlab.gnome.org/GNOME/libxml2/-/issues/200") if Nokogiri.uses_libxml?("<=2.9.10")
+      skip("see #2132 and https://gitlab.gnome.org/GNOME/libxml2/-/issues/200") if Nokogiri::VersionInfo.instance.libxml2_using_system?
 
       template = <<~EOF
         <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Backport of #2716 to get CI green again.
