### PR TITLE
perf: avoid gumbo_debug function calls when GUMBO_DEBUG isn't def'd

### DIFF
--- a/gumbo-parser/src/util.c
+++ b/gumbo-parser/src/util.c
@@ -63,6 +63,4 @@ void gumbo_debug(const char* format, ...) {
   va_end(args);
   fflush(stdout);
 }
-#else
-void gumbo_debug(const char* UNUSED_ARG(format), ...) {}
 #endif

--- a/gumbo-parser/src/util.h
+++ b/gumbo-parser/src/util.h
@@ -21,7 +21,11 @@ void* gumbo_realloc(void* ptr, size_t size) RETURNS_NONNULL;
 void gumbo_free(void* ptr);
 
 // Debug wrapper for printf
+#ifdef GUMBO_DEBUG
 void gumbo_debug(const char* format, ...) PRINTF(1);
+#else
+static inline void PRINTF(1) gumbo_debug(const char* UNUSED_ARG(format), ...) {};
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Part of #2722, optimizing performance of gumbo.

Benchmarks from running show 7-11% improvements.

-  "test/files/GH_1042.html", # 650b
-  "test/files/tlm.html", # 70kb
-  "big_shopping.html", # 1.9mb

```
Comparison:
nodbg html5 parse 656:    16646.6 i/s
BASE_ html5 parse 656:    15545.9 i/s - same-ish: difference falls within error
                   with 99.0% confidence

Comparison:
nodbg html5 parse 70095:      271.1 i/s
BASE_ html5 parse 70095:      253.1 i/s - same-ish: difference falls within error
                   with 99.0% confidence

Comparison:
nodbg html5 parse 1929522:       14.9 i/s
BASE_ html5 parse 1929522:       13.4 i/s - 1.11x  (± 0.07) slower
                   with 99.0% confidence
```
