### PR TITLE
perf: use default memory management within libxml2

### DIFF
--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -176,26 +176,7 @@ Init_nokogiri()
   rb_const_set(mNokogiri, rb_intern("OTHER_LIBRARY_VERSIONS"), NOKOGIRI_STR_NEW2(NOKOGIRI_OTHER_LIBRARY_VERSIONS));
 #endif
 
-#if defined(_WIN32) && !defined(NOKOGIRI_PACKAGED_LIBRARIES)
-  /*
-   *  We choose *not* to do use Ruby's memory management functions with windows DLLs because of this
-   *  issue in libxml 2.9.12:
-   *
-   *    https://github.com/sparklemotion/nokogiri/issues/2241
-   *
-   *  If the atexit() issue gets fixed in a future version of libxml2, then we may be able to skip
-   *  this config only for the specific libxml2 versions 2.9.12.
-   *
-   *  Alternatively, now that Ruby has a generational GC, it might be OK to let libxml2 use its
-   *  default memory management functions (recall that this config was introduced to reduce memory
-   *  bloat and allow Ruby to GC more often); but we should *really* test with production workloads
-   *  before making that kind of a potentially-invasive change.
-   */
   rb_const_set(mNokogiri, rb_intern("LIBXML_MEMORY_MANAGEMENT"), NOKOGIRI_STR_NEW2("default"));
-#else
-  rb_const_set(mNokogiri, rb_intern("LIBXML_MEMORY_MANAGEMENT"), NOKOGIRI_STR_NEW2("ruby"));
-  xmlMemSetup((xmlFreeFunc)ruby_xfree, (xmlMallocFunc)ruby_xmalloc, (xmlReallocFunc)ruby_xrealloc, ruby_strdup);
-#endif
 
   xmlInitParser();
   exsltRegisterAll();


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Related to #2722, performance.

use default memory management within libxml2 instead of ruby's memory management functions (which has been used since 2009).

HTML4 parsing is 14-19% faster:

    alloc html4 parse 656:    22371.3 i/s
    BASE_ html4 parse 656:    19589.4 i/s - 1.14x  (± 0.03) slower

    alloc html4 parse 70095:      461.4 i/s
    BASE_ html4 parse 70095:      385.5 i/s - 1.19x  (± 0.11) slower

    alloc html4 parse 1929522:       43.7 i/s
    BASE_ html4 parse 1929522:       37.2 i/s - 1.18x  (± 0.05) slower

HTML5 parsing is 5-8% faster:

    alloc html5 parse 656:    17909.1 i/s
    BASE_ html5 parse 656:    16597.7 i/s - 1.08x  (± 0.04) slower

    alloc html5 parse 70095:      277.3 i/s
    BASE_ html5 parse 70095:      263.4 i/s - same-ish: difference falls within error

    alloc html5 parse 1929522:       16.6 i/s
    BASE_ html5 parse 1929522:       15.8 i/s - 1.05x  (± 0.03) slower

HTML4 serialization is 10-14% faster:

    alloc html4 srlze 656:    69707.3 i/s
    BASE_ html4 srlze 656:    63537.4 i/s - 1.10x  (± 0.02) slower

    alloc html4 srlze 70095:     1504.5 i/s
    BASE_ html4 srlze 70095:     1331.9 i/s - 1.13x  (± 0.02) slower

    alloc html4 srlze 1929522:      145.5 i/s
    BASE_ html4 srlze 1929522:      128.0 i/s - 1.14x  (± 0.02) slower

HTML5 serialization is not very impacted, as expected.

    alloc html5 srlze 656:    42255.7 i/s
    BASE_ html5 srlze 656:    41118.8 i/s - 1.03x  (± 0.02) slower

    alloc html5 srlze 70095:     1050.6 i/s
    BASE_ html5 srlze 70095:     1033.8 i/s - same-ish: difference falls within error

    alloc html5 srlze 1929522:      121.5 i/s
    BASE_ html5 srlze 1929522:      118.3 i/s - 1.03x  (± 0.02) slower

**Have you included adequate test coverage?**

N/A

**Does this change affect the behavior of either the C or the Java implementations?**

N/A
