### PR TITLE
ci: cache ports for zlib and iconv on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - run: git config --global --add safe.directory /__w/nokogiri/nokogiri # shrug
       - uses: actions/cache@v3
         with:
           path: ports/archives

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,6 +455,11 @@ jobs:
         with:
           ruby-version: "3.0"
           mingw: "libxml2 libxslt"
+      - uses: actions/cache@v3
+        if: matrix.sys == 'disable'
+        with:
+          path: ports
+          key: ports-${{runner.os}}-msvcrt-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - uses: actions/download-artifact@v3
         with:
           name: generic-gem
@@ -477,6 +482,11 @@ jobs:
         with:
           ruby-version: "3.1"
           mingw: "libxml2 libxslt"
+      - uses: actions/cache@v3
+        if: matrix.sys == 'disable'
+        with:
+          path: ports
+          key: ports-${{runner.os}}-ucrt-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - uses: actions/download-artifact@v3
         with:
           name: generic-gem


### PR DESCRIPTION

**What problem is this PR intended to solve?**

CI windows builds have been failing recently while attempting to download the zlib tarball.

This change should cache the tarball for subsequent runs.
