### PR TITLE
ci: use the new rake-compiler-dock oci images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # image: "larskanis/rake-compiler-dock-mri-x86_64-linux:${{needs.rcd_image_version.outputs.rcd_image_version}}"
-      image: "ghcr.io/rake-compiler/rake-compiler-dock-snapshot:x86_64-linux"
+      image: "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x86_64-linux"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -515,7 +515,7 @@ jobs:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - env:
-          DOCKER_IMAGE: "ghcr.io/rake-compiler/rake-compiler-dock-snapshot:${{matrix.plat}}"
+          DOCKER_IMAGE: "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-${{matrix.plat}}"
           # DOCKER_IMAGE: "larskanis/rake-compiler-dock-mri-${{matrix.plat}}:${{needs.rcd_image_version.outputs.rcd_image_version}}"
         run: |
           docker run --rm -v "$(pwd):/nokogiri" -w /nokogiri \
@@ -698,7 +698,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # image: "larskanis/rake-compiler-dock-jruby:${{needs.rcd_image_version.outputs.rcd_image_version}}"
-      image: "ghcr.io/rake-compiler/rake-compiler-dock-snapshot:jruby"
+      image: "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-jruby"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -324,7 +324,7 @@ namespace "gem" do
   CROSS_RUBIES.find_all { |cr| cr.windows? || cr.linux? || cr.darwin? }.map(&:platform).uniq.each do |plat|
     desc "build native gem for #{plat} platform"
     task plat do
-      ENV["RCD_IMAGE"] = "ghcr.io/rake-compiler/rake-compiler-dock-snapshot:#{plat}"
+      ENV["RCD_IMAGE"] = "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-#{plat}"
       RakeCompilerDock.sh(<<~EOT, platform: plat, verbose: true)
         ruby -v &&
         gem install bundler --no-document &&
@@ -345,7 +345,7 @@ namespace "gem" do
 
   desc "build a jruby gem"
   task "jruby" do
-    ENV["RCD_IMAGE"] = "ghcr.io/rake-compiler/rake-compiler-dock-snapshot:jruby"
+    ENV["RCD_IMAGE"] = "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-jruby"
     RakeCompilerDock.sh(<<~EOF, rubyvm: "jruby", platform: "jruby", verbose: true)
       gem install bundler --no-document &&
       bundle &&


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Trying out the new rake-compiler-dock OCI images from https://github.com/rake-compiler/rake-compiler-dock/pull/95
