### PR TITLE
Get rid of anonymous eval calls

### DIFF
--- a/lib/nokogiri/css/xpath_visitor.rb
+++ b/lib/nokogiri/css/xpath_visitor.rb
@@ -230,11 +230,11 @@ module Nokogiri
         "descendant_selector" => "//",
         "child_selector" => "/",
       }.each do |k, v|
-        class_eval %{
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
           def visit_#{k} node
             "\#{node.value.first.accept(self) if node.value.first}#{v}\#{node.value.last.accept(self)}"
           end
-        }
+        RUBY
       end
 
       def visit_conditional_selector(node)

--- a/lib/nokogiri/xml/node/save_options.rb
+++ b/lib/nokogiri/xml/node/save_options.rb
@@ -49,7 +49,7 @@ module Nokogiri
         end
 
         constants.each do |constant|
-          class_eval %{
+          class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def #{constant.downcase}
               @options |= #{constant}
               self
@@ -58,7 +58,7 @@ module Nokogiri
             def #{constant.downcase}?
               #{constant} & @options == #{constant}
             end
-          }
+          RUBY
         end
 
         alias_method :to_i, :options

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -169,7 +169,7 @@ module Nokogiri
       constants.each do |constant|
         next if constant.to_sym == :STRICT
 
-        class_eval %{
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
           def #{constant.downcase}
             @options |= #{constant}
             self
@@ -183,7 +183,7 @@ module Nokogiri
           def #{constant.downcase}?
             #{constant} & @options == #{constant}
           end
-        }
+        RUBY
       end
 
       def strict

--- a/lib/xsd/xmlparser/nokogiri.rb
+++ b/lib/xsd/xmlparser/nokogiri.rb
@@ -95,7 +95,9 @@ module XSD
       end
 
       ["xmldecl", "start_document", "end_document", "comment"].each do |name|
-        class_eval %{ def #{name}(*args); end }
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{name}(*args); end
+        RUBY
       end
 
       add_factory(self)

--- a/test/xml/node/test_save_options.rb
+++ b/test/xml/node/test_save_options.rb
@@ -7,14 +7,14 @@ module Nokogiri
     class Node
       class TestSaveOptions < Nokogiri::TestCase
         SaveOptions.constants.each do |constant|
-          class_eval <<-EOEVAL
+          class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def test_predicate_#{constant.downcase}
               options = SaveOptions.new(SaveOptions::#{constant})
               assert options.#{constant.downcase}?
 
               assert SaveOptions.new.#{constant.downcase}.#{constant.downcase}?
             end
-          EOEVAL
+          RUBY
         end
 
         def test_default_xml_save_options

--- a/test/xml/node/test_subclass.rb
+++ b/test/xml/node/test_subclass.rb
@@ -16,16 +16,16 @@ module Nokogiri
           Nokogiri::XML::Node => '"foo", doc',
           Nokogiri::XML::Text => '"foo", doc',
         }.each do |klass, constructor|
-          class_eval %{
+          class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def test_subclass_#{klass.name.gsub("::", "_")}
               doc = Nokogiri::XML::Document.new
               klass = Class.new(#{klass.name})
               node = klass.new(#{constructor})
               assert_instance_of klass, node
             end
-          }
+          RUBY
 
-          class_eval <<-eocode, __FILE__, __LINE__ + 1
+          class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def test_subclass_initialize_#{klass.name.gsub("::", "_")}
               doc = Nokogiri::XML::Document.new
               klass = Class.new(#{klass.name}) do
@@ -38,7 +38,7 @@ module Nokogiri
               node = klass.new(#{constructor}, 1)
               assert_equal [#{constructor}, 1], node.initialized_with
             end
-          eocode
+          RUBY
         end
       end
     end

--- a/test/xml/test_parse_options.rb
+++ b/test/xml/test_parse_options.rb
@@ -18,14 +18,14 @@ module Nokogiri
       ParseOptions.constants.each do |constant|
         next if constant == "STRICT"
 
-        class_eval %{
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
           def test_predicate_#{constant.downcase}
             options = ParseOptions.new(ParseOptions::#{constant})
             assert options.#{constant.downcase}?
 
             assert ParseOptions.new.#{constant.downcase}.#{constant.downcase}?
           end
-        }
+        RUBY
       end
 
       def test_strict_noent


### PR DESCRIPTION
Things declared in anonymous eval are always annoying to locate. (e.g. profling etc).

cc @flavorjones 