### PR TITLE
dep: update to rake-compiler-dock 1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,8 +382,7 @@ jobs:
     name: "generic-package"
     runs-on: ubuntu-latest
     container:
-      # image: "larskanis/rake-compiler-dock-mri-x86_64-linux:${{needs.rcd_image_version.outputs.rcd_image_version}}"
-      image: "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x86_64-linux"
+      image: "ghcr.io/rake-compiler/rake-compiler-dock-image:${{needs.rcd_image_version.outputs.rcd_image_version}}-mri-x86_64-linux"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -515,8 +514,7 @@ jobs:
           path: ports/archives
           key: tarballs-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - env:
-          DOCKER_IMAGE: "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-${{matrix.plat}}"
-          # DOCKER_IMAGE: "larskanis/rake-compiler-dock-mri-${{matrix.plat}}:${{needs.rcd_image_version.outputs.rcd_image_version}}"
+          DOCKER_IMAGE: "ghcr.io/rake-compiler/rake-compiler-dock-image:${{needs.rcd_image_version.outputs.rcd_image_version}}-mri-${{matrix.plat}}"
         run: |
           docker run --rm -v "$(pwd):/nokogiri" -w /nokogiri \
             ${DOCKER_IMAGE} \
@@ -697,8 +695,7 @@ jobs:
     name: "jruby-package"
     runs-on: ubuntu-latest
     container:
-      # image: "larskanis/rake-compiler-dock-jruby:${{needs.rcd_image_version.outputs.rcd_image_version}}"
-      image: "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-jruby"
+      image: "ghcr.io/rake-compiler/rake-compiler-dock-image:${{needs.rcd_image_version.outputs.rcd_image_version}}-jruby"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
 
   # building extensions
   gem "rake-compiler", "= 1.2.1"
-  gem "rake-compiler-dock", "= 1.2.2"
+  gem "rake-compiler-dock", "= 1.3.0"
 
   # documentation
   gem "hoe-markdown", "= 1.4.0"

--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -324,7 +324,6 @@ namespace "gem" do
   CROSS_RUBIES.find_all { |cr| cr.windows? || cr.linux? || cr.darwin? }.map(&:platform).uniq.each do |plat|
     desc "build native gem for #{plat} platform"
     task plat do
-      ENV["RCD_IMAGE"] = "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-#{plat}"
       RakeCompilerDock.sh(<<~EOT, platform: plat, verbose: true)
         ruby -v &&
         gem install bundler --no-document &&
@@ -345,7 +344,6 @@ namespace "gem" do
 
   desc "build a jruby gem"
   task "jruby" do
-    ENV["RCD_IMAGE"] = "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-jruby"
     RakeCompilerDock.sh(<<~EOF, rubyvm: "jruby", platform: "jruby", verbose: true)
       gem install bundler --no-document &&
       bundle &&


### PR DESCRIPTION

**What problem is this PR intended to solve?**

update to rake-compiler-dock 1.3.0 with official ruby 3.2 support. this is the final step for #2564 
