### PR TITLE
Fix Clang warnings about casting void* to an enum

### DIFF
--- a/gumbo-parser/src/error.c
+++ b/gumbo-parser/src/error.c
@@ -96,7 +96,7 @@ static void print_tag_stack (
     if (i) {
       print_message(output, ", ");
     }
-    GumboTag tag = (GumboTag) error->tag_stack.data[i];
+    GumboTag tag = (GumboTag)(intptr_t) error->tag_stack.data[i];
     print_message(output, "%s", gumbo_normalized_tagname(tag));
   }
   gumbo_string_buffer_append_codepoint('.', output);

--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -537,7 +537,7 @@ static GumboInsertionMode get_current_template_insertion_mode (
   if (modes->length == 0) {
     return GUMBO_INSERTION_MODE_INITIAL;
   }
-  return (GumboInsertionMode) modes->data[(modes->length - 1)];
+  return (GumboInsertionMode)(intptr_t) modes->data[(modes->length - 1)];
 }
 
 // Returns true if the specified token is either a start or end tag


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Clang warns about casting `void *` to an enum. This cast is fine in this case so first cast to `intptr_t`.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

This isn't a functional change so no tests were added. (I don't think we test for the absence of compiler warnings.)

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

No.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
