### PR TITLE
Move rdoc and psych into their own bundler group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,5 +40,4 @@ end
 # Then re-run `bundle install`.
 group :rdoc do
   gem "rdoc", "6.5.0"
-  gem "psych", "~> 5.0" # psych 5 isn't building in places yet https://github.com/ruby/setup-ruby/issues/409
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,6 @@ group :development do
 
   # documentation
   gem "hoe-markdown", "= 1.4.0"
-  gem "rdoc", "6.5.0"
-  gem "psych", "~> 5.0" # psych 5 isn't building in places yet https://github.com/ruby/setup-ruby/issues/409
 
   # parser generator
   gem "rexical", "= 1.0.7"
@@ -35,4 +33,12 @@ group :development do
     gem "rubocop-rake", "= 0.6.0"
     gem "rubocop-shopify", "2.10.1"
   end
+end
+
+# If Psych doesn't build, you can disable this group locally by running
+# `bundle config set --local without rdoc`
+# Then re-run `bundle install`.
+group :rdoc do
+  gem "rdoc", "6.5.0"
+  gem "psych", "~> 5.0" # psych 5 isn't building in places yet https://github.com/ruby/setup-ruby/issues/409
 end


### PR DESCRIPTION
Psych 5 no longer bundles libyaml which causes `bundle install` to fail on macOS which doesn't have libyaml and doesn't have an easy, standard way to install it.

One can use `bundle config set --local without rdoc` to disable installing the `psych` and `rdoc` (which depends on `psych`) gems.

Hopefully, this is only temporary and the upstream Psych team will produce a better way to handle this.

<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

#2769

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

As this is a (hopefully temporary) workaround, rather than a supported configuration, I have not.

**Does this change affect the behavior of either the C or the Java implementations?**

No.
<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
