### PR TITLE
fix: serialization with pseudo-IO objects like Zip::OutputStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## 1.14.1 / unreleased
+
+### Fixed
+
+* Serializing documents now works again with pseudo-IO objects that don't support IO's encoding API (like rubyzip's `Zip::OutputStream`). This was a regression in v1.14.0 due to the fix for [#752](https://github.com/sparklemotion/nokogiri/issues/752) in [#2434](https://github.com/sparklemotion/nokogiri/issues/2434), and was not completely fixed by [#2753](https://github.com/sparklemotion/nokogiri/issues/2753). [[#2773](https://github.com/sparklemotion/nokogiri/issues/2773)]
+
+2e260f53e6b84b8f9c1b115b0ded85eebc8155d7
+
+
 ## 1.14.0 / 2023-01-12
 
 ### Notable Changes

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development do
   gem "minitest-reporters", "= 1.5.0"
   gem "ruby_memcheck", "1.2.0" unless RUBY_PLATFORM == "java"
   gem "simplecov", "= 0.21.2"
+  gem "rubyzip", "~> 2.3.2"
 
   # rubocop
   if Gem::Requirement.new("~> 3.0").satisfied_by?(Gem::Version.new(RUBY_VERSION))

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -112,8 +112,13 @@ noko_io_write(void *io, char *c_buffer, int c_buffer_len)
 {
   VALUE rb_args[2], rb_n_bytes_written;
   VALUE rb_io = (VALUE)io;
-  VALUE rb_enc = rb_funcall(rb_io, id_external_encoding, 0);
-  rb_encoding *io_encoding = RB_NIL_P(rb_enc) ? rb_ascii8bit_encoding() : rb_to_encoding(rb_enc);
+  VALUE rb_enc = Qnil;
+  rb_encoding *io_encoding;
+
+  if (rb_respond_to(rb_io, id_external_encoding)) {
+    rb_enc = rb_funcall(rb_io, id_external_encoding, 0);
+  }
+  io_encoding = RB_NIL_P(rb_enc) ? rb_ascii8bit_encoding() : rb_to_encoding(rb_enc);
 
   rb_args[0] = rb_io;
   rb_args[1] = rb_enc_str_new(c_buffer, (long)c_buffer_len, io_encoding);

--- a/test/xml/test_document_encoding.rb
+++ b/test/xml/test_document_encoding.rb
@@ -31,17 +31,19 @@ module Nokogiri
         end
 
         it "encodes the URL as UTF-8" do
-          assert_equal("UTF-8", shift_jis_document.url.encoding.name)
+          assert_equal(Encoding::UTF_8, shift_jis_document.url.encoding)
         end
 
         it "encodes the encoding name as UTF-8" do
-          assert_equal("UTF-8", shift_jis_document.encoding.encoding.name)
+          assert_equal(Encoding::UTF_8, shift_jis_document.encoding.encoding)
         end
 
         it "encodes the library versions as UTF-8" do
           skip_unless_libxml2
-          assert_equal("UTF-8", Nokogiri::LIBXML_COMPILED_VERSION.encoding.name)
-          assert_equal("UTF-8", Nokogiri::LIBXSLT_COMPILED_VERSION.encoding.name)
+
+          assert_equal(Encoding::UTF_8, Nokogiri::LIBXML_COMPILED_VERSION.encoding)
+          assert_equal(Encoding::UTF_8, Nokogiri::LIBXSLT_COMPILED_VERSION.encoding)
+        end
         end
 
         it "serializes UTF-16 correctly across libxml2 buffer flushes" do


### PR DESCRIPTION

**What problem is this PR intended to solve?**

#2773 

Serializing documents now works again with pseudo-IO objects that don't support IO's encoding API (like rubyzip's `Zip::OutputStream`). This was a regression in v1.14.0 due to the fix for #752 in #2434, and was not completely fixed by #2753. [#2773]

**Have you included adequate test coverage?**

Yes, existing coverage was extended to include JRuby, and new coverage was added for this case.

**Does this change affect the behavior of either the C or the Java implementations?**

This restores CRuby behavior to parity with the previous behavior that matches JRuby.
