### PR TITLE
dev: update old-style function definitions to ANSI C

### DIFF
--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -576,7 +576,7 @@ fragment_continue(VALUE parse_args)
 
 // Initialize the Nokogumbo class and fetch constants we will use later.
 void
-noko_init_gumbo()
+noko_init_gumbo(void)
 {
   // Class constants.
   cNokogiriHtml5Document = rb_define_class_under(mNokogiriHtml5, "Document", cNokogiriHtml4Document);

--- a/ext/nokogiri/html4_document.c
+++ b/ext/nokogiri/html4_document.c
@@ -150,7 +150,7 @@ rb_html_document_type(VALUE self)
 }
 
 void
-noko_init_html_document()
+noko_init_html_document(void)
 {
   assert(cNokogiriXmlDocument);
   cNokogiriHtml4Document = rb_define_class_under(mNokogiriHtml4, "Document", cNokogiriXmlDocument);

--- a/ext/nokogiri/html4_element_description.c
+++ b/ext/nokogiri/html4_element_description.c
@@ -270,7 +270,7 @@ get_description(VALUE klass, VALUE tag_name)
 }
 
 void
-noko_init_html_element_description()
+noko_init_html_element_description(void)
 {
   cNokogiriHtml4ElementDescription = rb_define_class_under(mNokogiriHtml4, "ElementDescription", rb_cObject);
 

--- a/ext/nokogiri/html4_entity_lookup.c
+++ b/ext/nokogiri/html4_entity_lookup.c
@@ -29,7 +29,7 @@ get(VALUE _, VALUE rb_entity_name)
 }
 
 void
-noko_init_html_entity_lookup()
+noko_init_html_entity_lookup(void)
 {
   cNokogiriHtml4EntityLookup = rb_define_class_under(mNokogiriHtml4, "EntityLookup", rb_cObject);
 

--- a/ext/nokogiri/html4_sax_parser_context.c
+++ b/ext/nokogiri/html4_sax_parser_context.c
@@ -101,7 +101,7 @@ parse_with(VALUE self, VALUE sax_handler)
 }
 
 void
-noko_init_html_sax_parser_context()
+noko_init_html_sax_parser_context(void)
 {
   assert(cNokogiriXmlSaxParserContext);
   cNokogiriHtml4SaxParserContext = rb_define_class_under(mNokogiriHtml4Sax, "ParserContext",

--- a/ext/nokogiri/html4_sax_push_parser.c
+++ b/ext/nokogiri/html4_sax_push_parser.c
@@ -85,7 +85,7 @@ initialize_native(VALUE self, VALUE _xml_sax, VALUE _filename,
 }
 
 void
-noko_init_html_sax_push_parser()
+noko_init_html_sax_push_parser(void)
 {
   assert(cNokogiriXmlSaxPushParser);
   cNokogiriHtml4SaxPushParser = rb_define_class_under(mNokogiriHtml4Sax, "PushParser", cNokogiriXmlSaxPushParser);

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -133,7 +133,7 @@ noko_io_close(void *io)
 
 
 void
-Init_nokogiri()
+Init_nokogiri(void)
 {
   mNokogiri         = rb_define_module("Nokogiri");
   mNokogiriGumbo    = rb_define_module_under(mNokogiri, "Gumbo");

--- a/ext/nokogiri/test_global_handlers.c
+++ b/ext/nokogiri/test_global_handlers.c
@@ -32,7 +32,7 @@ rb_foreign_error_handler(VALUE klass)
  *  Do NOT use this outside of the Nokogiri test suite.
  */
 void
-noko_init_test_global_handlers()
+noko_init_test_global_handlers(void)
 {
   VALUE mNokogiriTest = rb_define_module_under(mNokogiri, "Test");
 

--- a/ext/nokogiri/xml_attr.c
+++ b/ext/nokogiri/xml_attr.c
@@ -89,7 +89,7 @@ new (int argc, VALUE *argv, VALUE klass)
 }
 
 void
-noko_init_xml_attr()
+noko_init_xml_attr(void)
 {
   assert(cNokogiriXmlNode);
   /*

--- a/ext/nokogiri/xml_attribute_decl.c
+++ b/ext/nokogiri/xml_attribute_decl.c
@@ -59,7 +59,7 @@ enumeration(VALUE self)
 }
 
 void
-noko_init_xml_attribute_decl()
+noko_init_xml_attribute_decl(void)
 {
   assert(cNokogiriXmlNode);
   cNokogiriXmlAttributeDecl = rb_define_class_under(mNokogiriXml, "AttributeDecl", cNokogiriXmlNode);

--- a/ext/nokogiri/xml_cdata.c
+++ b/ext/nokogiri/xml_cdata.c
@@ -45,7 +45,7 @@ new (int argc, VALUE *argv, VALUE klass)
 }
 
 void
-noko_init_xml_cdata()
+noko_init_xml_cdata(void)
 {
   assert(cNokogiriXmlText);
   /*

--- a/ext/nokogiri/xml_comment.c
+++ b/ext/nokogiri/xml_comment.c
@@ -48,7 +48,7 @@ new (int argc, VALUE *argv, VALUE klass)
 }
 
 void
-noko_init_xml_comment()
+noko_init_xml_comment(void)
 {
   assert(cNokogiriXmlCharacterData);
   /*

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -664,7 +664,7 @@ noko_xml_document_pin_namespace(xmlNsPtr ns, xmlDocPtr doc)
 
 
 void
-noko_init_xml_document()
+noko_init_xml_document(void)
 {
   assert(cNokogiriXmlNode);
   /*

--- a/ext/nokogiri/xml_document_fragment.c
+++ b/ext/nokogiri/xml_document_fragment.c
@@ -32,7 +32,7 @@ new (int argc, VALUE *argv, VALUE klass)
 }
 
 void
-noko_init_xml_document_fragment()
+noko_init_xml_document_fragment(void)
 {
   assert(cNokogiriXmlNode);
   /*

--- a/ext/nokogiri/xml_dtd.c
+++ b/ext/nokogiri/xml_dtd.c
@@ -190,7 +190,7 @@ external_id(VALUE self)
 }
 
 void
-noko_init_xml_dtd()
+noko_init_xml_dtd(void)
 {
   assert(cNokogiriXmlNode);
   /*

--- a/ext/nokogiri/xml_element_content.c
+++ b/ext/nokogiri/xml_element_content.c
@@ -112,7 +112,7 @@ noko_xml_element_content_wrap(VALUE doc, xmlElementContentPtr element)
 }
 
 void
-noko_init_xml_element_content()
+noko_init_xml_element_content(void)
 {
   cNokogiriXmlElementContent = rb_define_class_under(mNokogiriXml, "ElementContent", rb_cObject);
 

--- a/ext/nokogiri/xml_element_decl.c
+++ b/ext/nokogiri/xml_element_decl.c
@@ -56,7 +56,7 @@ prefix(VALUE self)
 }
 
 void
-noko_init_xml_element_decl()
+noko_init_xml_element_decl(void)
 {
   assert(cNokogiriXmlNode);
   cNokogiriXmlElementDecl = rb_define_class_under(mNokogiriXml, "ElementDecl", cNokogiriXmlNode);

--- a/ext/nokogiri/xml_encoding_handler.c
+++ b/ext/nokogiri/xml_encoding_handler.c
@@ -89,7 +89,7 @@ rb_xml_encoding_handler_name(VALUE self)
 
 
 void
-noko_init_xml_encoding_handler()
+noko_init_xml_encoding_handler(void)
 {
   cNokogiriEncodingHandler = rb_define_class_under(mNokogiri, "EncodingHandler", rb_cObject);
 

--- a/ext/nokogiri/xml_entity_decl.c
+++ b/ext/nokogiri/xml_entity_decl.c
@@ -86,7 +86,7 @@ system_id(VALUE self)
 }
 
 void
-noko_init_xml_entity_decl()
+noko_init_xml_entity_decl(void)
 {
   assert(cNokogiriXmlNode);
   cNokogiriXmlEntityDecl = rb_define_class_under(mNokogiriXml, "EntityDecl", cNokogiriXmlNode);

--- a/ext/nokogiri/xml_entity_reference.c
+++ b/ext/nokogiri/xml_entity_reference.c
@@ -38,7 +38,7 @@ new (int argc, VALUE *argv, VALUE klass)
 }
 
 void
-noko_init_xml_entity_reference()
+noko_init_xml_entity_reference(void)
 {
   assert(cNokogiriXmlNode);
   /*

--- a/ext/nokogiri/xml_namespace.c
+++ b/ext/nokogiri/xml_namespace.c
@@ -175,7 +175,7 @@ noko_xml_namespace_wrap_xpath_copy(xmlNsPtr c_namespace)
 }
 
 void
-noko_init_xml_namespace()
+noko_init_xml_namespace(void)
 {
   cNokogiriXmlNamespace = rb_define_class_under(mNokogiriXml, "Namespace", rb_cObject);
 

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -2357,7 +2357,7 @@ noko_xml_node_attrs(xmlNodePtr c_node)
 }
 
 void
-noko_init_xml_node()
+noko_init_xml_node(void)
 {
   cNokogiriXmlNode = rb_define_class_under(mNokogiriXml, "Node", rb_cObject);
 

--- a/ext/nokogiri/xml_processing_instruction.c
+++ b/ext/nokogiri/xml_processing_instruction.c
@@ -41,7 +41,7 @@ new (int argc, VALUE *argv, VALUE klass)
 }
 
 void
-noko_init_xml_processing_instruction()
+noko_init_xml_processing_instruction(void)
 {
   assert(cNokogiriXmlNode);
   /*

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -752,7 +752,7 @@ rb_xml_reader_encoding(VALUE rb_reader)
 }
 
 void
-noko_init_xml_reader()
+noko_init_xml_reader(void)
 {
   /*
    * The Reader parser allows you to effectively pull parse an XML document.

--- a/ext/nokogiri/xml_relax_ng.c
+++ b/ext/nokogiri/xml_relax_ng.c
@@ -171,7 +171,7 @@ from_document(int argc, VALUE *argv, VALUE klass)
 }
 
 void
-noko_init_xml_relax_ng()
+noko_init_xml_relax_ng(void)
 {
   assert(cNokogiriXmlSchema);
   cNokogiriXmlRelaxNG = rb_define_class_under(mNokogiriXml, "RelaxNG", cNokogiriXmlSchema);

--- a/ext/nokogiri/xml_sax_parser.c
+++ b/ext/nokogiri/xml_sax_parser.c
@@ -294,7 +294,7 @@ allocate(VALUE klass)
 }
 
 void
-noko_init_xml_sax_parser()
+noko_init_xml_sax_parser(void)
 {
   cNokogiriXmlSaxParser = rb_define_class_under(mNokogiriXmlSax, "Parser", rb_cObject);
 

--- a/ext/nokogiri/xml_sax_parser_context.c
+++ b/ext/nokogiri/xml_sax_parser_context.c
@@ -261,7 +261,7 @@ get_recovery(VALUE self)
 }
 
 void
-noko_init_xml_sax_parser_context()
+noko_init_xml_sax_parser_context(void)
 {
   cNokogiriXmlSaxParserContext = rb_define_class_under(mNokogiriXmlSax, "ParserContext", rb_cObject);
 

--- a/ext/nokogiri/xml_sax_push_parser.c
+++ b/ext/nokogiri/xml_sax_push_parser.c
@@ -150,7 +150,7 @@ set_replace_entities(VALUE self, VALUE value)
 }
 
 void
-noko_init_xml_sax_push_parser()
+noko_init_xml_sax_push_parser(void)
 {
   cNokogiriXmlSaxPushParser = rb_define_class_under(mNokogiriXmlSax, "PushParser", rb_cObject);
 

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -268,7 +268,7 @@ from_document(int argc, VALUE *argv, VALUE klass)
 }
 
 void
-noko_init_xml_schema()
+noko_init_xml_schema(void)
 {
   cNokogiriXmlSchema = rb_define_class_under(mNokogiriXml, "Schema", rb_cObject);
 

--- a/ext/nokogiri/xml_syntax_error.c
+++ b/ext/nokogiri/xml_syntax_error.c
@@ -75,7 +75,7 @@ Nokogiri_wrap_xml_syntax_error(xmlErrorPtr error)
 }
 
 void
-noko_init_xml_syntax_error()
+noko_init_xml_syntax_error(void)
 {
   assert(cNokogiriSyntaxError);
   /*

--- a/ext/nokogiri/xml_text.c
+++ b/ext/nokogiri/xml_text.c
@@ -36,7 +36,7 @@ new (int argc, VALUE *argv, VALUE klass)
 }
 
 void
-noko_init_xml_text()
+noko_init_xml_text(void)
 {
   assert(cNokogiriXmlCharacterData);
   /*

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -348,7 +348,7 @@ registr(VALUE self, VALUE uri, VALUE obj)
 }
 
 void
-noko_init_xslt_stylesheet()
+noko_init_xslt_stylesheet(void)
 {
   rb_define_singleton_method(mNokogiriXslt, "register", registr, 2);
   rb_iv_set(mNokogiriXslt, "@modules", rb_hash_new());


### PR DESCRIPTION
**What problem is this PR intended to solve?**

modern Ruby will emit warnings with -Wold-style-definitions.
