### PR TITLE
fix: empty node set serialization when document encoding is nil

### DIFF
--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -345,8 +345,9 @@ module Nokogiri
           args.insert(0, options)
         end
         if empty?
-          encoding = (args.first.is_a?(Hash) ? args.first[:encoding] : nil) || document.encoding
-          "".encode(encoding)
+          encoding = (args.first.is_a?(Hash) ? args.first[:encoding] : nil)
+          encoding ||= document.encoding
+          encoding.nil? ? "" : "".encode(encoding)
         else
           map { |x| x.to_html(*args) }.join
         end

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -976,6 +976,12 @@ module Nokogiri
             assert_equal(doc2, node_set[1].document)
           end
         end
+
+        describe "empty sets" do
+          it "#to_html returns an empty string" do
+            assert_equal("", NodeSet.new(xml, []).to_html)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes #2784

**Have you included adequate test coverage?**

Yes

**Does this change affect the behavior of either the C or the Java implementations?**

No
