### PR TITLE
fix: empty node set serialization when document encoding is nil (backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## 1.14.next / unreleased
+
+### Fixed
+
+* Calling `NodeSet#to_html` on an empty node set no longer raises an encoding-related exception. This bug was introduced in v1.14.0 while fixing [#2649](https://github.com/sparklemotion/nokogiri/issues/2649). [[#2784](https://github.com/sparklemotion/nokogiri/issues/2784)]
+
+
 ## 1.14.1 / 2023-01-30
 
 ### Fixed

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -345,8 +345,9 @@ module Nokogiri
           args.insert(0, options)
         end
         if empty?
-          encoding = (args.first.is_a?(Hash) ? args.first[:encoding] : nil) || document.encoding
-          "".encode(encoding)
+          encoding = (args.first.is_a?(Hash) ? args.first[:encoding] : nil)
+          encoding ||= document.encoding
+          encoding.nil? ? "" : "".encode(encoding)
         else
           map { |x| x.to_html(*args) }.join
         end

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -961,6 +961,12 @@ module Nokogiri
             assert_equal(doc2, node_set[1].document)
           end
         end
+
+        describe "empty sets" do
+          it "#to_html returns an empty string" do
+            assert_equal("", NodeSet.new(xml, []).to_html)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Backport of #2789 to v1.14.x

Fixes #2784 