### PR TITLE
Fix deprecated double_heap option to GC.verify_compaction_references under 3.2

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -202,7 +202,7 @@ module Nokogiri
         when "verify"
           if @@test_count % COMPACT_EVERY == 0
             # https://alanwu.space/post/check-compaction/
-            GC.verify_compaction_references(double_heap: true, toward: :empty)
+            gc_verify_compaction_references
           end
           GC.start(full_mark: true)
         when "stress"
@@ -215,6 +215,14 @@ module Nokogiri
       end
 
       super
+    end
+
+    def gc_verify_compaction_references
+      if Gem::Requirement.new(">= 3.2.0").satisfied_by?(Gem::Version.new(RUBY_VERSION))
+        GC.verify_compaction_references(expand_heap: true, toward: :empty)
+      else
+        GC.verify_compaction_references(double_heap: true, toward: :empty)
+      end
     end
 
     def stress_memory_while(&block)

--- a/test/test_compaction.rb
+++ b/test/test_compaction.rb
@@ -14,7 +14,7 @@ describe "compaction" do
       doc.root.children.each(&:inspect)
 
       # compact the heap and try to get the node wrappers to move
-      GC.verify_compaction_references(double_heap: true, toward: :empty)
+      gc_verify_compaction_references
 
       # access the node wrappers and make sure they didn't move
       doc.root.children.each(&:inspect)
@@ -35,7 +35,7 @@ describe "compaction" do
 
       doc.at_xpath("//root:first", "root" => "http://example.com/root").namespace_scopes.inspect
 
-      GC.verify_compaction_references(double_heap: true, toward: :empty)
+      gc_verify_compaction_references
 
       doc.at_xpath("//root:first", "root" => "http://example.com/root").namespace_scopes.inspect
     end
@@ -57,7 +57,7 @@ describe "compaction" do
       namespaces.each(&:inspect)
       doc.remove_namespaces!
 
-      GC.verify_compaction_references(double_heap: true, toward: :empty)
+      gc_verify_compaction_references
 
       namespaces.each(&:inspect)
     end


### PR DESCRIPTION
When I'm running the tests with Ruby 3.2 I can see a deprecation warning, this fixes it.
