### PR TITLE
dev: better pp and inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 ### Improved
 
 * `Nokogiri::XML::Node::SaveOptions#inspect` now shows the names of the options set in the bitmask, similar to `ParseOptions`. [[#2767](https://github.com/sparklemotion/nokogiri/issues/2767)]
+* `#inspect` and pretty-printing are improved for `AttributeDecl`, `ElementContent`, `ElementDecl`, and `EntityDecl`.
 
 
 ### Deprecated

--- a/ext/nokogiri/xml_element_content.c
+++ b/ext/nokogiri/xml_element_content.c
@@ -102,10 +102,10 @@ VALUE
 noko_xml_element_content_wrap(VALUE rb_document, xmlElementContentPtr c_element_content)
 {
   VALUE elem = TypedData_Wrap_Struct(
-    cNokogiriXmlElementContent,
-    &element_content_data_type,
-    c_element_content
-  );
+                 cNokogiriXmlElementContent,
+                 &element_content_data_type,
+                 c_element_content
+               );
 
   /* keep a handle on the document for GC marking */
   rb_iv_set(elem, "@document", rb_document);

--- a/lib/nokogiri/xml/attribute_decl.rb
+++ b/lib/nokogiri/xml/attribute_decl.rb
@@ -12,8 +12,10 @@ module Nokogiri
       undef_method :namespace_definitions
       undef_method :line if method_defined?(:line)
 
-      def inspect
-        "#<#{self.class.name}:#{format("0x%x", object_id)} #{to_s.inspect}>"
+      private
+
+      def inspect_attributes
+        [:to_s]
       end
     end
   end

--- a/lib/nokogiri/xml/element_content.rb
+++ b/lib/nokogiri/xml/element_content.rb
@@ -14,6 +14,8 @@ module Nokogiri
     # ElementContent represents the binary tree inside the <!ELEMENT> tag shown above that lists the
     # possible content for the div1 tag.
     class ElementContent
+      include Nokogiri::XML::PP::Node
+
       # Possible definitions of type
       PCDATA  = 1
       ELEMENT = 2
@@ -32,6 +34,12 @@ module Nokogiri
       # Get the children of this ElementContent node
       def children
         [c1, c2].compact
+      end
+
+      private
+
+      def inspect_attributes
+        [:prefix, :name, :type, :occur, :children]
       end
     end
   end

--- a/lib/nokogiri/xml/element_decl.rb
+++ b/lib/nokogiri/xml/element_decl.rb
@@ -7,8 +7,10 @@ module Nokogiri
       undef_method :namespace_definitions
       undef_method :line if method_defined?(:line)
 
-      def inspect
-        "#<#{self.class.name}:#{format("0x%x", object_id)} #{to_s.inspect}>"
+      private
+
+      def inspect_attributes
+        [:to_s]
       end
     end
   end

--- a/lib/nokogiri/xml/entity_decl.rb
+++ b/lib/nokogiri/xml/entity_decl.rb
@@ -13,8 +13,10 @@ module Nokogiri
         doc.create_entity(name, *args)
       end
 
-      def inspect
-        "#<#{self.class.name}:#{format("0x%x", object_id)} #{to_s.inspect}>"
+      private
+
+      def inspect_attributes
+        [:to_s]
       end
     end
   end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Improve output of inspect and pp for some classes: AttributeDecl, ElementContent, ElementDecl, and EntityDecl

These classes were either:

- inheriting `PP::Node` and overriding `#inspect` but not `#pretty_print`, or
- not inheriting `PP::Node` where they could be to simplify things

Additionally, `PP::Node#inspect` and `PP::Node#pretty_print` no longer munge the names of inspected attributes (e.g., `attribute_nodes` appears as-is instead of as `attributes`), and if there is only a single `inspect_attributes`, we omit the key name which makes the XML declarations' output nicer. 

**Have you included adequate test coverage?**

Err, no, but these changes should only impact debugging.

**Does this change affect the behavior of either the C or the Java implementations?**

N/A