### PR TITLE
Migrate XML::SAX::Parser to the TypedData API

### DIFF
--- a/ext/nokogiri/html4_sax_parser_context.c
+++ b/ext/nokogiri/html4_sax_parser_context.c
@@ -83,7 +83,7 @@ parse_with(VALUE self, VALUE sax_handler)
   }
 
   Data_Get_Struct(self, htmlParserCtxt, ctxt);
-  Data_Get_Struct(sax_handler, htmlSAXHandler, sax);
+  TypedData_Get_Struct(sax_handler, htmlSAXHandler, &noko_sax_handler_type, sax);
 
   /* Free the sax handler since we'll assign our own */
   if (ctxt->sax && ctxt->sax != (xmlSAXHandlerPtr)&xmlDefaultSAXHandler) {

--- a/ext/nokogiri/html4_sax_push_parser.c
+++ b/ext/nokogiri/html4_sax_push_parser.c
@@ -54,7 +54,7 @@ initialize_native(VALUE self, VALUE _xml_sax, VALUE _filename,
   htmlParserCtxtPtr ctx;
   xmlCharEncoding enc = XML_CHAR_ENCODING_NONE;
 
-  Data_Get_Struct(_xml_sax, xmlSAXHandler, sax);
+  TypedData_Get_Struct(_xml_sax, xmlSAXHandler, &noko_sax_handler_type, sax);
 
   if (_filename != Qnil) { filename = StringValueCStr(_filename); }
 

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -167,6 +167,7 @@ typedef struct _nokogiriXsltStylesheetTuple {
 } nokogiriXsltStylesheetTuple;
 
 extern const rb_data_type_t noko_xml_document_data_type;
+extern const rb_data_type_t noko_sax_handler_type;
 
 void noko_xml_document_pin_node(xmlNodePtr);
 void noko_xml_document_pin_namespace(xmlNsPtr, xmlDocPtr);

--- a/ext/nokogiri/xml_sax_parser_context.c
+++ b/ext/nokogiri/xml_sax_parser_context.c
@@ -117,7 +117,7 @@ parse_with(VALUE self, VALUE sax_handler)
   }
 
   Data_Get_Struct(self, xmlParserCtxt, ctxt);
-  Data_Get_Struct(sax_handler, xmlSAXHandler, sax);
+  TypedData_Get_Struct(sax_handler, xmlSAXHandler, &noko_sax_handler_type, sax);
 
   /* Free the sax handler since we'll assign our own */
   if (ctxt->sax && ctxt->sax != (xmlSAXHandlerPtr)&xmlDefaultSAXHandler) {

--- a/ext/nokogiri/xml_sax_push_parser.c
+++ b/ext/nokogiri/xml_sax_push_parser.c
@@ -63,7 +63,7 @@ initialize_native(VALUE self, VALUE _xml_sax, VALUE _filename)
   const char *filename = NULL;
   xmlParserCtxtPtr ctx;
 
-  Data_Get_Struct(_xml_sax, xmlSAXHandler, sax);
+  TypedData_Get_Struct(_xml_sax, xmlSAXHandler, &noko_sax_handler_type, sax);
 
   if (_filename != Qnil) { filename = StringValueCStr(_filename); }
 


### PR DESCRIPTION
Ref: #2808

We now rely on `TypedData_Make_Struct` to do the allocation instead of using `ruby_xcalloc` directly, and we use RUBY_TYPED_DEFAULT_FREE to let Ruby free it as well.

There's no mark function so we can enable RUBY_TYPED_WB_PROTECTED.