### PR TITLE
ext: migrate NodeSet to TypedData api

### DIFF
--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -188,6 +188,7 @@ VALUE noko_xml_namespace_wrap_xpath_copy(xmlNsPtr node);
 VALUE noko_xml_element_content_wrap(VALUE doc, xmlElementContentPtr element);
 
 VALUE noko_xml_node_set_wrap(xmlNodeSetPtr node_set, VALUE document) ;
+xmlNodeSetPtr noko_xml_node_set_unwrap(VALUE rb_node_set) ;
 
 VALUE noko_xml_document_wrap_with_init_args(VALUE klass, xmlDocPtr doc, int argc, VALUE *argv);
 VALUE noko_xml_document_wrap(VALUE klass, xmlDocPtr doc);

--- a/ext/nokogiri/xml_node_set.c
+++ b/ext/nokogiri/xml_node_set.c
@@ -111,16 +111,16 @@ allocate(VALUE klass)
  * duplicated (similar to how Array and other Enumerable classes work).
  */
 static VALUE
-duplicate(VALUE self)
+duplicate(VALUE rb_self)
 {
-  xmlNodeSetPtr node_set;
+  xmlNodeSetPtr c_self;
   xmlNodeSetPtr dupl;
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
 
-  dupl = xmlXPathNodeSetMerge(NULL, node_set);
+  dupl = xmlXPathNodeSetMerge(NULL, c_self);
 
-  return noko_xml_node_set_wrap(dupl, rb_iv_get(self, "@document"));
+  return noko_xml_node_set_wrap(dupl, rb_iv_get(rb_self, "@document"));
 }
 
 /*
@@ -130,13 +130,13 @@ duplicate(VALUE self)
  * Get the length of the node set
  */
 static VALUE
-length(VALUE self)
+length(VALUE rb_self)
 {
-  xmlNodeSetPtr node_set;
+  xmlNodeSetPtr c_self;
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
 
-  return node_set ? INT2NUM(node_set->nodeNr) : INT2NUM(0);
+  return c_self ? INT2NUM(c_self->nodeNr) : INT2NUM(0);
 }
 
 /*
@@ -146,19 +146,19 @@ length(VALUE self)
  * Append +node+ to the NodeSet.
  */
 static VALUE
-push(VALUE self, VALUE rb_node)
+push(VALUE rb_self, VALUE rb_node)
 {
-  xmlNodeSetPtr node_set;
+  xmlNodeSetPtr c_self;
   xmlNodePtr node;
 
   Check_Node_Set_Node_Type(rb_node);
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
   Noko_Node_Get_Struct(rb_node, xmlNode, node);
 
-  xmlXPathNodeSetAdd(node_set, node);
+  xmlXPathNodeSetAdd(c_self, node);
 
-  return self;
+  return rb_self;
 }
 
 /*
@@ -169,18 +169,18 @@ push(VALUE self, VALUE rb_node)
  *  if found, otherwise returns nil.
  */
 static VALUE
-delete (VALUE self, VALUE rb_node)
+delete (VALUE rb_self, VALUE rb_node)
 {
-  xmlNodeSetPtr node_set;
+  xmlNodeSetPtr c_self;
   xmlNodePtr node;
 
   Check_Node_Set_Node_Type(rb_node);
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
   Noko_Node_Get_Struct(rb_node, xmlNode, node);
 
-  if (xmlXPathNodeSetContains(node_set, node)) {
-    xpath_node_set_del(node_set, node);
+  if (xmlXPathNodeSetContains(c_self, node)) {
+    xpath_node_set_del(c_self, node);
     return rb_node;
   }
   return Qnil ;
@@ -194,20 +194,20 @@ delete (VALUE self, VALUE rb_node)
  * Set Intersection — Returns a new NodeSet containing nodes common to the two NodeSets.
  */
 static VALUE
-intersection(VALUE self, VALUE rb_other)
+intersection(VALUE rb_self, VALUE rb_other)
 {
-  xmlNodeSetPtr node_set, other ;
+  xmlNodeSetPtr c_self, c_other ;
   xmlNodeSetPtr intersection;
 
   if (!rb_obj_is_kind_of(rb_other, cNokogiriXmlNodeSet)) {
     rb_raise(rb_eArgError, "node_set must be a Nokogiri::XML::NodeSet");
   }
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
-  Data_Get_Struct(rb_other, xmlNodeSet, other);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
+  Data_Get_Struct(rb_other, xmlNodeSet, c_other);
 
-  intersection = xmlXPathIntersection(node_set, other);
-  return noko_xml_node_set_wrap(intersection, rb_iv_get(self, "@document"));
+  intersection = xmlXPathIntersection(c_self, c_other);
+  return noko_xml_node_set_wrap(intersection, rb_iv_get(rb_self, "@document"));
 }
 
 
@@ -218,17 +218,17 @@ intersection(VALUE self, VALUE rb_other)
  *  Returns true if any member of node set equals +node+.
  */
 static VALUE
-include_eh(VALUE self, VALUE rb_node)
+include_eh(VALUE rb_self, VALUE rb_node)
 {
-  xmlNodeSetPtr node_set;
+  xmlNodeSetPtr c_self;
   xmlNodePtr node;
 
   Check_Node_Set_Node_Type(rb_node);
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
   Noko_Node_Get_Struct(rb_node, xmlNode, node);
 
-  return (xmlXPathNodeSetContains(node_set, node) ? Qtrue : Qfalse);
+  return (xmlXPathNodeSetContains(c_self, node) ? Qtrue : Qfalse);
 }
 
 
@@ -240,22 +240,22 @@ include_eh(VALUE self, VALUE rb_node)
  * set.
  */
 static VALUE
-rb_xml_node_set_union(VALUE rb_node_set, VALUE rb_other)
+rb_xml_node_set_union(VALUE rb_self, VALUE rb_other)
 {
-  xmlNodeSetPtr c_node_set, c_other;
+  xmlNodeSetPtr c_self, c_other;
   xmlNodeSetPtr c_new_node_set;
 
   if (!rb_obj_is_kind_of(rb_other, cNokogiriXmlNodeSet)) {
     rb_raise(rb_eArgError, "node_set must be a Nokogiri::XML::NodeSet");
   }
 
-  Data_Get_Struct(rb_node_set, xmlNodeSet, c_node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
   Data_Get_Struct(rb_other, xmlNodeSet, c_other);
 
-  c_new_node_set = xmlXPathNodeSetMerge(NULL, c_node_set);
+  c_new_node_set = xmlXPathNodeSetMerge(NULL, c_self);
   c_new_node_set = xmlXPathNodeSetMerge(c_new_node_set, c_other);
 
-  return noko_xml_node_set_wrap(c_new_node_set, rb_iv_get(rb_node_set, "@document"));
+  return noko_xml_node_set_wrap(c_new_node_set, rb_iv_get(rb_self, "@document"));
 }
 
 /*
@@ -266,9 +266,9 @@ rb_xml_node_set_union(VALUE rb_node_set, VALUE rb_other)
  *  each item that also appears in +node_set+
  */
 static VALUE
-minus(VALUE self, VALUE rb_other)
+minus(VALUE rb_self, VALUE rb_other)
 {
-  xmlNodeSetPtr node_set, other;
+  xmlNodeSetPtr c_self, c_other;
   xmlNodeSetPtr new;
   int j ;
 
@@ -276,55 +276,55 @@ minus(VALUE self, VALUE rb_other)
     rb_raise(rb_eArgError, "node_set must be a Nokogiri::XML::NodeSet");
   }
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
-  Data_Get_Struct(rb_other, xmlNodeSet, other);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
+  Data_Get_Struct(rb_other, xmlNodeSet, c_other);
 
-  new = xmlXPathNodeSetMerge(NULL, node_set);
-  for (j = 0 ; j < other->nodeNr ; ++j) {
-    xpath_node_set_del(new, other->nodeTab[j]);
+  new = xmlXPathNodeSetMerge(NULL, c_self);
+  for (j = 0 ; j < c_other->nodeNr ; ++j) {
+    xpath_node_set_del(new, c_other->nodeTab[j]);
   }
 
-  return noko_xml_node_set_wrap(new, rb_iv_get(self, "@document"));
+  return noko_xml_node_set_wrap(new, rb_iv_get(rb_self, "@document"));
 }
 
 
 static VALUE
-index_at(VALUE self, long offset)
+index_at(VALUE rb_self, long offset)
 {
-  xmlNodeSetPtr node_set;
+  xmlNodeSetPtr c_self;
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
 
-  if (offset >= node_set->nodeNr || abs((int)offset) > node_set->nodeNr) {
+  if (offset >= c_self->nodeNr || abs((int)offset) > c_self->nodeNr) {
     return Qnil;
   }
 
-  if (offset < 0) { offset += node_set->nodeNr ; }
+  if (offset < 0) { offset += c_self->nodeNr ; }
 
-  return noko_xml_node_wrap_node_set_result(node_set->nodeTab[offset], self);
+  return noko_xml_node_wrap_node_set_result(c_self->nodeTab[offset], rb_self);
 }
 
 static VALUE
-subseq(VALUE self, long beg, long len)
+subseq(VALUE rb_self, long beg, long len)
 {
   long j;
-  xmlNodeSetPtr node_set;
+  xmlNodeSetPtr c_self;
   xmlNodeSetPtr new_set ;
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
 
-  if (beg > node_set->nodeNr) { return Qnil ; }
+  if (beg > c_self->nodeNr) { return Qnil ; }
   if (beg < 0 || len < 0) { return Qnil ; }
 
-  if ((beg + len) > node_set->nodeNr) {
-    len = node_set->nodeNr - beg ;
+  if ((beg + len) > c_self->nodeNr) {
+    len = c_self->nodeNr - beg ;
   }
 
   new_set = xmlXPathNodeSetCreate(NULL);
   for (j = beg ; j < beg + len ; ++j) {
-    xmlXPathNodeSetAddUnique(new_set, node_set->nodeTab[j]);
+    xmlXPathNodeSetAddUnique(new_set, c_self->nodeTab[j]);
   }
-  return noko_xml_node_set_wrap(new_set, rb_iv_get(self, "@document"));
+  return noko_xml_node_set_wrap(new_set, rb_iv_get(rb_self, "@document"));
 }
 
 /*
@@ -343,21 +343,21 @@ subseq(VALUE self, long beg, long len)
  * nil if the +index+ (or +start+) are out of range.
  */
 static VALUE
-slice(int argc, VALUE *argv, VALUE self)
+slice(int argc, VALUE *argv, VALUE rb_self)
 {
   VALUE arg ;
   long beg, len ;
-  xmlNodeSetPtr node_set;
+  xmlNodeSetPtr c_self;
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
 
   if (argc == 2) {
     beg = NUM2LONG(argv[0]);
     len = NUM2LONG(argv[1]);
     if (beg < 0) {
-      beg += node_set->nodeNr ;
+      beg += c_self->nodeNr ;
     }
-    return subseq(self, beg, len);
+    return subseq(rb_self, beg, len);
   }
 
   if (argc != 1) {
@@ -366,20 +366,20 @@ slice(int argc, VALUE *argv, VALUE self)
   arg = argv[0];
 
   if (FIXNUM_P(arg)) {
-    return index_at(self, FIX2LONG(arg));
+    return index_at(rb_self, FIX2LONG(arg));
   }
 
   /* if arg is Range */
-  switch (rb_range_beg_len(arg, &beg, &len, (long)node_set->nodeNr, 0)) {
+  switch (rb_range_beg_len(arg, &beg, &len, (long)c_self->nodeNr, 0)) {
     case Qfalse:
       break;
     case Qnil:
       return Qnil;
     default:
-      return subseq(self, beg, len);
+      return subseq(rb_self, beg, len);
   }
 
-  return index_at(self, NUM2LONG(arg));
+  return index_at(rb_self, NUM2LONG(arg));
 }
 
 
@@ -390,17 +390,17 @@ slice(int argc, VALUE *argv, VALUE self)
  * Return this list as an Array
  */
 static VALUE
-to_array(VALUE self)
+to_array(VALUE rb_self)
 {
-  xmlNodeSetPtr node_set ;
+  xmlNodeSetPtr c_self ;
   VALUE list;
   int i;
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
 
-  list = rb_ary_new2(node_set->nodeNr);
-  for (i = 0; i < node_set->nodeNr; i++) {
-    VALUE elt = noko_xml_node_wrap_node_set_result(node_set->nodeTab[i], self);
+  list = rb_ary_new2(c_self->nodeNr);
+  for (i = 0; i < c_self->nodeNr; i++) {
+    VALUE elt = noko_xml_node_wrap_node_set_result(c_self->nodeTab[i], rb_self);
     rb_ary_push(list, elt);
   }
 
@@ -414,25 +414,25 @@ to_array(VALUE self)
  * Unlink this NodeSet and all Node objects it contains from their current context.
  */
 static VALUE
-unlink_nodeset(VALUE self)
+unlink_nodeset(VALUE rb_self)
 {
-  xmlNodeSetPtr node_set;
+  xmlNodeSetPtr c_self;
   int j, nodeNr ;
 
-  Data_Get_Struct(self, xmlNodeSet, node_set);
+  Data_Get_Struct(rb_self, xmlNodeSet, c_self);
 
-  nodeNr = node_set->nodeNr ;
+  nodeNr = c_self->nodeNr ;
   for (j = 0 ; j < nodeNr ; j++) {
-    if (! NOKOGIRI_NAMESPACE_EH(node_set->nodeTab[j])) {
+    if (! NOKOGIRI_NAMESPACE_EH(c_self->nodeTab[j])) {
       VALUE node ;
       xmlNodePtr node_ptr;
-      node = noko_xml_node_wrap(Qnil, node_set->nodeTab[j]);
+      node = noko_xml_node_wrap(Qnil, c_self->nodeTab[j]);
       rb_funcall(node, rb_intern("unlink"), 0); /* modifies the C struct out from under the object */
       Noko_Node_Get_Struct(node, xmlNode, node_ptr);
-      node_set->nodeTab[j] = node_ptr ;
+      c_self->nodeTab[j] = node_ptr ;
     }
   }
-  return self ;
+  return rb_self ;
 }
 
 

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -277,13 +277,13 @@ Nokogiri_marshal_xpath_funcall_and_return_values(
     case T_ARRAY: {
       VALUE construct_args[2] = { DOC_RUBY_OBJECT(ctxt->context->doc), rb_retval };
       rb_node_set = rb_class_new_instance(2, construct_args, cNokogiriXmlNodeSet);
-      Data_Get_Struct(rb_node_set, xmlNodeSet, c_node_set);
+      c_node_set = noko_xml_node_set_unwrap(rb_node_set);
       xmlXPathReturnNodeSet(ctxt, xmlXPathNodeSetMerge(NULL, c_node_set));
     }
     break;
     case T_DATA:
       if (rb_obj_is_kind_of(rb_retval, cNokogiriXmlNodeSet)) {
-        Data_Get_Struct(rb_retval, xmlNodeSet, c_node_set);
+        c_node_set = noko_xml_node_set_unwrap(rb_retval);
         /* Copy the node set, otherwise it will get GC'd. */
         xmlXPathReturnNodeSet(ctxt, xmlXPathNodeSetMerge(NULL, c_node_set));
         break;


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See #2808.

Note that I chose to make a new public function, `noko_xml_node_set_unwrap`, to allow other files to unwrap node sets. This differs from the tactic adopted in #2807 / cb1557d0 which was to make public the data type.

We should probably decide which is the better approach and standardize on it.

cc @etiennebarrie @casperisfine