### PR TITLE
miscellaneous TypedData changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ### Deprecated
 
+* Passing a `Nokogiri::XML::Node` as the first parameter to `CDATA.new` is deprecated and will generate a warning. This parameter should be a kind of `Nokogiri::XML::Document`. This will become an error in a future version of Nokogiri.
+* Passing a `Nokogiri::XML::Node` as the first parameter to `Schema.from_document` is deprecated and will generate a warning. This parameter should be a kind of `Nokogiri::XML::Document`. This will become an error in a future version of Nokogiri.
+* Passing a `Nokogiri::XML::Node` as the second parameter to `Text.new` is deprecated and will generate a warning. This parameter should be a kind of `Nokogiri::XML::Document`. This will become an error in a future version of Nokogiri.
+
+
 ### Performance
 
 ### Security

--- a/ext/java/nokogiri/XmlCdata.java
+++ b/ext/java/nokogiri/XmlCdata.java
@@ -45,6 +45,12 @@ public class XmlCdata extends XmlText
     }
     IRubyObject doc = args[0];
     content = args[1];
+
+    if (!(doc instanceof XmlDocument)) {
+      // TODO: deprecate allowing Node
+      context.runtime.getWarnings().warn("Passing a Node as the first parameter to CDATA.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
+    }
+
     Document document = ((XmlNode) doc).getOwnerDocument();
     Node node = document.createCDATASection(rubyStringToString(content));
     setNode(context.runtime, node);

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -149,6 +149,11 @@ public class XmlSchema extends RubyObject
       parseOptions = args[1];
     }
 
+    if (!(document instanceof XmlDocument)) {
+      // TODO: deprecate allowing Node
+      context.runtime.getWarnings().warn("Passing a Node as the first parameter to Schema.from_document is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
+    }
+
     XmlDocument doc = ((XmlDocument)((XmlNode) document).document(context));
 
     RubyArray<?> errors = (RubyArray) doc.getInstanceVariable("@errors");

--- a/ext/java/nokogiri/XmlText.java
+++ b/ext/java/nokogiri/XmlText.java
@@ -53,6 +53,11 @@ public class XmlText extends XmlNode
     content = args[0];
     IRubyObject xNode = args[1];
 
+    if (!(xNode instanceof XmlDocument)) {
+      // TODO: deprecate allowing Node
+      context.runtime.getWarnings().warn("Passing a Node as the second parameter to Text.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
+    }
+
     Document document = asXmlNode(context, xNode).getOwnerDocument();
     // text node content should not be encoded when it is created by Text node.
     // while content should be encoded when it is created by Element node.

--- a/ext/nokogiri/html4_document.c
+++ b/ext/nokogiri/html4_document.c
@@ -144,8 +144,7 @@ rb_html_document_s_read_memory(VALUE klass, VALUE rb_html, VALUE rb_url, VALUE r
 static VALUE
 rb_html_document_type(VALUE self)
 {
-  htmlDocPtr doc;
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, doc);
+  htmlDocPtr doc = noko_xml_document_unwrap(self);
   return INT2NUM(doc->type);
 }
 

--- a/ext/nokogiri/html4_element_description.c
+++ b/ext/nokogiri/html4_element_description.c
@@ -2,11 +2,7 @@
 
 static const rb_data_type_t html4_element_description_type = {
   .wrap_struct_name = "Nokogiri::HTML4::ElementDescription",
-  .function = {
-    .dmark = NULL,
-    .dfree = NULL,
-  },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 VALUE cNokogiriHtml4ElementDescription ;

--- a/ext/nokogiri/html4_sax_parser_context.c
+++ b/ext/nokogiri/html4_sax_parser_context.c
@@ -83,7 +83,7 @@ parse_with(VALUE self, VALUE sax_handler)
   }
 
   Data_Get_Struct(self, htmlParserCtxt, ctxt);
-  TypedData_Get_Struct(sax_handler, htmlSAXHandler, &noko_sax_handler_type, sax);
+  sax = noko_sax_handler_unwrap(sax_handler);
 
   /* Free the sax handler since we'll assign our own */
   if (ctxt->sax && ctxt->sax != (xmlSAXHandlerPtr)&xmlDefaultSAXHandler) {

--- a/ext/nokogiri/html4_sax_push_parser.c
+++ b/ext/nokogiri/html4_sax_push_parser.c
@@ -54,7 +54,7 @@ initialize_native(VALUE self, VALUE _xml_sax, VALUE _filename,
   htmlParserCtxtPtr ctx;
   xmlCharEncoding enc = XML_CHAR_ENCODING_NONE;
 
-  TypedData_Get_Struct(_xml_sax, xmlSAXHandler, &noko_sax_handler_type, sax);
+  sax = noko_sax_handler_unwrap(_xml_sax);
 
   if (_filename != Qnil) { filename = StringValueCStr(_filename); }
 

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -166,9 +166,6 @@ typedef struct _nokogiriXsltStylesheetTuple {
   VALUE func_instances;
 } nokogiriXsltStylesheetTuple;
 
-extern const rb_data_type_t noko_xml_document_data_type;
-extern const rb_data_type_t noko_sax_handler_type;
-
 void noko_xml_document_pin_node(xmlNodePtr);
 void noko_xml_document_pin_namespace(xmlNsPtr, xmlDocPtr);
 
@@ -193,8 +190,11 @@ xmlNodeSetPtr noko_xml_node_set_unwrap(VALUE rb_node_set) ;
 
 VALUE noko_xml_document_wrap_with_init_args(VALUE klass, xmlDocPtr doc, int argc, VALUE *argv);
 VALUE noko_xml_document_wrap(VALUE klass, xmlDocPtr doc);
+xmlDocPtr noko_xml_document_unwrap(VALUE rb_document);
 NOKOPUBFUN VALUE Nokogiri_wrap_xml_document(VALUE klass,
     xmlDocPtr doc); /* deprecated. use noko_xml_document_wrap() instead. */
+
+xmlSAXHandlerPtr noko_sax_handler_unwrap(VALUE rb_sax_handler);
 
 #define DOC_RUBY_OBJECT_TEST(x) ((nokogiriTuplePtr)(x->_private))
 #define DOC_RUBY_OBJECT(x) (((nokogiriTuplePtr)(x->_private))->doc)

--- a/ext/nokogiri/xml_attr.c
+++ b/ext/nokogiri/xml_attr.c
@@ -68,7 +68,7 @@ new (int argc, VALUE *argv, VALUE klass)
     rb_raise(rb_eArgError, "parameter must be a Nokogiri::XML::Document");
   }
 
-  Noko_Node_Get_Struct(document, xmlDoc, xml_doc);
+  xml_doc = noko_xml_document_unwrap(document);
 
   node = xmlNewDocProp(
            xml_doc,

--- a/ext/nokogiri/xml_cdata.c
+++ b/ext/nokogiri/xml_cdata.c
@@ -25,14 +25,22 @@ new (int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "2*", &doc, &content, &rest);
 
-  Noko_Node_Get_Struct(doc, xmlDoc, xml_doc);
+  if (rb_obj_is_kind_of(doc, cNokogiriXmlDocument)) {
+    xml_doc = noko_xml_document_unwrap(doc);
+  } else {
+    xmlNodePtr deprecated_node_type_arg;
+    // TODO: deprecate allowing Node
+    NOKO_WARN_DEPRECATION("Passing a Node as the first parameter to CDATA.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
+    Noko_Node_Get_Struct(doc, xmlNode, deprecated_node_type_arg);
+    xml_doc = deprecated_node_type_arg->doc;
+  }
 
   if (!NIL_P(content)) {
     content_str = (xmlChar *)StringValuePtr(content);
     content_str_len = RSTRING_LENINT(content);
   }
 
-  node = xmlNewCDataBlock(xml_doc->doc, content_str, content_str_len);
+  node = xmlNewCDataBlock(xml_doc, content_str, content_str_len);
 
   noko_xml_document_pin_node(node);
 

--- a/ext/nokogiri/xml_comment.c
+++ b/ext/nokogiri/xml_comment.c
@@ -30,7 +30,7 @@ new (int argc, VALUE *argv, VALUE klass)
     rb_raise(rb_eArgError, "first argument must be a XML::Document or XML::Node");
   }
 
-  TypedData_Get_Struct(document, xmlDoc, &noko_xml_document_data_type, xml_doc);
+  xml_doc = noko_xml_document_unwrap(document);
 
   node = xmlNewDocComment(
            xml_doc,

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -122,7 +122,8 @@ const rb_data_type_t noko_xml_document_data_type = {
     .dmark = mark,
     .dfree = dealloc,
     .dsize = memsize,
-  }
+  },
+  // .flags = RUBY_TYPED_FREE_IMMEDIATELY, // TODO see https://github.com/sparklemotion/nokogiri/issues/2822
 };
 
 static void

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -116,7 +116,7 @@ memsize(const void *data)
   return memsize;
 }
 
-const rb_data_type_t noko_xml_document_data_type = {
+static const rb_data_type_t noko_xml_document_data_type = {
   .wrap_struct_name = "Nokogiri::XML::Document",
   .function = {
     .dmark = mark,
@@ -168,8 +168,7 @@ recursively_remove_namespaces_from_node(xmlNodePtr node)
 static VALUE
 url(VALUE self)
 {
-  xmlDocPtr doc;
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, doc);
+  xmlDocPtr doc = noko_xml_document_unwrap(self);
 
   if (doc->URL) { return NOKOGIRI_STR_NEW2(doc->URL); }
 
@@ -188,7 +187,7 @@ rb_xml_document_root_set(VALUE self, VALUE rb_new_root)
   xmlDocPtr c_document;
   xmlNodePtr c_new_root = NULL, c_current_root;
 
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, c_document);
+  c_document = noko_xml_document_unwrap(self);
 
   c_current_root = xmlDocGetRootElement(c_document);
   if (c_current_root) {
@@ -232,7 +231,7 @@ rb_xml_document_root(VALUE self)
   xmlDocPtr c_document;
   xmlNodePtr c_root;
 
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, c_document);
+  c_document = noko_xml_document_unwrap(self);
 
   c_root = xmlDocGetRootElement(c_document);
   if (!c_root) {
@@ -251,8 +250,7 @@ rb_xml_document_root(VALUE self)
 static VALUE
 set_encoding(VALUE self, VALUE encoding)
 {
-  xmlDocPtr doc;
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, doc);
+  xmlDocPtr doc = noko_xml_document_unwrap(self);
 
   if (doc->encoding) {
     xmlFree(DISCARD_CONST_QUAL_XMLCHAR(doc->encoding));
@@ -272,8 +270,7 @@ set_encoding(VALUE self, VALUE encoding)
 static VALUE
 encoding(VALUE self)
 {
-  xmlDocPtr doc;
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, doc);
+  xmlDocPtr doc = noko_xml_document_unwrap(self);
 
   if (!doc->encoding) { return Qnil; }
   return NOKOGIRI_STR_NEW2(doc->encoding);
@@ -288,8 +285,7 @@ encoding(VALUE self)
 static VALUE
 version(VALUE self)
 {
-  xmlDocPtr doc;
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, doc);
+  xmlDocPtr doc = noko_xml_document_unwrap(self);
 
   if (!doc->version) { return Qnil; }
   return NOKOGIRI_STR_NEW2(doc->version);
@@ -411,7 +407,7 @@ duplicate_document(int argc, VALUE *argv, VALUE self)
     level = INT2NUM((long)1);
   }
 
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, doc);
+  doc = noko_xml_document_unwrap(self);
 
   dup = xmlCopyDoc(doc, (int)NUM2INT(level));
 
@@ -484,8 +480,7 @@ new (int argc, VALUE *argv, VALUE klass)
 static VALUE
 remove_namespaces_bang(VALUE self)
 {
-  xmlDocPtr doc ;
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, doc);
+  xmlDocPtr doc = noko_xml_document_unwrap(self);
 
   recursively_remove_namespaces_from_node((xmlNodePtr)doc);
   return self;
@@ -513,7 +508,7 @@ create_entity(int argc, VALUE *argv, VALUE self)
   xmlEntityPtr ptr;
   xmlDocPtr doc ;
 
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, doc);
+  doc = noko_xml_document_unwrap(self);
 
   rb_scan_args(argc, argv, "14", &name, &type, &external_id, &system_id,
                &content);
@@ -601,7 +596,7 @@ rb_xml_document_canonicalize(int argc, VALUE *argv, VALUE self)
     }
   }
 
-  TypedData_Get_Struct(self, xmlDoc, &noko_xml_document_data_type, c_doc);
+  c_doc = noko_xml_document_unwrap(self);
 
   rb_cStringIO = rb_const_get_at(rb_cObject, rb_intern("StringIO"));
   rb_io = rb_class_new_instance(0, 0, rb_cStringIO);
@@ -682,6 +677,13 @@ noko_xml_document_wrap(VALUE klass, xmlDocPtr doc)
   return noko_xml_document_wrap_with_init_args(klass, doc, 0, NULL);
 }
 
+xmlDocPtr
+noko_xml_document_unwrap(VALUE rb_document)
+{
+  xmlDocPtr c_document;
+  TypedData_Get_Struct(rb_document, xmlDoc, &noko_xml_document_data_type, c_document);
+  return c_document;
+}
 
 void
 noko_xml_document_pin_node(xmlNodePtr node)

--- a/ext/nokogiri/xml_document_fragment.c
+++ b/ext/nokogiri/xml_document_fragment.c
@@ -19,7 +19,7 @@ new (int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "1*", &document, &rest);
 
-  TypedData_Get_Struct(document, xmlDoc, &noko_xml_document_data_type, xml_doc);
+  xml_doc = noko_xml_document_unwrap(document);
 
   node = xmlNewDocFragment(xml_doc->doc);
 

--- a/ext/nokogiri/xml_dtd.c
+++ b/ext/nokogiri/xml_dtd.c
@@ -139,7 +139,7 @@ validate(VALUE self, VALUE document)
   VALUE error_list;
 
   Noko_Node_Get_Struct(self, xmlDtd, dtd);
-  Noko_Node_Get_Struct(document, xmlDoc, doc);
+  doc = noko_xml_document_unwrap(document);
   error_list = rb_ary_new();
 
   ctxt = xmlNewValidCtxt();

--- a/ext/nokogiri/xml_element_content.c
+++ b/ext/nokogiri/xml_element_content.c
@@ -4,6 +4,7 @@ VALUE cNokogiriXmlElementContent;
 
 const rb_data_type_t element_content_data_type = {
   .wrap_struct_name = "Nokogiri::XML::ElementContent",
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 /*

--- a/ext/nokogiri/xml_element_content.c
+++ b/ext/nokogiri/xml_element_content.c
@@ -2,7 +2,7 @@
 
 VALUE cNokogiriXmlElementContent;
 
-const rb_data_type_t element_content_data_type = {
+static const rb_data_type_t element_content_data_type = {
   .wrap_struct_name = "Nokogiri::XML::ElementContent",
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };

--- a/ext/nokogiri/xml_encoding_handler.c
+++ b/ext/nokogiri/xml_encoding_handler.c
@@ -15,7 +15,7 @@ static const rb_data_type_t xml_encoding_handler_type = {
   .function = {
     .dfree = xml_encoding_handler_dealloc,
   },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 

--- a/ext/nokogiri/xml_entity_reference.c
+++ b/ext/nokogiri/xml_entity_reference.c
@@ -20,7 +20,7 @@ new (int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "2*", &document, &name, &rest);
 
-  TypedData_Get_Struct(document, xmlDoc, &noko_xml_document_data_type, xml_doc);
+  xml_doc = noko_xml_document_unwrap(document);
 
   node = xmlNewReference(
            xml_doc,

--- a/ext/nokogiri/xml_namespace.c
+++ b/ext/nokogiri/xml_namespace.c
@@ -56,21 +56,20 @@ _xml_namespace_update_references(void *ptr)
 #endif
 
 static const rb_data_type_t nokogiri_xml_namespace_type_with_dealloc = {
-  "Nokogiri/XMLNamespace/WithDealloc",
-  {0, _xml_namespace_dealloc, 0, _xml_namespace_update_references},
-  0, 0,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
-  RUBY_TYPED_FREE_IMMEDIATELY,
-#endif
+  .wrap_struct_name = "Nokogiri::XML::Namespace#with_dealloc",
+  .function = {
+    .dfree = _xml_namespace_dealloc,
+    .dcompact = _xml_namespace_update_references,
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static const rb_data_type_t nokogiri_xml_namespace_type_without_dealloc = {
-  "Nokogiri/XMLNamespace/WithoutDealloc",
-  {0, 0, 0, _xml_namespace_update_references},
-  0, 0,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
-  RUBY_TYPED_FREE_IMMEDIATELY,
-#endif
+  .wrap_struct_name = "Nokogiri::XML::Namespace#without_dealloc",
+  .function = {
+    .dcompact = _xml_namespace_update_references,
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 /*

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -43,12 +43,12 @@ _xml_node_update_references(void *ptr)
 #endif
 
 static const rb_data_type_t nokogiri_node_type = {
-  "Nokogiri/XMLNode",
-  {_xml_node_mark, 0, 0, _xml_node_update_references},
-  0, 0,
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
-  RUBY_TYPED_FREE_IMMEDIATELY,
-#endif
+  .wrap_struct_name = "Nokogiri::XML::Node",
+  .function = {
+    .dmark = _xml_node_mark,
+    .dcompact = _xml_node_update_references,
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 static void

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -984,7 +984,7 @@ duplicate_node(int argc, VALUE *argv, VALUE self)
   if (n_args < 2) {
     new_parent_doc = node->doc;
   } else {
-    TypedData_Get_Struct(r_new_parent_doc, xmlDoc, &noko_xml_document_data_type, new_parent_doc);
+    new_parent_doc = noko_xml_document_unwrap(r_new_parent_doc);
   }
 
   dup = xmlDocCopyNode(node, new_parent_doc, level);

--- a/ext/nokogiri/xml_node_set.c
+++ b/ext/nokogiri/xml_node_set.c
@@ -81,7 +81,7 @@ static const rb_data_type_t xml_node_set_type = {
     .dmark = xml_node_set_mark,
     .dfree = xml_node_set_deallocate,
   },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 static void

--- a/ext/nokogiri/xml_processing_instruction.c
+++ b/ext/nokogiri/xml_processing_instruction.c
@@ -22,7 +22,7 @@ new (int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "3*", &document, &name, &content, &rest);
 
-  TypedData_Get_Struct(document, xmlDoc, &noko_xml_document_data_type, xml_doc);
+  xml_doc = noko_xml_document_unwrap(document);
 
   node = xmlNewDocPI(
            xml_doc,

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -14,7 +14,7 @@ static const rb_data_type_t xml_reader_type = {
   .function = {
     .dfree = xml_reader_deallocate,
   },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static int

--- a/ext/nokogiri/xml_relax_ng.c
+++ b/ext/nokogiri/xml_relax_ng.c
@@ -32,7 +32,7 @@ validate_document(VALUE self, VALUE document)
   xmlRelaxNGValidCtxtPtr valid_ctxt;
 
   TypedData_Get_Struct(self, xmlRelaxNG, &xml_relax_ng_type, schema);
-  TypedData_Get_Struct(document, xmlDoc, &noko_xml_document_data_type, doc);
+  doc = noko_xml_document_unwrap(document);
 
   errors = rb_ary_new();
 
@@ -149,7 +149,7 @@ from_document(int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "11", &rb_document, &rb_parse_options);
 
-  TypedData_Get_Struct(rb_document, xmlDoc, &noko_xml_document_data_type, c_document);
+  c_document = noko_xml_document_unwrap(rb_document);
   c_document = c_document->doc; /* In case someone passes us a node. ugh. */
 
   c_parser_context = xmlRelaxNGNewDocParserCtxt(c_document);

--- a/ext/nokogiri/xml_relax_ng.c
+++ b/ext/nokogiri/xml_relax_ng.c
@@ -14,7 +14,7 @@ static const rb_data_type_t xml_relax_ng_type = {
   .function = {
     .dfree = xml_relax_ng_deallocate,
   },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 /*

--- a/ext/nokogiri/xml_sax_parser.c
+++ b/ext/nokogiri/xml_sax_parser.c
@@ -272,7 +272,7 @@ memsize(const void *data)
 }
 
 /* Used by Nokogiri::XML::SAX::Parser and Nokogiri::HTML::SAX::Parser */
-const rb_data_type_t noko_sax_handler_type = {
+static const rb_data_type_t noko_sax_handler_type = {
   .wrap_struct_name = "Nokogiri::SAXHandler",
   .function = {
     .dfree = RUBY_TYPED_DEFAULT_FREE,
@@ -302,6 +302,14 @@ allocate(VALUE klass)
   handler->initialized = XML_SAX2_MAGIC;
 
   return self;
+}
+
+xmlSAXHandlerPtr
+noko_sax_handler_unwrap(VALUE rb_sax_handler)
+{
+  xmlSAXHandlerPtr c_sax_handler;
+  TypedData_Get_Struct(rb_sax_handler, xmlSAXHandler, &noko_sax_handler_type, c_sax_handler);
+  return c_sax_handler;
 }
 
 void

--- a/ext/nokogiri/xml_sax_parser_context.c
+++ b/ext/nokogiri/xml_sax_parser_context.c
@@ -117,7 +117,7 @@ parse_with(VALUE self, VALUE sax_handler)
   }
 
   Data_Get_Struct(self, xmlParserCtxt, ctxt);
-  TypedData_Get_Struct(sax_handler, xmlSAXHandler, &noko_sax_handler_type, sax);
+  sax = noko_sax_handler_unwrap(sax_handler);
 
   /* Free the sax handler since we'll assign our own */
   if (ctxt->sax && ctxt->sax != (xmlSAXHandlerPtr)&xmlDefaultSAXHandler) {

--- a/ext/nokogiri/xml_sax_push_parser.c
+++ b/ext/nokogiri/xml_sax_push_parser.c
@@ -63,7 +63,7 @@ initialize_native(VALUE self, VALUE _xml_sax, VALUE _filename)
   const char *filename = NULL;
   xmlParserCtxtPtr ctx;
 
-  TypedData_Get_Struct(_xml_sax, xmlSAXHandler, &noko_sax_handler_type, sax);
+  sax = noko_sax_handler_unwrap(_xml_sax);
 
   if (_filename != Qnil) { filename = StringValueCStr(_filename); }
 

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -14,7 +14,7 @@ static const rb_data_type_t xml_schema_type = {
   .function = {
     .dfree = xml_schema_deallocate,
   },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 /*

--- a/ext/nokogiri/xml_text.c
+++ b/ext/nokogiri/xml_text.c
@@ -20,10 +20,18 @@ new (int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "2*", &string, &document, &rest);
 
-  Noko_Node_Get_Struct(document, xmlDoc, doc);
+  if (rb_obj_is_kind_of(document, cNokogiriXmlDocument)) {
+    doc = noko_xml_document_unwrap(document);
+  } else {
+    xmlNodePtr deprecated_node_type_arg;
+    // TODO: deprecate allowing Node
+    NOKO_WARN_DEPRECATION("Passing a Node as the second parameter to Text.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
+    Noko_Node_Get_Struct(document, xmlNode, deprecated_node_type_arg);
+    doc = deprecated_node_type_arg->doc;
+  }
 
   node = xmlNewText((xmlChar *)StringValueCStr(string));
-  node->doc = doc->doc;
+  node->doc = doc;
 
   noko_xml_document_pin_node(node);
 

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -23,7 +23,7 @@ static const rb_data_type_t xml_xpath_context_type = {
   .function = {
     .dfree = xml_xpath_context_deallocate,
   },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 /* find a CSS class in an HTML element's `class` attribute */

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -79,7 +79,8 @@ parse_stylesheet_doc(VALUE klass, VALUE xmldocobj)
   xmlDocPtr xml, xml_cpy;
   VALUE errstr, exception;
   xsltStylesheetPtr ss ;
-  TypedData_Get_Struct(xmldocobj, xmlDoc, &noko_xml_document_data_type, xml);
+
+  xml = noko_xml_document_unwrap(xmldocobj);
 
   errstr = rb_str_new(0, 0);
   xsltSetGenericErrorFunc((void *)errstr, xslt_generic_error_handler);
@@ -114,12 +115,7 @@ rb_xslt_stylesheet_serialize(VALUE self, VALUE xmlobj)
   int doc_len ;
   VALUE rval ;
 
-  TypedData_Get_Struct(
-    xmlobj,
-    xmlDoc,
-    &noko_xml_document_data_type,
-    xml
-  );
+  xml = noko_xml_document_unwrap(xmlobj);
   TypedData_Get_Struct(
     self,
     nokogiriXsltStylesheetTuple,
@@ -270,7 +266,7 @@ rb_xslt_stylesheet_transform(int argc, VALUE *argv, VALUE self)
 
   Check_Type(paramobj, T_ARRAY);
 
-  TypedData_Get_Struct(xmldoc, xmlDoc, &noko_xml_document_data_type, xml);
+  xml = noko_xml_document_unwrap(xmldoc);
   TypedData_Get_Struct(self, nokogiriXsltStylesheetTuple, &xslt_stylesheet_type, wrapper);
 
   param_len = RARRAY_LEN(paramobj);

--- a/test/xml/test_cdata.rb
+++ b/test/xml/test_cdata.rb
@@ -21,7 +21,9 @@ module Nokogiri
         node = CDATA.new(@xml, "foo")
         assert_equal("foo", node.content)
 
-        node = CDATA.new(@xml.root, "foo")
+        assert_output(nil, /Passing a Node as the first parameter to CDATA\.new is deprecated/) do
+          node = CDATA.new(@xml.root, "foo")
+        end
         assert_equal("foo", node.content)
       end
 

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -88,7 +88,11 @@ module Nokogiri
       def test_schema_from_document_node
         doc = Nokogiri::XML(File.open(PO_SCHEMA_FILE))
         assert(doc)
-        xsd = Nokogiri::XML::Schema.from_document(doc.root)
+        xsd = nil
+
+        assert_output(nil, /Passing a Node as the first parameter to Schema.from_document is deprecated/) do
+          xsd = Nokogiri::XML::Schema.from_document(doc.root)
+        end
         assert_instance_of(Nokogiri::XML::Schema, xsd)
       end
 

--- a/test/xml/test_text.rb
+++ b/test/xml/test_text.rb
@@ -31,8 +31,12 @@ module Nokogiri
       def test_new_without_document
         doc = Document.new
         node = Nokogiri::XML::Element.new("foo", doc)
+        new_node = nil
 
-        assert(Text.new("hello world", node))
+        assert_output(nil, /Passing a Node as the second parameter to Text.new is deprecated/) do
+          new_node = Text.new("hello world", node)
+        end
+        assert(new_node)
       end
 
       def test_content=


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See #2808 

 - use WB_PROTECTED on all of the classes that don't declare mark functions
 - consistently use a method to unwrap rather than extern the data type struct

Note that being more rigorous about types caught a few places where we were being sloppy about accepting Node arguments where Document was expected; and those places have been deprecated with warning messages (see CHANGELOG).

**Have you included adequate test coverage?**

Tests updated to reflect deprecated argument types.

**Does this change affect the behavior of either the C or the Java implementations?**

Deprecation warnings added to both C and Java.