### PR TITLE
cleanup: update memcheck suppression with correct function name

### DIFF
--- a/ext/java/nokogiri/NokogiriService.java
+++ b/ext/java/nokogiri/NokogiriService.java
@@ -227,7 +227,6 @@ public class NokogiriService implements BasicLibraryService
   {
     RubyClass stylesheet = xsltModule.defineClassUnder("Stylesheet", ruby.getObject(), XSLT_STYLESHEET_ALLOCATOR);
     stylesheet.defineAnnotatedMethods(XsltStylesheet.class);
-    xsltModule.defineAnnotatedMethod(XsltStylesheet.class, "register");
   }
 
   public static final ObjectAllocator HTML_DOCUMENT_ALLOCATOR = new ObjectAllocator()

--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -345,17 +345,4 @@ public class XsltStylesheet extends RubyObject
     if (arg instanceof XmlDocument) { return; }
     throw runtime.newArgumentError("argument must be a Nokogiri::XML::Document");
   }
-
-  @JRubyMethod(name = {"registr", "register"}, meta = true)
-  public static IRubyObject
-  register(ThreadContext context, IRubyObject cls, IRubyObject uri, IRubyObject receiver)
-  {
-    throw context.getRuntime().newNotImplementedError("Nokogiri::XSLT.register method is not implemented");
-    /* When API conflict is solved, this method should be below:
-    // ThreadContext is used while executing xslt extension function
-    registry.put("context", context);
-    registry.put("receiver", receiver);
-    return context.getRuntime().getNil();
-    */
-  }
 }

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -368,14 +368,9 @@ shutdownFunc(xsltTransformContextPtr ctxt,
   rb_ary_clear(wrapper->func_instances);
 }
 
-/*
- *  call-seq:
- *    register(uri, custom_handler_class)
- *
- *  Register a class that implements custom XSLT transformation functions.
- */
+/* docstring is in lib/nokogiri/xslt.rb */
 static VALUE
-rb_xslt_stylesheet_s_register(VALUE self, VALUE uri, VALUE obj)
+rb_xslt_s_register(VALUE self, VALUE uri, VALUE obj)
 {
   VALUE modules = rb_iv_get(self, "@modules");
   if (NIL_P(modules)) {
@@ -394,7 +389,7 @@ rb_xslt_stylesheet_s_register(VALUE self, VALUE uri, VALUE obj)
 void
 noko_init_xslt_stylesheet(void)
 {
-  rb_define_singleton_method(mNokogiriXslt, "register", rb_xslt_stylesheet_s_register, 2);
+  rb_define_singleton_method(mNokogiriXslt, "register", rb_xslt_s_register, 2);
   rb_iv_set(mNokogiriXslt, "@modules", rb_hash_new());
 
   cNokogiriXsltStylesheet = rb_define_class_under(mNokogiriXslt, "Stylesheet", rb_cObject);

--- a/suppressions/ruby.supp
+++ b/suppressions/ruby.supp
@@ -110,14 +110,14 @@
 {
   TODO
   # 128 bytes in 1 blocks are definitely lost in loss record 26,649 of 37,883
-  # *rb_xslt_stylesheet_s_register (xslt_stylesheet.c:385)
+  # *rb_xslt_s_register (xslt_stylesheet.c:373)
   Memcheck:Leak
   fun:malloc
   fun:objspace_xmalloc0
   ...
   fun:ar_alloc_table
   fun:rb_hash_aset
-  fun:rb_xslt_stylesheet_s_register
+  fun:rb_xslt_s_register
 }
 {
   TODO


### PR DESCRIPTION

**What problem is this PR intended to solve?**

After renaming the function in c75c0dce we need to update the suppression file. But while I was in here, I cleaned some things up:

- function name for `XSLT.register` is now `rb_xslt_s_register`
- improve the test coverage for XSLT custom functions
- add complete usage to the docstrings for XSLT custom functions
- remove the JRuby native stub for XSLT.register

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

No behavior changes.