### PR TITLE
fix tests for upstream libxml2 handling of HTML4 namespaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,12 +199,20 @@ NOKOGIRI_TEST_GC_LEVEL=stress bundle exec rake compile test
 
 ### libxml2 advanced usage
 
-If you want to build Nokogiri against a modified version of libxml2, clone libxml2 to `../libxml2` and then run `scripts/compile-against-libxml2-source`.
+If you want to build Nokogiri against a modified version of libxml2 or libxslt, clone them both into sibling directories (`../libxml2` and `../libxslt`) then run `scripts/compile-against-libxml2-source`.
 
-That script also takes an optional command to run with the proper environment variables set to use the local libxml2 library, which can be useful when trying to `git bisect` against libxml2. So, for example:
+That script also takes an optional command to run with the proper environment variables set to use the local libxml2 library, which can be useful when trying to `git bisect` against libxml2 or libxslt. So, for example:
 
 ``` sh
 scripts/compile-against-libxml2-source bundle exec rake test
+```
+
+An alternative, if you're not bisecting or hacking on libxml2 or libxslt, is:
+
+``` sh
+bundle exec rake compile -- \
+  --with-xslt-source-dir=$(pwd)/../libxslt \
+  --with-xml2-source-dir=$(pwd)/../libxml2
 ```
 
 

--- a/scripts/compile-against-libxml2-source
+++ b/scripts/compile-against-libxml2-source
@@ -1,12 +1,17 @@
 #! /usr/bin/env bash
-
+#
+#  Use this script to build libxml2 and libxslt from source, and then compile and link Nokogiri against them.
+#  Unless you're hacking on those libraries, consider using this command instead:
+#
+#    bundle exec rake compile -- \\
+#      --with-xslt-source-dir=$(pwd)/../libxslt \\
+#      --with-xml2-source-dir=$(pwd)/../libxml2
+#
 set -eu
 
 PREFIX="${HOME}/tmp/libxml2"
 rm -rf "${PREFIX}"
 mkdir -p "$PREFIX"
-
-pushd ../libxml2
 
 clean_p=0
 if [[ ${1:-} == "--clean" ]] ; then
@@ -14,31 +19,44 @@ if [[ ${1:-} == "--clean" ]] ; then
   shift
 fi
 
-if [[ $clean_p -gt 0 ]] ; then
+function clean_and_configure_libxml2 {
   make clean || true
 
   ./configure --prefix="${PREFIX}" --without-python --without-readline --with-c14n --with-debug --with-threads --with-iconv=yes --host=x86_64-pc-linux-gnu CFLAGS="-O2 -g -std=c89 -D_XOPEN_SOURCE=700"
+}
+
+function clean_and_configure_libxslt {
+  make clean || true
+
+  ./configure --prefix="${PREFIX}" --without-python --with-debug --host=x86_64-pc-linux-gnu CFLAGS="-O2 -g -std=c89 -D_XOPEN_SOURCE=700"
+}
+
+# libxml2
+pushd ../libxml2
+if [[ $clean_p -gt 0 ]] ; then
+  clean_and_configure_libxml2
 fi
-
 make install
+popd
 
+# libxslt
+pushd ../libxslt
+if [[ $clean_p -gt 0 ]] ; then
+  clean_and_configure_libxslt
+fi
+make install
 popd
 
 export LD_LIBRARY_PATH=${PREFIX}/lib
-export CFLAGS="-I${PREFIX}/include/libxml2"
-export LDFLAGS="-lxml2 -L${PREFIX}/lib"
-
-echo export LD_LIBRARY_PATH=${PREFIX}/lib
-echo export CFLAGS="-I${PREFIX}/include/libxml2"
-echo export LDFLAGS="-lxml2 -L${PREFIX}/lib"
+export CFLAGS="-I${PREFIX}/include/libxml2 -I${PREFIX}/include"
+export LDFLAGS="-lxml2 -lxslt -L${PREFIX}/lib"
 
 if [[ $clean_p -gt 0 ]] ; then
   bundle exec rake clean
 fi
 
-NOKOGIRI_USE_SYSTEM_LIBRARIES=t bundle exec rake compile
+bundle exec rake compile -- --enable-system-libraries
 
 if [[ ${1:-} != "" ]] ; then
   $*
 fi
-

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -1168,7 +1168,10 @@ module Nokogiri
           node = html.at("div").children.first
           refute_nil(node)
 
-          if Nokogiri.uses_libxml?(">= 2.9.12")
+          if Nokogiri.uses_libxml?(">= 2.11.0") || Nokogiri.jruby?
+            assert_empty(node.namespaces.keys)
+            assert_equal("<o:p>foo</o:p>", node.to_html)
+          elsif Nokogiri.uses_libxml?(">= 2.9.12")
             assert_empty(node.namespaces.keys)
             assert_equal("<p>foo</p>", node.to_html)
           elsif Nokogiri.uses_libxml?
@@ -1176,9 +1179,6 @@ module Nokogiri
             assert(node.namespaces.key?("xmlns:o"))
             assert_nil(node.namespaces["xmlns:o"])
             assert_equal("<p>foo</p>", node.to_html)
-          else # jruby
-            assert_empty(node.namespaces.keys)
-            assert_equal("<o:p>foo</o:p>", node.to_html)
           end
         end
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See #2836 for more context. Upstream libxml2 is changing how namespaces are handled. For background see https://gitlab.gnome.org/GNOME/libxml2/-/commit/d7d0bc6581e332f49c9ff628f548eced03c65189

This PR updates the tests to handle both older and newer libxml2 behaviors. At some point, we will likely have to update downstream loofah and rails-html-sanitizer tests, but I'll wait for an official libxml2 release to do that.

Closes #2836 

**Have you included adequate test coverage?**

The important change here is to preserve existing test coverage.


**Does this change affect the behavior of either the C or the Java implementations?**

No behavioral changes are _introduced_, but when libxml2 2.11.0 finally ships with the relevant change, the behavior of the C extension will finally match the behavior of the Java extension. :tada: 