### PR TITLE
dep(style): rubocop-packaging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-minitest
+  - rubocop-packaging
   - rubocop-performance
   - rubocop-rake
 inherit_gem:

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development do
   if Gem::Requirement.new("~> 3.0").satisfied_by?(Gem::Version.new(RUBY_VERSION))
     gem "rubocop", "1.48.1"
     gem "rubocop-minitest", "0.29.0"
+    gem "rubocop-packaging", "0.5.2"
     gem "rubocop-performance", "1.16.0"
     gem "rubocop-rake", "= 0.6.0"
     gem "rubocop-shopify", "2.12.0"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Use `rubocop-packaging` to ensure Nokogiri continues to be easy to repackage.
