### PR TITLE
gumbo: update adjusted foreign attributes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,8 @@
+# [submodule "test/html5lib-tests"]
+# 	path = test/html5lib-tests
+# 	url = https://github.com/html5lib/html5lib-tests.git
+# 	branch = master
 [submodule "test/html5lib-tests"]
 	path = test/html5lib-tests
-	url = https://github.com/html5lib/html5lib-tests.git
-	branch = master
+	url = https://github.com/flavorjones/html5lib-tests.git
+	branch = flavorjones-fix-template-2023-04

--- a/gumbo-parser/src/foreign_attrs.c
+++ b/gumbo-parser/src/foreign_attrs.c
@@ -1,6 +1,6 @@
 /* ANSI-C code produced by gperf version 3.1 */
 /* Command-line: gperf -m100 -n src/foreign_attrs.gperf  */
-/* Computed positions: -k'2,8' */
+/* Computed positions: -k'8-9' */
 /* Filtered by: gperf-filter.sed */
 
 #include "replacement.h"
@@ -29,9 +29,9 @@ hash (register const char *str, register size_t len)
       11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
       11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
       11, 11, 11, 11, 11, 11, 11, 11, 11,  2,
-      11, 10, 11,  9,  7,  6, 11, 11,  1,  0,
-      11,  5, 11, 11,  4, 11, 11, 11, 11, 11,
-      11,  3, 11, 11, 11, 11, 11, 11, 11, 11,
+      11,  1, 11, 10,  4,  4, 11, 11,  3, 11,
+      11,  5,  3, 11,  0, 11,  2, 11, 11, 11,
+      11,  2, 11, 11, 11, 11, 11, 11, 11, 11,
       11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
       11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
       11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
@@ -51,15 +51,14 @@ hash (register const char *str, register size_t len)
   switch (len)
     {
       default:
+        hval += asso_values[(unsigned char)str[8]];
+      /*FALLTHROUGH*/
+      case 8:
         hval += asso_values[(unsigned char)str[7]];
       /*FALLTHROUGH*/
       case 7:
       case 6:
       case 5:
-      case 4:
-      case 3:
-      case 2:
-        hval += asso_values[(unsigned char)str[1]];
         break;
     }
   return hval;
@@ -70,21 +69,21 @@ gumbo_get_foreign_attr_replacement (register const char *str, register size_t le
 {
   static const unsigned char lengthtable[] =
     {
-       5, 11,  9, 13, 10, 10, 10, 11, 10,  8,  8
+       5, 10, 13,  9, 13, 10, 11, 11, 10, 10,  8
     };
   static const ForeignAttrReplacement wordlist[] =
     {
       {"xmlns", "xmlns", GUMBO_ATTR_NAMESPACE_XMLNS},
-      {"xmlns:xlink", "xlink", GUMBO_ATTR_NAMESPACE_XMLNS},
+      {"xlink:href", "href", GUMBO_ATTR_NAMESPACE_XLINK},
+      {"xlink:arcrole", "arcrole", GUMBO_ATTR_NAMESPACE_XLINK},
       {"xml:space", "space", GUMBO_ATTR_NAMESPACE_XML},
       {"xlink:actuate", "actuate", GUMBO_ATTR_NAMESPACE_XLINK},
       {"xlink:type", "type", GUMBO_ATTR_NAMESPACE_XLINK},
-      {"xlink:href", "href", GUMBO_ATTR_NAMESPACE_XLINK},
-      {"xlink:role", "role", GUMBO_ATTR_NAMESPACE_XLINK},
       {"xlink:title", "title", GUMBO_ATTR_NAMESPACE_XLINK},
+      {"xmlns:xlink", "xlink", GUMBO_ATTR_NAMESPACE_XMLNS},
+      {"xlink:role", "role", GUMBO_ATTR_NAMESPACE_XLINK},
       {"xlink:show", "show", GUMBO_ATTR_NAMESPACE_XLINK},
-      {"xml:lang", "lang", GUMBO_ATTR_NAMESPACE_XML},
-      {"xml:base", "base", GUMBO_ATTR_NAMESPACE_XML}
+      {"xml:lang", "lang", GUMBO_ATTR_NAMESPACE_XML}
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)

--- a/gumbo-parser/src/foreign_attrs.gperf
+++ b/gumbo-parser/src/foreign_attrs.gperf
@@ -15,12 +15,12 @@ ForeignAttrReplacement;
 
 %%
 "xlink:actuate", "actuate", GUMBO_ATTR_NAMESPACE_XLINK
+"xlink:arcrole", "arcrole", GUMBO_ATTR_NAMESPACE_XLINK
 "xlink:href", "href", GUMBO_ATTR_NAMESPACE_XLINK
 "xlink:role", "role", GUMBO_ATTR_NAMESPACE_XLINK
 "xlink:show", "show", GUMBO_ATTR_NAMESPACE_XLINK
 "xlink:title", "title", GUMBO_ATTR_NAMESPACE_XLINK
 "xlink:type", "type", GUMBO_ATTR_NAMESPACE_XLINK
-"xml:base", "base", GUMBO_ATTR_NAMESPACE_XML
 "xml:lang", "lang", GUMBO_ATTR_NAMESPACE_XML
 "xml:space", "space", GUMBO_ATTR_NAMESPACE_XML
 "xmlns", "xmlns", GUMBO_ATTR_NAMESPACE_XMLNS

--- a/test/html5/test_tree_construction.rb
+++ b/test/html5/test_tree_construction.rb
@@ -30,7 +30,7 @@ class TestHtml5TreeConstructionBase < Nokogiri::TestCase
         else
           attributes[attr[:name]].value
         end
-        assert_equal(attr[:value], value)
+        assert_equal(attr[:value], value, "expected #{attr}[:value] to equal #{value.inspect}")
       end
       assert_equal(
         node[:children].length,
@@ -117,7 +117,12 @@ class TestHtml5TreeConstructionBase < Nokogiri::TestCase
     end
 
     # Test the errors.
-    assert_equal(@test[:errors].length, doc.errors.length, "Wrong number of errors for #{@test[:data]}")
+    errpayload = doc.errors.map(&:to_s).join("\n")
+    assert_equal(
+      @test[:errors].length,
+      doc.errors.length,
+      "Expected #{@test[:errors].length} errors for #{@test[:data]}, found:\n#{errpayload}",
+    )
 
     # The new, standardized tokenizer errors live in @test[:new_errors]. Let's
     # match each one to exactly one error in doc.errors. Unfortunately, the


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Partial fix for #2841

A test recently added upstream showed that the list of foreign attributes gumbo is adjusting needed to be updated. Specifically:

- add `xlink:arcrole`
- remove `xml:base`

(see https://html.spec.whatwg.org/multipage/parsing.html#adjust-foreign-attributes)

I've also pinned (for now) to my branch of html5lib-tests, and improved some of the error messages from the tree construction test wrapper.

**Have you included adequate test coverage?**

This PR is all about the tests! :tada: 

**Does this change affect the behavior of either the C or the Java implementations?**

The HTML5/gumbo functionality changed, but this does not exist in the Java implementation.
