### PR TITLE
fix(jruby): first_element_child properly returns nil

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -762,14 +762,14 @@ public class XmlNode extends RubyObject
     if (children.getLength() == 0) {
       return Collections.emptyList();
     }
-    ArrayList<Node> elements = firstOnly ? null : new ArrayList<Node>(children.getLength());
+    ArrayList<Node> elements = new ArrayList<Node>();
     for (int i = 0; i < children.getLength(); i++) {
       Node child = children.item(i);
       if (child.getNodeType() == Node.ELEMENT_NODE) {
-        if (firstOnly) {
-          return Collections.singletonList(child);
-        }
         elements.add(child);
+        if (firstOnly) {
+          return elements;
+        }
       }
     }
     return elements;

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -16,6 +16,11 @@ module Nokogiri
           assert_predicate(node, :element?, "node is an element")
         end
 
+        def test_first_element_child_with_no_match
+          doc = Nokogiri::XML::Document.parse("<root>asdf</root>")
+          assert_nil(doc.root.first_element_child)
+        end
+
         def test_element_children
           nodes = xml.root.element_children
           assert_equal(xml.root.first_element_child, nodes.first)
@@ -25,6 +30,11 @@ module Nokogiri
         def test_last_element_child
           nodes = xml.root.element_children
           assert_equal(nodes.last, xml.root.element_children.last)
+        end
+
+        def test_last_element_child_with_no_match
+          doc = Nokogiri::XML::Document.parse("<root>asdf</root>")
+          assert_nil(doc.root.last_element_child)
         end
 
         def test_bad_xpath


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes #2802 

On JRuby, `first_element_child` properly returns nil when only non-element children exist. Previously this NPEd.

**Have you included adequate test coverage?**

Yes!


**Does this change affect the behavior of either the C or the Java implementations?**

This brings the Java implementation into alignment with the C implementation.
