### PR TITLE
dep: update libxml2 to 2.10.4 from 2.10.3

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,7 +1,7 @@
 libxml2:
-  version: "2.10.3"
-  sha256: "5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.3.sha256sum
+  version: "2.10.4"
+  sha256: "ed0c91c5845008f1936739e4eee2035531c1c94742c6541f44ee66d885948d45"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.4.sha256sum
 
 libxslt:
   version: "1.1.37"

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -1178,7 +1178,7 @@ module Nokogiri
           node = html.at("div").children.first
           refute_nil(node)
 
-          if Nokogiri.uses_libxml?(">= 2.11.0") || Nokogiri.jruby?
+          if Nokogiri.uses_libxml?(">= 2.10.4") || Nokogiri.jruby?
             assert_empty(node.namespaces.keys)
             assert_equal("<o:p>foo</o:p>", node.to_html)
           elsif Nokogiri.uses_libxml?(">= 2.9.12")


### PR DESCRIPTION
**What problem is this PR intended to solve?**

https://github.com/sparklemotion/nokogiri/issues/2851 update libxml2 to 2.10.4 from 2.10.3

and update a test which assumed a behavior change was going to go into 2.11.0 but ended up in this release
