### PR TITLE
test: update html5lib-tests back to origin/master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,4 @@
-# [submodule "test/html5lib-tests"]
-# 	path = test/html5lib-tests
-# 	url = https://github.com/html5lib/html5lib-tests.git
-# 	branch = master
 [submodule "test/html5lib-tests"]
 	path = test/html5lib-tests
-	url = https://github.com/flavorjones/html5lib-tests.git
-	branch = flavorjones-fix-template-2023-04
+	url = https://github.com/html5lib/html5lib-tests.git
+	branch = master


### PR DESCRIPTION
**What problem is this PR intended to solve?**

update html5lib-tests back to origin/master now that upstream fixes have been applied in https://github.com/html5lib/html5lib-tests/pull/165
