### PR TITLE
jruby: some cleanup / refactoring

### DIFF
--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -79,14 +79,12 @@ public class XsltStylesheet extends RubyObject
   private void
   addParametersToTransformer(ThreadContext context, Transformer transf, IRubyObject parameters)
   {
-    Ruby runtime = context.getRuntime();
-
     if (parameters instanceof RubyHash) {
       setHashParameters(transf, (RubyHash)parameters);
     } else if (parameters instanceof RubyArray) {
-      setArrayParameters(transf, runtime, (RubyArray)parameters);
+      setArrayParameters(transf, context, (RubyArray)parameters);
     } else {
-      throw runtime.newTypeError("parameters should be given either Array or Hash");
+      throw context.getRuntime().newTypeError("parameters should be given either Array or Hash");
     }
   }
 
@@ -100,14 +98,14 @@ public class XsltStylesheet extends RubyObject
   }
 
   private void
-  setArrayParameters(Transformer transformer, Ruby runtime, RubyArray<?> params)
+  setArrayParameters(Transformer transformer, ThreadContext context, RubyArray<?> params)
   {
     int limit = params.getLength();
     if (limit % 2 == 1) { limit--; }
 
     for (int i = 0; i < limit; i += 2) {
-      String name = params.aref(runtime.newFixnum(i)).asJavaString();
-      String value = params.aref(runtime.newFixnum(i + 1)).asJavaString();
+      String name = params.aref(context, context.getRuntime().newFixnum(i)).asJavaString();
+      String value = params.aref(context, context.getRuntime().newFixnum(i + 1)).asJavaString();
       transformer.setParameter(name, unparseValue(value));
     }
   }

--- a/ext/java/nokogiri/internals/HtmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/HtmlDomParserContext.java
@@ -56,9 +56,7 @@ public class HtmlDomParserContext extends XmlDomParserContext
   initParser(Ruby runtime)
   {
     XMLParserConfiguration config = new HTMLConfiguration();
-    //XMLDocumentFilter removeNSAttrsFilter = new RemoveNSAttrsFilter();
     XMLDocumentFilter elementValidityCheckFilter = new ElementValidityCheckFilter(errorHandler);
-    //XMLDocumentFilter[] filters = { removeNSAttrsFilter,  elementValidityCheckFilter};
     XMLDocumentFilter[] filters = { elementValidityCheckFilter};
 
     config.setErrorHandler(this.errorHandler);
@@ -160,29 +158,6 @@ public class HtmlDomParserContext extends XmlDomParserContext
       }
     }
     return null;
-  }
-
-  /**
-   * Filter to strip out attributes that pertain to XML namespaces.
-   */
-  public static class RemoveNSAttrsFilter extends DefaultFilter
-  {
-    @Override
-    public void
-    startElement(QName element, XMLAttributes attrs,
-                 Augmentations augs) throws XNIException
-    {
-      int i;
-      for (i = 0; i < attrs.getLength(); ++i) {
-        if (isNamespace(attrs.getQName(i))) {
-          attrs.removeAttributeAt(i);
-          --i;
-        }
-      }
-
-      element.uri = null;
-      super.startElement(element, attrs, augs);
-    }
   }
 
   public static class ElementValidityCheckFilter extends DefaultFilter

--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -258,16 +258,7 @@ Gem::Specification.new do |spec|
     "lib/nokogiri/html5/document_fragment.rb",
     "lib/nokogiri/html5/node.rb",
     "lib/nokogiri/jruby/dependencies.rb",
-    "lib/nokogiri/jruby/isorelax/isorelax/20030108/isorelax-20030108.jar",
-    "lib/nokogiri/jruby/net/sf/saxon/Saxon-HE/9.6.0-4/Saxon-HE-9.6.0-4.jar",
-    "lib/nokogiri/jruby/net/sourceforge/htmlunit/neko-htmlunit/2.63.0/neko-htmlunit-2.63.0.jar",
     "lib/nokogiri/jruby/nokogiri_jars.rb",
-    "lib/nokogiri/jruby/nu/validator/jing/20200702VNU/jing-20200702VNU.jar",
-    "lib/nokogiri/jruby/org/nokogiri/nekodtd/0.1.11.noko1/nekodtd-0.1.11.noko1.jar",
-    "lib/nokogiri/jruby/xalan/serializer/2.7.2/serializer-2.7.2.jar",
-    "lib/nokogiri/jruby/xalan/xalan/2.7.2/xalan-2.7.2.jar",
-    "lib/nokogiri/jruby/xerces/xercesImpl/2.12.2/xercesImpl-2.12.2.jar",
-    "lib/nokogiri/jruby/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01.jar",
     "lib/nokogiri/syntax_error.rb",
     "lib/nokogiri/version.rb",
     "lib/nokogiri/version/constant.rb",
@@ -313,6 +304,19 @@ Gem::Specification.new do |spec|
     "lib/nokogiri/xslt/stylesheet.rb",
     "lib/xsd/xmlparser/nokogiri.rb",
   ]
+
+  spec.files += Dir.glob([
+    "lib/nokogiri/jruby/isorelax/isorelax/*/isorelax-*.jar",
+    "lib/nokogiri/jruby/net/sf/saxon/Saxon-HE/*/Saxon-HE-*.jar",
+    "lib/nokogiri/jruby/net/sourceforge/htmlunit/neko-htmlunit/*/neko-htmlunit-*.jar",
+    "lib/nokogiri/jruby/nu/validator/jing/*/jing-*.jar",
+    "lib/nokogiri/jruby/org/nokogiri/nekodtd/*/nekodtd-*.jar",
+    "lib/nokogiri/jruby/xalan/serializer/*/serializer-*.jar",
+    "lib/nokogiri/jruby/xalan/xalan/*/xalan-*.jar",
+    "lib/nokogiri/jruby/xerces/xercesImpl/*/xercesImpl-*.jar",
+    "lib/nokogiri/jruby/xml-apis/xml-apis/*/xml-apis-*.jar",
+  ])
+
   spec.bindir = "bin"
   spec.executables = spec.files.grep(/^bin/) { |f| File.basename(f) }
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Written while spiking on #2565, these commits are valuable and should be applied.

- address JRuby 9.4 deprecations
- simplify the jar handling in the gemspec
- remove some unused code


**Have you included adequate test coverage?**

Existing test coverage is sufficient.


**Does this change affect the behavior of either the C or the Java implementations?**

No behavioral changes.