### PR TITLE
Improve gumbo error messages during tree construction

### DIFF
--- a/gumbo-parser/src/error.c
+++ b/gumbo-parser/src/error.c
@@ -91,7 +91,7 @@ static void print_tag_stack (
   const GumboParserError* error,
   GumboStringBuffer* output
 ) {
-  print_message(output, "  Currently open tags: ");
+  print_message(output, " Currently open tags: ");
   for (unsigned int i = 0; i < error->tag_stack.length; ++i) {
     if (i) {
       print_message(output, ", ");
@@ -347,15 +347,19 @@ static void handle_parser_error (
       if (error->parser_state == GUMBO_INSERTION_MODE_INITIAL) {
         print_message(output, "You must provide a doctype");
       } else {
-        print_message(output, "Premature end of file");
+        print_message(output, "Premature end of file.");
         print_tag_stack(error, output);
       }
       return;
     case GUMBO_TOKEN_START_TAG:
-    case GUMBO_TOKEN_END_TAG:
-      print_message(output, "That tag isn't allowed here");
+      print_message(output, "Start tag '%s' isn't allowed here.",
+                    gumbo_normalized_tagname(error->input_tag));
       print_tag_stack(error, output);
-      // TODO(jdtang): Give more specific messaging.
+      return;
+    case GUMBO_TOKEN_END_TAG:
+      print_message(output, "Eng tag '%s' isn't allowed here.",
+                    gumbo_normalized_tagname(error->input_tag));
+      print_tag_stack(error, output);
       return;
   }
 }


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Gumbo tree constructions errors could be improved. In this PR we're adding punctuation, cleaning up whitespace, and naming the input tag.

If the message was:

> 1:13: ERROR: This tag isn't allowed here  Currently open tags: html, body, div, table.

it is now:

> 1:13: ERROR: Start tag 'svg' isn't allowed here. Currently open tags: html, body, div, table.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

No tests exist for error message contents. This is a potential area we could improve in the future.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

No behavioral changes other than the contents of the error message.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
