### PR TITLE
ci: upstream libxml2 testing: windows and ruby_memcheck coverage

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -61,7 +61,6 @@ jobs:
       - run: "bundle exec rake test"
 
   xmlsoft-head-valgrind:
-    needs: ["xmlsoft-head"]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
@@ -90,6 +89,7 @@ jobs:
       - name: "Compile against libxml2 and libxslt source directories"
         run: "bundle exec rake compile -- --with-xml2-source-dir=${GITHUB_WORKSPACE}/libxml2 --with-xslt-source-dir=${GITHUB_WORKSPACE}/libxslt"
       - run: "bundle exec rake test:valgrind"
+      - run: "bundle exec rake test:memcheck"
 
   ruby-head:
     strategy:
@@ -123,7 +123,6 @@ jobs:
       - run: bundle exec rake test
 
   ruby-head-valgrind:
-    needs: ["ruby-head"]
     strategy:
       fail-fast: false
       matrix:
@@ -146,6 +145,7 @@ jobs:
           key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
+      - run: bundle exec rake test:memcheck
 
   jruby-head:
     runs-on: ubuntu-latest

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -23,17 +23,21 @@ jobs:
         with:
           submodules: true
       - name: Setup libxml2
+        env:
+          NOCONFIGURE: t
         run: |
           git clone --depth=1 https://gitlab.gnome.org/GNOME/libxml2
           cd libxml2
           git log -n1
-          env NOCONFIGURE=t ./autogen.sh
+          ./autogen.sh
       - name: Setup libxslt
+        env:
+          NOCONFIGURE: t
         run: |
           git clone --depth=1 https://gitlab.gnome.org/GNOME/libxslt
           cd libxslt
           git log -n1
-          env NOCONFIGURE=t ./autogen.sh
+          ./autogen.sh
       - name: "Run bundle install"
         run: "bundle install --local || bundle install"
       - name: "Compile against libxml2 and libxslt source directories"
@@ -50,17 +54,21 @@ jobs:
         with:
           submodules: true
       - name: Setup libxml2
+        env:
+          NOCONFIGURE: t
         run: |
           git clone --depth=1 https://gitlab.gnome.org/GNOME/libxml2
           cd libxml2
           git log -n1
-          env NOCONFIGURE=t ./autogen.sh
+          ./autogen.sh
       - name: Setup libxslt
+        env:
+          NOCONFIGURE: t
         run: |
           git clone --depth=1 https://gitlab.gnome.org/GNOME/libxslt
           cd libxslt
           git log -n1
-          env NOCONFIGURE=t ./autogen.sh
+          ./autogen.sh
       - name: "Run bundle install"
         run: "bundle install --local || bundle install"
       - name: "Compile against libxml2 and libxslt source directories"

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -15,16 +15,32 @@ on:
 
 jobs:
   xmlsoft-head:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
+    strategy:
+      fail-fast: false
+      matrix:
+        plat: ["ubuntu", "windows", "macos"]
+    runs-on: ${{matrix.plat}}-latest
     steps:
+      - name: configure git crlf
+        if: matrix.plat == 'windows'
+        run: |
+          git config --system core.autocrlf false
+          git config --system core.eol lf
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "3.2"
+          apt-get: "autogen libtool shtool"
+          brew: "automake autogen libtool shtool"
+          mingw: "autotools"
+          bundler-cache: true
+          bundler: latest
       - name: Setup libxml2
         env:
           NOCONFIGURE: t
+        shell: bash
         run: |
           git clone --depth=1 https://gitlab.gnome.org/GNOME/libxml2
           cd libxml2
@@ -33,14 +49,14 @@ jobs:
       - name: Setup libxslt
         env:
           NOCONFIGURE: t
+        shell: bash
         run: |
           git clone --depth=1 https://gitlab.gnome.org/GNOME/libxslt
           cd libxslt
           git log -n1
           ./autogen.sh
-      - name: "Run bundle install"
-        run: "bundle install --local || bundle install"
       - name: "Compile against libxml2 and libxslt source directories"
+        shell: bash
         run: "bundle exec rake compile -- --with-xml2-source-dir=${GITHUB_WORKSPACE}/libxml2 --with-xslt-source-dir=${GITHUB_WORKSPACE}/libxslt"
       - run: "bundle exec rake test"
 

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -15,7 +15,7 @@ PACKAGE_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."
 REQUIRED_LIBXML_VERSION = "2.6.21"
 RECOMMENDED_LIBXML_VERSION = "2.9.3"
 
-REQUIRED_MINI_PORTILE_VERSION = "~> 2.8.0" # keep this version in sync with the one in the gemspec
+REQUIRED_MINI_PORTILE_VERSION = "~> 2.8.2" # keep this version in sync with the one in the gemspec
 REQUIRED_PKG_CONFIG_VERSION = "~> 1.1"
 
 # Keep track of what versions of what libraries we build against

--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -339,7 +339,7 @@ Gem::Specification.new do |spec|
     spec.requirements << "jar xerces, xercesImpl, 2.12.2" # https://search.maven.org/artifact/xerces/xercesImpl
     spec.requirements << "jar xml-apis, xml-apis, 1.4.01" # https://search.maven.org/artifact/xml-apis/xml-apis
   else
-    spec.add_runtime_dependency("mini_portile2", "~> 2.8.0") # keep version in sync with extconf.rb
+    spec.add_runtime_dependency("mini_portile2", "~> 2.8.2") # keep version in sync with extconf.rb
   end
   spec.add_runtime_dependency("racc", "~> 1.4")
 

--- a/suppressions/ruby.supp
+++ b/suppressions/ruby.supp
@@ -126,6 +126,32 @@
   fun:read_memory
 }
 {
+  https://github.com/sparklemotion/nokogiri/actions/runs/4845701723/jobs/8634781681
+  # same as previous warning but on libxml 2.11, I think?
+  # 240 (120 direct, 120 indirect) bytes in 1 blocks are definitely lost in loss record 30,974 of 40,320
+  #   malloc (at /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
+  #   objspace_xmalloc0 (gc.c:12258)
+  #   xmlNewDocNodeEatName (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
+  #   xmlSAX2StartElementNs (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
+  #   <unknown stack frame>
+  #   <unknown stack frame>
+  #   xmlParseContent (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
+  #   xmlParseDocument (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
+  #   xmlReadMemory (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
+  #  *read_memory (xml_document.c:369)
+  Memcheck:Leak
+  fun:malloc
+  fun:objspace_xmalloc0
+  ...
+  fun:xmlNewDocNodeEatName
+  fun:xmlSAX2StartElementNs
+  ...
+  fun:xmlParseContent
+  fun:xmlParseDocument
+  fun:xmlReadMemory
+  fun:read_memory
+}
+{
   TODO
   # 1,464 (72 direct, 1,392 indirect) bytes in 1 blocks are definitely lost in loss record 35,525 of 37,883
   # *xmlXPathWrapNodeSet (xpath.c:4386)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[libxml2 2.11.0 is failing windows builds](https://github.com/sparklemotion/nokogiri/pull/2866), and I think I probably could have caught the problem earlier if I was running the upstream builds on windows. This PR adds that integration testing.

libxml2 is also leaking memory, so this PR also adds `ruby_memcheck` testing on the upstream builds to try to detect these problems earlier.