### PR TITLE
ci: downstream integration testing of ruby-saml

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -45,6 +45,9 @@ jobs:
           - url: https://github.com/pythonicrubyist/creek
             name: creek
             command: "bundle exec rake spec"
+          - url: https://github.com/SAML-Toolkits/ruby-saml
+            name: ruby-saml
+            command: "bundle exec rake test"
           # - url: https://github.com/instructure/nokogiri-xmlsec-instructure
           #   name: nokogiri-xmlsec-instructure
           #   precommand: "apt install -y libxmlsec1-dev"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

It looks like libxml2 master has broken something related to flagging nondeterministic schemas, and in particular is failing a test that was sent by the maintainers of ruby-saml a long time ago.

https://gitlab.gnome.org/GNOME/libxml2/-/commit/a06eaa6119ca5b296b8105dc8c9a34ed5fc1f338

Let's add some coverage for this project, so that we can know if and when libxml2 has broken something.
