### PR TITLE
fix: make sure libxml memory management is set early enough

### DIFF
--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -192,6 +192,10 @@ Init_nokogiri(void)
   mNokogiriXmlXpath = rb_define_module_under(mNokogiriXml, "XPath");
   mNokogiriXslt     = rb_define_module_under(mNokogiri, "XSLT");
 
+  set_libxml_memory_management(); /* must be before any function calls that might invoke xmlInitParser() */
+  xmlInitParser();
+  exsltRegisterAll();
+
   rb_const_set(mNokogiri, rb_intern("LIBXML_COMPILED_VERSION"), NOKOGIRI_STR_NEW2(LIBXML_DOTTED_VERSION));
   rb_const_set(mNokogiri, rb_intern("LIBXML_LOADED_VERSION"), NOKOGIRI_STR_NEW2(xmlParserVersion));
 
@@ -223,11 +227,6 @@ Init_nokogiri(void)
 #ifdef NOKOGIRI_OTHER_LIBRARY_VERSIONS
   rb_const_set(mNokogiri, rb_intern("OTHER_LIBRARY_VERSIONS"), NOKOGIRI_STR_NEW2(NOKOGIRI_OTHER_LIBRARY_VERSIONS));
 #endif
-
-  set_libxml_memory_management();
-
-  xmlInitParser();
-  exsltRegisterAll();
 
   if (xsltExtModuleFunctionLookup((const xmlChar *)"date-time", EXSLT_DATE_NAMESPACE)) {
     rb_const_set(mNokogiri, rb_intern("LIBXSLT_DATETIME_ENABLED"), Qtrue);


### PR DESCRIPTION
**What problem is this PR intended to solve?**

fix: make sure libxml memory management is set early enough to avoid mistakenly calling xmlCleanupParser at exit on windows.

Note that calling `xmlParserVersion` will implicitly call `xmlInitParser` (via `xmlIsMainThread`) on systems with thread support.

Something may have changed in libxml2 since v2.10 around thread detection, because this didn't happen on earlier versions.

Anyway, what is happening with v2.11 is that `xmlInitParser` was being implicitly called before the memory management functions were set, meaning that these lines in parser.c were setting up an atexit memory cleaner:

    if (xmlFree == free)
      atexit(xmlCleanupParser);

which we know is a problem when we're using the ruby memory functions (on versions of ruby without the fix from https://bugs.ruby-lang.org/issues/19580).


**Have you included adequate test coverage?**

Existing coverage is adequate. This change is forward-compatible with libxml v2.11 (see https://github.com/sparklemotion/nokogiri/issues/2865)


**Does this change affect the behavior of either the C or the Java implementations?**

No behavioral changes.