### PR TITLE
feat: gumbo support for `hr` in `select`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,11 @@ You can read more about this in the decision record at `adr/2023-04-libxml-memor
 * [CRuby] The C extension now uses Ruby's [TypedData API](https://docs.ruby-lang.org/en/3.0/extension_rdoc.html#label-Encapsulate+C+Data+into+a+Ruby+Object) for managing all the libxml2 structs. Write barriers may improve GC performance in some extreme cases. [[#2808](https://github.com/sparklemotion/nokogiri/issues/2808)] (Thanks, [@etiennebarrie](https://github.com/etiennebarrie) and [@byroot](https://github.com/byroot)!)
 * [CRuby] `ObjectSpace.memsize_of` reports a pretty good guess of memory usage when called on `Nokogiri::XML::Document` objects. [[#2807](https://github.com/sparklemotion/nokogiri/issues/2807)] (Thanks, [@etiennebarrie](https://github.com/etiennebarrie) and [@byroot](https://github.com/byroot)!)
 * [CRuby] Users installing the "ruby" platform gem and compiling libxml2 and libxslt from source will now be using a modern `config.guess` and `config.sub` that supports new architectures like `loongarch64`. [[#2831](https://github.com/sparklemotion/nokogiri/issues/2831)] (Thanks, [@zhangwenlong8911](https://github.com/zhangwenlong8911)!)
-* [CRuby] HTML5 parser now adjusts the specified attributes, adding `xlink:arcrole` and removing `xml:base` [[#2841](https://github.com/sparklemotion/nokogiri/issues/2841), [#2842](https://github.com/sparklemotion/nokogiri/issues/2842)]
 * [JRuby] `Node#first_element_child` now returns `nil` if there are only non-element children. [[#2808](https://github.com/sparklemotion/nokogiri/issues/2808), [#2844](https://github.com/sparklemotion/nokogiri/issues/2844)]
 * Documentation for `Nokogiri::XSLT` now has usage examples including custom function handlers.
+* [CRuby] HTML5 parser:
+  * adjusts the specified attributes, adding `xlink:arcrole` and removing `xml:base` [[#2841](https://github.com/sparklemotion/nokogiri/issues/2841), [#2842](https://github.com/sparklemotion/nokogiri/issues/2842)]
+  * allows `<hr>` in `<select>` [[whatwg/html#3410](https://github.com/whatwg/html/issues/3410), [whatwg/html#9124](https://github.com/whatwg/html/pull/9124)]
 
 
 ### Deprecated

--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -3964,6 +3964,18 @@ static void handle_in_select(GumboParser* parser, GumboToken* token) {
     insert_element_from_token(parser, token);
     return;
   }
+  if (tag_is(token, kStartTag, GUMBO_TAG_HR)) {
+    if (node_html_tag_is(get_current_node(parser), GUMBO_TAG_OPTION)) {
+      pop_current_node(parser);
+    }
+    if (node_html_tag_is(get_current_node(parser), GUMBO_TAG_OPTGROUP)) {
+      pop_current_node(parser);
+    }
+    insert_element_from_token(parser, token);
+    pop_current_node(parser);
+    acknowledge_self_closing_tag(parser);
+    return;
+  }
   if (tag_is(token, kEndTag, GUMBO_TAG_OPTGROUP)) {
     GumboVector* open_elements = &parser->_parser_state->_open_elements;
     if (

--- a/test/html5/test_tree_construction.rb
+++ b/test/html5/test_tree_construction.rb
@@ -35,7 +35,12 @@ class TestHtml5TreeConstructionBase < Nokogiri::TestCase
       assert_equal(
         node[:children].length,
         ng_node.children.length,
-        "Element <#{node[:tag]}> has wrong number of children #{ng_node.children.map(&:name)} in #{@test[:data]}",
+        [
+          "Element <#{node[:tag]}> has wrong number of children #{ng_node.children.map(&:name)}",
+          "   Input: #{@test[:data]}",
+          "Expected: #{@test[:raw].join("\n          ")}",
+          "  Parsed: #{ng_node.to_html}",
+        ].join("\n"),
       )
     when Nokogiri::XML::Node::TEXT_NODE, Nokogiri::XML::Node::CDATA_SECTION_NODE
       # We preserve the CDATA in the tree, but the tests represent it as text.
@@ -205,8 +210,11 @@ module Html5libTestCaseParser
       children: [],
     }
     open_nodes = [document]
+    test[:raw] = []
     while index < lines.length
       raise(BadHtml5libFormat, "Expected '| ' but got #{lines[index]}") unless /^\| ( *)([^ ].*$)/ =~ lines[index]
+
+      test[:raw] << lines[index]
 
       depth = $LAST_MATCH_INFO[1].length
       if depth.odd?


### PR DESCRIPTION
**What problem is this PR intended to solve?**

feat: gumbo support for `<hr>` in `<select>`

- https://github.com/whatwg/html/issues/3410
- https://github.com/whatwg/html/pull/9124
- https://github.com/html5lib/html5lib-tests/pull/167
- https://github.com/html5lib/html5lib-tests/pull/168

The text added to the parser spec, under ["in select" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inselect), is:

> A start tag whose tag name is "hr"
>
> If the [current node](https://html.spec.whatwg.org/multipage/parsing.html#current-node) is an [option](https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element) element, pop that node from the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements).
>
> If the [current node](https://html.spec.whatwg.org/multipage/parsing.html#current-node) is an [optgroup](https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element) element, pop that node from the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements).
>
> [Insert an HTML element](https://html.spec.whatwg.org/multipage/parsing.html#insert-an-html-element) for the token. Immediately pop the [current node](https://html.spec.whatwg.org/multipage/parsing.html#current-node) off the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements).
>
> [Acknowledge the token's self-closing flag](https://html.spec.whatwg.org/multipage/parsing.html#acknowledge-self-closing-flag), if it is set.

Also improve gumbo tree construction test failure messages.

**Have you included adequate test coverage?**

Yes.


**Does this change affect the behavior of either the C or the Java implementations?**

The HTML5 parser is only available in CRuby.

