### PR TITLE
dep: update ruby_memcheck to 1.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development do
   # tests
   gem "minitest", "5.18.0"
   gem "minitest-reporters", "1.6.0"
-  gem "ruby_memcheck", git: "https://github.com/flavorjones/ruby_memcheck", ref: "flavorjones-nokogiri-huge-parse-option"
+  gem "ruby_memcheck", "1.3.2"
   gem "rubyzip", "~> 2.3.2"
   gem "simplecov", "= 0.21.2"
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

update ruby_memcheck to 1.3.2 for the HUGE parse option fix. we had previously pinned to a PR branch.

https://github.com/Shopify/ruby_memcheck/releases/tag/1.3.2
