### PR TITLE
Move back to release verion of ruby_memcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
       - uses: vmactions/freebsd-vm@v0
         with:
           usesh: true
-          prepare: pkg install -y ruby devel/ruby-gems pkgconf libxml2 libxslt git
+          prepare: pkg install -y ruby devel/ruby-gems pkgconf libxml2 libxslt
           run: |
             gem install bundler
             bundle install --local || bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development do
   # tests
   gem "minitest", "5.18.0"
   gem "minitest-reporters", "1.6.0"
-  gem "ruby_memcheck", git: "https://github.com/flavorjones/ruby_memcheck", ref: "flavorjones-nokogiri-huge-parse-option"
+  gem "ruby_memcheck"
   gem "rubyzip", "~> 2.3.2"
   gem "simplecov", "= 0.21.2"
 

--- a/oci-images/nokogiri-test/ubuntu.dockerfile
+++ b/oci-images/nokogiri-test/ubuntu.dockerfile
@@ -9,12 +9,6 @@ RUN apt-get upgrade -y
 RUN apt-get install -y apt-utils
 
 
-# include_file debian-git.step
-# -*- dockerfile -*-
-
-RUN apt-get install -y git-core
-
-
 # include_file debian-libxml-et-al.step
 # -*- dockerfile -*-
 

--- a/oci-images/nokogiri-test/ubuntu.erb
+++ b/oci-images/nokogiri-test/ubuntu.erb
@@ -2,8 +2,6 @@ FROM ubuntu:focal
 
 <%= include_file "debian-prelude.step" %>
 
-<%= include_file "debian-git.step" %>
-
 <%= include_file "debian-libxml-et-al.step" %>
 
 <%= include_file "debian-ruby.step" %>

--- a/oci-images/nokogiri-test/ubuntu32.dockerfile
+++ b/oci-images/nokogiri-test/ubuntu32.dockerfile
@@ -9,12 +9,6 @@ RUN apt-get upgrade -y
 RUN apt-get install -y apt-utils
 
 
-# include_file debian-git.step
-# -*- dockerfile -*-
-
-RUN apt-get install -y git-core
-
-
 # include_file debian-libxml-et-al.step
 # -*- dockerfile -*-
 

--- a/oci-images/nokogiri-test/ubuntu32.erb
+++ b/oci-images/nokogiri-test/ubuntu32.erb
@@ -2,8 +2,6 @@ FROM i386/ubuntu:focal
 
 <%= include_file "debian-prelude.step" %>
 
-<%= include_file "debian-git.step" %>
-
 <%= include_file "debian-libxml-et-al.step" %>
 
 <%= include_file "debian-ruby.step" %>


### PR DESCRIPTION
Shopify/ruby_memcheck#16 has been merged and released, so we can move back to released version of ruby_memcheck.

