### PR TITLE
dep: update libxml2 to v2.11.4

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,7 +1,7 @@
 libxml2:
-  version: "2.11.3"
-  sha256: "f1acae1664bda006cd81bfc238238217043d586d06659d5c0e3d1bcebe040870"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.3.sha256sum
+  version: "2.11.4"
+  sha256: "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.4.sha256sum
 
 libxslt:
   version: "1.1.38"


### PR DESCRIPTION

**What problem is this PR intended to solve?**

update libxml2 to v2.11.4

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.4

Closes #2882 