### PR TITLE
ci: add mechanize to the downstream suite

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -48,6 +48,9 @@ jobs:
           - url: https://github.com/SAML-Toolkits/ruby-saml
             name: ruby-saml
             command: "bundle exec rake test"
+          - url: https://github.com/sparklemotion/mechanize
+            name: mechanize
+            command: "bundle exec rake test"
           # - url: https://github.com/instructure/nokogiri-xmlsec-instructure
           #   name: nokogiri-xmlsec-instructure
           #   precommand: "apt install -y libxmlsec1-dev"


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Mechanize just started failing its test suite on encoding errors. I suspect this has to do with the libxml2 update to 2.11.

Add mechanize to the downstream suite.
