### PR TITLE
ci: drop valgrind on 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2"]
         mem: ["ruby"]
         include:
           - sys: "disable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -71,7 +71,7 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
           bundler: latest
       - run: bundle exec rake gumbo:test
@@ -175,7 +175,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable"]
-        ruby: ["3.1"]
+        ruby: ["3.2"]
     env:
       BUNDLE_GEMFILE: "Gemfile-libxml-ruby"
     runs-on: ubuntu-latest
@@ -200,7 +200,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["disable"]
-        ruby: ["3.1"]
+        ruby: ["3.2"]
     env:
       BUNDLE_GEMFILE: "Gemfile-libxml-ruby"
     runs-on: ubuntu-latest
@@ -349,7 +349,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["disable"]
-        ruby: ["3.1"]
+        ruby: ["3.2"]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
@@ -378,7 +378,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
           bundler: latest
       - id: rcd_image_version


### PR DESCRIPTION
**What problem is this PR intended to solve?**

ci: drop valgrind checks on Ruby 2.7

because there seems to be a compaction bug in 2.7 that occasionally (rarely) gets triggered. it happens more frequently on windows, where we get segfaults, but sometimes valgrind catches it on linux, too.

e.g. https://github.com/sparklemotion/nokogiri/actions/runs/5063811163/jobs/9090845467?pr=2890#step:7:3154

```
== Invalid read of size 4
==780==    at 0x4908CB0: rb_gc_location (gc.c:8136)
==780==    by 0x4908CB0: rb_gc_location (gc.c:8127)
==780==    by 0x4A4CAD1: transient_heap_block_update_refs (transient_heap.c:831)
==780==    by 0x4A4CAD1: transient_heap_blocks_update_refs (transient_heap.c:847)
==780==    by 0x4A4CAD1: rb_transient_heap_update_references (transient_heap.c:859)
==780==    by 0x490FCA1: gc_update_references (gc.c:8433)
==780==    by 0x490FCA1: gc_compact_after_gc (gc.c:8576)
==780==    by 0x4911052: gc_compact (gc.c:8477)
==780==    by 0x4911052: gc_verify_compaction_references (gc.c:8683)
```

This PR also updates the version of Ruby used for some jobs to 3.2 (those jobs that don't need a specific version of Ruby).

