### PR TITLE
Serializing unparented HTML node on JRuby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## next / unreleased
+
+### Fixed
+
+* [JRuby] Fixed NPE when serializing an unparented HTML node. [[#2559](https://github.com/sparklemotion/nokogiri/issues/2559), [#2895](https://github.com/sparklemotion/nokogiri/issues/2895)] (Thanks, [@cbasguti](https://github.com/cbasguti)!)
+
+
 ## 1.15.2 / 2023-05-24
 
 ### Dependencies

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -807,9 +807,12 @@ public class SaveContextVisitor
     // no-op
   }
 
-  private boolean isCDATA(Text text) {
+  private boolean
+  isCDATA(Text text)
+  {
     Node parentNode = text.getParentNode();
-    return htmlDoc && parentNode != null && (parentNode.getNodeName().equals("style") || parentNode.getNodeName().equals("script"));
+    return htmlDoc && parentNode != null && (parentNode.getNodeName().equals("style")
+           || parentNode.getNodeName().equals("script"));
   }
 
 

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -807,7 +807,9 @@ public class SaveContextVisitor
     // no-op
   }
 
-  private boolean isHtmlScript(Text text) {
+  private boolean
+  isHtmlScript(Text text)
+  {
     Node parentNode = text.getParentNode();
     if (parentNode != null && parentNode.getNodeName().equals("script")) {
       return htmlDoc;
@@ -816,8 +818,10 @@ public class SaveContextVisitor
       return false;
     }
   }
-  
-  private boolean isHtmlStyle(Text text) {
+
+  private boolean
+  isHtmlStyle(Text text)
+  {
     Node parentNode = text.getParentNode();
     if (parentNode != null && parentNode.getNodeName().equals("style")) {
       return htmlDoc;
@@ -826,7 +830,7 @@ public class SaveContextVisitor
       return false;
     }
   }
-  
+
 
   public boolean
   enter(Text text)

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -807,28 +807,9 @@ public class SaveContextVisitor
     // no-op
   }
 
-  private boolean
-  isHtmlScript(Text text)
-  {
+  private boolean isCDATA(Text text) {
     Node parentNode = text.getParentNode();
-    if (parentNode != null && parentNode.getNodeName().equals("script")) {
-      return htmlDoc;
-    } else {
-      System.out.println("getParentNode() returned null or parent node is not 'script'.");
-      return false;
-    }
-  }
-
-  private boolean
-  isHtmlStyle(Text text)
-  {
-    Node parentNode = text.getParentNode();
-    if (parentNode != null && parentNode.getNodeName().equals("style")) {
-      return htmlDoc;
-    } else {
-      System.out.println("getParentNode() returned null or parent node is not 'style'.");
-      return false;
-    }
+    return htmlDoc && parentNode != null && (parentNode.getNodeName().equals("style") || parentNode.getNodeName().equals("script"));
   }
 
 
@@ -844,7 +825,7 @@ public class SaveContextVisitor
       }
     }
 
-    if (shouldEncode(text) && !isHtmlScript(text) && !isHtmlStyle(text)) {
+    if (shouldEncode(text) && !isCDATA(text)) {
       textContent = encodeJavaString(textContent);
     }
 

--- a/ext/java/nokogiri/internals/SaveContextVisitor.java
+++ b/ext/java/nokogiri/internals/SaveContextVisitor.java
@@ -807,17 +807,26 @@ public class SaveContextVisitor
     // no-op
   }
 
-  private boolean
-  isHtmlScript(Text text)
-  {
-    return htmlDoc && text.getParentNode().getNodeName().equals("script");
+  private boolean isHtmlScript(Text text) {
+    Node parentNode = text.getParentNode();
+    if (parentNode != null && parentNode.getNodeName().equals("script")) {
+      return htmlDoc;
+    } else {
+      System.out.println("getParentNode() returned null or parent node is not 'script'.");
+      return false;
+    }
   }
-
-  private boolean
-  isHtmlStyle(Text text)
-  {
-    return htmlDoc && text.getParentNode().getNodeName().equals("style");
+  
+  private boolean isHtmlStyle(Text text) {
+    Node parentNode = text.getParentNode();
+    if (parentNode != null && parentNode.getNodeName().equals("style")) {
+      return htmlDoc;
+    } else {
+      System.out.println("getParentNode() returned null or parent node is not 'style'.");
+      return false;
+    }
   }
+  
 
   public boolean
   enter(Text text)

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -1342,6 +1342,11 @@ module Nokogiri
           end
         end
 
+        # issue 2559
+        def test_serialize_unparented_node
+          assert_equal("asdf", Nokogiri::HTML4::Document.parse("<div></div>").create_text_node("asdf").to_s)
+        end
+
         describe "#wrap" do
           let(:xml) { "<root><thing><div>important thing</div></thing></root>" }
           let(:doc) { Nokogiri::XML(xml) }


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Closes #2559

This PR aims to solve issue #2559 in the Nokogiri project. After investigating the reported bug, it was identified that a NullPointerException occurs in the isHtmlScript and isHtmlStyle functions due to the inability to evaluate a null object in Java. The proposed solution involves adding a null check for the getParentNode() method's return value and logging an appropriate message if the parent node is null or does not match the expected tag name. A draft PR will be opened to implement these modifications and gather feedback for effectiveness.

**Have you included adequate test coverage?**

As this is my first contribution to the project, I am uncertain about the appropriate location to include the corresponding test. However, I am committed to ensuring adequate test coverage for this change and will collaborate with the project team to determine the best approach.

**Does this change affect the behavior of either the C or the Java implementations?**

This change only affects the Java implementation, as the issue of a NullPointerException is specific to that platform. The C implementation does not encounter this problem.
