### PR TITLE
Add xmlsec native library

### DIFF
--- a/oci-images/nokogiri-test/alpine.dockerfile
+++ b/oci-images/nokogiri-test/alpine.dockerfile
@@ -2,13 +2,13 @@ FROM ruby:alpine3.12
 
 # prelude
 RUN apk update
-RUN apk add bash build-base git
+RUN apk add bash build-base git perl
 
 # valgrind
 RUN apk add valgrind
 
 # libxml-et-al
-RUN apk add libxml2-dev libxslt-dev pkgconfig
+RUN apk add libxml2-dev libxslt-dev xmlsec-dev pkgconfig
 
 # include_file bundle-install.step
 # -*- dockerfile -*-

--- a/oci-images/nokogiri-test/alpine.erb
+++ b/oci-images/nokogiri-test/alpine.erb
@@ -2,12 +2,12 @@ FROM ruby:alpine3.12
 
 # prelude
 RUN apk update
-RUN apk add bash build-base git
+RUN apk add bash build-base git perl
 
 # valgrind
 RUN apk add valgrind
 
 # libxml-et-al
-RUN apk add libxml2-dev libxslt-dev pkgconfig
+RUN apk add libxml2-dev libxslt-dev xmlsec-dev pkgconfig
 
 <%= include_file "bundle-install.step" %>

--- a/oci-images/nokogiri-test/debian-libxml-et-al.step
+++ b/oci-images/nokogiri-test/debian-libxml-et-al.step
@@ -1,4 +1,4 @@
 # -*- dockerfile -*-
 
-RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev libxmlsec1-dev pkg-config
 RUN apt-get install -y libyaml-dev # for psych 5

--- a/oci-images/nokogiri-test/mri-2.7.dockerfile
+++ b/oci-images/nokogiri-test/mri-2.7.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y valgrind
 # include_file debian-libxml-et-al.step
 # -*- dockerfile -*-
 
-RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev libxmlsec1-dev pkg-config
 RUN apt-get install -y libyaml-dev # for psych 5
 
 

--- a/oci-images/nokogiri-test/mri-3.0.dockerfile
+++ b/oci-images/nokogiri-test/mri-3.0.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y valgrind
 # include_file debian-libxml-et-al.step
 # -*- dockerfile -*-
 
-RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev libxmlsec1-dev pkg-config
 RUN apt-get install -y libyaml-dev # for psych 5
 
 

--- a/oci-images/nokogiri-test/mri-3.1.dockerfile
+++ b/oci-images/nokogiri-test/mri-3.1.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y valgrind
 # include_file debian-libxml-et-al.step
 # -*- dockerfile -*-
 
-RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev libxmlsec1-dev pkg-config
 RUN apt-get install -y libyaml-dev # for psych 5
 
 

--- a/oci-images/nokogiri-test/mri-3.2.dockerfile
+++ b/oci-images/nokogiri-test/mri-3.2.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y valgrind
 # include_file debian-libxml-et-al.step
 # -*- dockerfile -*-
 
-RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev libxmlsec1-dev pkg-config
 RUN apt-get install -y libyaml-dev # for psych 5
 
 

--- a/oci-images/nokogiri-test/truffle-nightly.dockerfile
+++ b/oci-images/nokogiri-test/truffle-nightly.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y valgrind
 # include_file debian-libxml-et-al.step
 # -*- dockerfile -*-
 
-RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev libxmlsec1-dev pkg-config
 RUN apt-get install -y libyaml-dev # for psych 5
 
 

--- a/oci-images/nokogiri-test/ubuntu.dockerfile
+++ b/oci-images/nokogiri-test/ubuntu.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y git-core
 # include_file debian-libxml-et-al.step
 # -*- dockerfile -*-
 
-RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev libxmlsec1-dev pkg-config
 RUN apt-get install -y libyaml-dev # for psych 5
 
 

--- a/oci-images/nokogiri-test/ubuntu32.dockerfile
+++ b/oci-images/nokogiri-test/ubuntu32.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y git-core
 # include_file debian-libxml-et-al.step
 # -*- dockerfile -*-
 
-RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev libxmlsec1-dev pkg-config
 RUN apt-get install -y libyaml-dev # for psych 5
 
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Pre-work for #2888 to have native libraries available in CI.  As can be seen here: https://github.com/maths22/nokogiri/actions/runs/5190697036/jobs/9357995415 , the build is almost passing using these images and the remaining issues will not require a new version of CI images.

Open issue for discussion: the 32-bit port of Ubuntu focal is a "partial port" and only includes a subset of packages.  Notably, xmlsec is not among those packages.  Therefore, using the Ubuntu focal base image with native xmlsec for 32 bit testing isn't really feasible.  We could possibly build that package in a PPA, or we could explore basing the 32 bit image on the `ruby:${version}` images, which are Debian bullseye (which has complete 32bit architecture support) instead of Ubuntu.  (Best I can tell that image is *only* used for the ci `basic` step, so I would think we could be flexible there, but I'm open to other thoughts.)

**Have you included adequate test coverage?**

n/a

**Does this change affect the behavior of either the C or the Java implementations?**

No, it is a build only change