### PR TITLE
Avoid incorrectly including xml header in xslt output on JRuby

### DIFF
--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -40,6 +40,7 @@ import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 import nokogiri.internals.NokogiriXsltErrorListener;
 
@@ -185,7 +186,23 @@ public class XsltStylesheet extends RubyObject
 
     java.util.Properties props = this.sheet.getOutputProperties();
     if (props.getProperty(OutputKeys.METHOD) == null) {
-      props.setProperty(OutputKeys.METHOD, "html");
+      Node rootNode = xmlDoc.getNode().getFirstChild();
+
+      if (rootNode != null && rootNode.getNodeType() == Node.ELEMENT_NODE) {
+        String firstChildLocalName = rootNode.getLocalName();
+
+        if (firstChildLocalName.equalsIgnoreCase("html") && rootNode.getNamespaceURI() == null) {
+          Node textNode = rootNode.getPreviousSibling();
+
+          if (textNode == null || (textNode.getNodeType() == Node.TEXT_NODE && textNode.getTextContent().trim().isEmpty())) {
+            props.setProperty(OutputKeys.METHOD, "html");
+          }
+        }
+      }
+
+      if (props.getProperty(OutputKeys.METHOD) == null) {
+        props.setProperty(OutputKeys.METHOD, "xml");
+      }
     }
 
     Serializer serializer = SerializerFactory.getSerializer(props);
@@ -194,6 +211,7 @@ public class XsltStylesheet extends RubyObject
 
     return context.getRuntime().newString(writer.toString());
   }
+
 
   @JRubyMethod(rest = true, required = 1, optional = 2)
   public IRubyObject

--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -185,7 +185,7 @@ public class XsltStylesheet extends RubyObject
 
     java.util.Properties props = this.sheet.getOutputProperties();
     if (props.getProperty(OutputKeys.METHOD) == null) {
-      props.setProperty(OutputKeys.METHOD, org.apache.xml.serializer.Method.UNKNOWN);
+      props.setProperty(OutputKeys.METHOD, "html");
     }
 
     Serializer serializer = SerializerFactory.getSerializer(props);

--- a/test/xslt/test_xml_header.rb
+++ b/test/xslt/test_xml_header.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "nokogiri"
+
+class OutputTest < Minitest::Test
+  def test_output
+    input_xml = <<~XML
+      <?xml version="1.0" encoding="utf-8"?>
+      <report>
+        <title>My Report</title>
+      </report>
+    XML
+
+    input_xsl = <<~XSL
+      <?xml version="1.0" encoding="utf-8"?>
+      <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+        <xsl:template match="/">
+          <html>
+            <head>
+              <title><xsl:value-of select="report/title"/></title>
+            </head>
+            <body>
+              <h1><xsl:value-of select="report/title"/></h1>
+            </body>
+          </html>
+        </xsl:template>
+      </xsl:stylesheet>
+    XSL
+
+    expected_output = <<~HTML
+      <html>
+      <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+      <title>My Report</title>
+      </head>
+      <body><h1>My Report</h1></body>
+      </html>
+    HTML
+
+    xml = Nokogiri::XML(input_xml)
+    xsl = Nokogiri::XSLT(input_xsl)
+    actual_output = xsl.apply_to(xml)
+
+    expected_output_normalized = expected_output.gsub(/\s+/, "").downcase
+    actual_output_normalized = actual_output.gsub(/\s+/, "").downcase
+
+    assert_equal(expected_output_normalized, actual_output_normalized)
+  end
+end


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

- In the updated function, the line props.setProperty(OutputKeys.METHOD, org.apache.xml.serializer.Method.UNKNOWN); was changed to props.setProperty(OutputKeys.METHOD, "html");.
- This change ensures that the METHOD property is set to "html" instead of the unknown method. This modification aims to address issue #1430 by explicitly specifying the method as "html" during serialization.
<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

A new test file named test_xml_header.rb was added .

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

The modification made to the Java implementation was to exclude the XML declaration tag (<?xml ... ?>) from the output. This was achieved by adjusting the code in the serialize function to remove the inclusion of the XML declaration. The purpose was to align the output with the expected format, where the XML declaration should not be present.
<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
