### PR TITLE
dev: make sure css:generate works if target doesn't exist

### DIFF
--- a/rakelib/css-generate.rake
+++ b/rakelib/css-generate.rake
@@ -3,7 +3,7 @@
 casual_file_task = Class.new(Rake::FileTask) do
   # to avoid re-running these tasks after a git checkout, let's give it a 1 second window before we re-run
   def needed?
-    out_of_date?(File.mtime(name) + 1) || @application.options.build_all
+    !File.exist?(name) || out_of_date?(File.mtime(name) + 1) || @application.options.build_all
   end
 end
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

```
$ be rake css:clean css:generate
rm -f lib/nokogiri/css/parser.rb
rm -f lib/nokogiri/css/tokenizer.rb
rake aborted!
Errno::ENOENT: No such file or directory @ rb_file_s_mtime - lib/nokogiri/css/parser.rb
/home/flavorjones/code/oss/nokogiri/rakelib/css-generate.rake:7:in `mtime'
/home/flavorjones/code/oss/nokogiri/rakelib/css-generate.rake:7:in `needed?'
/home/flavorjones/.rbenv/versions/3.2.2/bin/bundle:25:in `load'
/home/flavorjones/.rbenv/versions/3.2.2/bin/bundle:25:in `<main>'
Tasks: TOP => css:generate => lib/nokogiri/css/parser.rb
(See full trace by running task with --trace)
```

Our hacky file task needs to check for file existence before invoking `File.mtime`.
