### PR TITLE
ci: build mri-3.2 image with modern valgrind

### DIFF
--- a/oci-images/nokogiri-test/mri-3.2.dockerfile
+++ b/oci-images/nokogiri-test/mri-3.2.dockerfile
@@ -9,10 +9,16 @@ RUN apt-get upgrade -y
 RUN apt-get install -y apt-utils
 
 
-# include_file debian-valgrind.step
+# include_file valgrind-from-source.step
 # -*- dockerfile -*-
 
-RUN apt-get install -y valgrind
+RUN apt-get install -y libc6-dbg
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.21.0.tar.bz2 && \
+    tar -xf valgrind-3.21.0.tar.bz2 && \
+    cd valgrind-3.21.0 && \
+    ./configure && \
+    make && \
+    make install
 
 
 # include_file debian-libxml-et-al.step

--- a/oci-images/nokogiri-test/mri.erb
+++ b/oci-images/nokogiri-test/mri.erb
@@ -2,7 +2,11 @@ FROM ruby:<%= version %>
 
 <%= include_file "debian-prelude.step" %>
 
+<% if version == "3.2" -%>
+<%= include_file "valgrind-from-source.step" %>
+<% else -%>
 <%= include_file "debian-valgrind.step" %>
+<% end -%>
 
 <%= include_file "debian-libxml-et-al.step" %>
 

--- a/oci-images/nokogiri-test/valgrind-from-source.step
+++ b/oci-images/nokogiri-test/valgrind-from-source.step
@@ -1,0 +1,9 @@
+# -*- dockerfile -*-
+
+RUN apt-get install -y libc6-dbg
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.21.0.tar.bz2 && \
+    tar -xf valgrind-3.21.0.tar.bz2 && \
+    cd valgrind-3.21.0 && \
+    ./configure && \
+    make && \
+    make install


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Build mri-3.2 image with modern valgrind from source. Otherwise we run into DWARF5 format issues.

Closes #2909
