### PR TITLE
Fix argument typechecking in Text.new, CDATA.new, and Schema.from_document

### DIFF
--- a/ext/java/nokogiri/XmlCdata.java
+++ b/ext/java/nokogiri/XmlCdata.java
@@ -43,15 +43,15 @@ public class XmlCdata extends XmlText
     if (args.length < 2) {
       throw getRuntime().newArgumentError(args.length, 2);
     }
-    IRubyObject doc = args[0];
+    IRubyObject rbDocument = args[0];
     content = args[1];
 
-    if (!(doc instanceof XmlDocument)) {
+    if (!(rbDocument instanceof XmlDocument)) {
       // TODO: deprecate allowing Node
       context.runtime.getWarnings().warn("Passing a Node as the first parameter to CDATA.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
     }
 
-    Document document = ((XmlNode) doc).getOwnerDocument();
+    Document document = ((XmlNode) rbDocument).getOwnerDocument();
     Node node = document.createCDATASection(rubyStringToString(content));
     setNode(context.runtime, node);
   }

--- a/ext/java/nokogiri/XmlCdata.java
+++ b/ext/java/nokogiri/XmlCdata.java
@@ -46,6 +46,10 @@ public class XmlCdata extends XmlText
     IRubyObject rbDocument = args[0];
     content = args[1];
 
+    if (!(rbDocument instanceof XmlNode)) {
+      String msg = "expected first parameter to be a Nokogiri::XML::Document, received " + rbDocument.getMetaClass();
+      throw context.runtime.newTypeError(msg);
+    }
     if (!(rbDocument instanceof XmlDocument)) {
       // TODO: deprecate allowing Node
       context.runtime.getWarnings().warn("Passing a Node as the first parameter to CDATA.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -149,6 +149,10 @@ public class XmlSchema extends RubyObject
       parseOptions = args[1];
     }
 
+    if (!(rbDocument instanceof XmlNode)) {
+      String msg = "expected parameter to be a Nokogiri::XML::Document, received " + rbDocument.getMetaClass();
+      throw context.runtime.newTypeError(msg);
+    }
     if (!(rbDocument instanceof XmlDocument)) {
       // TODO: deprecate allowing Node
       context.runtime.getWarnings().warn("Passing a Node as the first parameter to Schema.from_document is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -143,18 +143,18 @@ public class XmlSchema extends RubyObject
   public static IRubyObject
   from_document(ThreadContext context, IRubyObject klazz, IRubyObject[] args)
   {
-    IRubyObject document = args[0];
+    IRubyObject rbDocument = args[0];
     IRubyObject parseOptions = null;
     if (args.length > 1) {
       parseOptions = args[1];
     }
 
-    if (!(document instanceof XmlDocument)) {
+    if (!(rbDocument instanceof XmlDocument)) {
       // TODO: deprecate allowing Node
       context.runtime.getWarnings().warn("Passing a Node as the first parameter to Schema.from_document is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
     }
 
-    XmlDocument doc = ((XmlDocument)((XmlNode) document).document(context));
+    XmlDocument doc = ((XmlDocument)((XmlNode) rbDocument).document(context));
 
     RubyArray<?> errors = (RubyArray) doc.getInstanceVariable("@errors");
     if (!errors.isEmpty()) {

--- a/ext/java/nokogiri/XmlText.java
+++ b/ext/java/nokogiri/XmlText.java
@@ -53,6 +53,10 @@ public class XmlText extends XmlNode
     content = args[0];
     IRubyObject rbDocument = args[1];
 
+    if (!(rbDocument instanceof XmlNode)) {
+      String msg = "expected second parameter to be a Nokogiri::XML::Document, received " + rbDocument.getMetaClass();
+      throw context.runtime.newTypeError(msg);
+    }
     if (!(rbDocument instanceof XmlDocument)) {
       // TODO: deprecate allowing Node
       context.runtime.getWarnings().warn("Passing a Node as the second parameter to Text.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");

--- a/ext/java/nokogiri/XmlText.java
+++ b/ext/java/nokogiri/XmlText.java
@@ -51,14 +51,14 @@ public class XmlText extends XmlNode
     }
 
     content = args[0];
-    IRubyObject xNode = args[1];
+    IRubyObject rbDocument = args[1];
 
-    if (!(xNode instanceof XmlDocument)) {
+    if (!(rbDocument instanceof XmlDocument)) {
       // TODO: deprecate allowing Node
       context.runtime.getWarnings().warn("Passing a Node as the second parameter to Text.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
     }
 
-    Document document = asXmlNode(context, xNode).getOwnerDocument();
+    Document document = asXmlNode(context, rbDocument).getOwnerDocument();
     // text node content should not be encoded when it is created by Text node.
     // while content should be encoded when it is created by Element node.
     Node node = document.createTextNode(rubyStringToString(content));

--- a/ext/nokogiri/xml_cdata.c
+++ b/ext/nokogiri/xml_cdata.c
@@ -12,39 +12,39 @@ VALUE cNokogiriXmlCData;
  * raise a TypeError exception.
  */
 static VALUE
-new (int argc, VALUE *argv, VALUE klass)
+rb_xml_cdata_s_new(int argc, VALUE *argv, VALUE klass)
 {
-  xmlDocPtr xml_doc;
-  xmlNodePtr node;
-  VALUE doc;
-  VALUE content;
-  VALUE rest;
+  xmlDocPtr c_document;
+  xmlNodePtr c_node;
+  VALUE rb_document;
+  VALUE rb_content;
+  VALUE rb_rest;
   VALUE rb_node;
-  xmlChar *content_str = NULL;
-  int content_str_len = 0;
+  xmlChar *c_content = NULL;
+  int c_content_len = 0;
 
-  rb_scan_args(argc, argv, "2*", &doc, &content, &rest);
+  rb_scan_args(argc, argv, "2*", &rb_document, &rb_content, &rb_rest);
 
-  if (rb_obj_is_kind_of(doc, cNokogiriXmlDocument)) {
-    xml_doc = noko_xml_document_unwrap(doc);
-  } else {
+  if (!rb_obj_is_kind_of(rb_document, cNokogiriXmlDocument)) {
     xmlNodePtr deprecated_node_type_arg;
     // TODO: deprecate allowing Node
     NOKO_WARN_DEPRECATION("Passing a Node as the first parameter to CDATA.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
-    Noko_Node_Get_Struct(doc, xmlNode, deprecated_node_type_arg);
-    xml_doc = deprecated_node_type_arg->doc;
+    Noko_Node_Get_Struct(rb_document, xmlNode, deprecated_node_type_arg);
+    c_document = deprecated_node_type_arg->doc;
+  } else {
+    c_document = noko_xml_document_unwrap(rb_document);
   }
 
-  if (!NIL_P(content)) {
-    content_str = (xmlChar *)StringValuePtr(content);
-    content_str_len = RSTRING_LENINT(content);
+  if (!NIL_P(rb_content)) {
+    c_content = (xmlChar *)StringValuePtr(rb_content);
+    c_content_len = RSTRING_LENINT(rb_content);
   }
 
-  node = xmlNewCDataBlock(xml_doc, content_str, content_str_len);
+  c_node = xmlNewCDataBlock(c_document, c_content, c_content_len);
 
-  noko_xml_document_pin_node(node);
+  noko_xml_document_pin_node(c_node);
 
-  rb_node = noko_xml_node_wrap(klass, node);
+  rb_node = noko_xml_node_wrap(klass, c_node);
   rb_obj_call_init(rb_node, argc, argv);
 
   if (rb_block_given_p()) { rb_yield(rb_node); }
@@ -61,5 +61,5 @@ noko_init_xml_cdata(void)
    */
   cNokogiriXmlCData = rb_define_class_under(mNokogiriXml, "CDATA", cNokogiriXmlText);
 
-  rb_define_singleton_method(cNokogiriXmlCData, "new", new, -1);
+  rb_define_singleton_method(cNokogiriXmlCData, "new", rb_xml_cdata_s_new, -1);
 }

--- a/ext/nokogiri/xml_cdata.c
+++ b/ext/nokogiri/xml_cdata.c
@@ -25,6 +25,12 @@ rb_xml_cdata_s_new(int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "2*", &rb_document, &rb_content, &rb_rest);
 
+  if (!rb_obj_is_kind_of(rb_document, cNokogiriXmlNode)) {
+    rb_raise(rb_eTypeError,
+             "expected first parameter to be a Nokogiri::XML::Document, received %"PRIsVALUE,
+             rb_obj_class(rb_document));
+  }
+
   if (!rb_obj_is_kind_of(rb_document, cNokogiriXmlDocument)) {
     xmlNodePtr deprecated_node_type_arg;
     // TODO: deprecate allowing Node

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -214,6 +214,12 @@ rb_xml_schema_s_from_document(int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "11", &rb_document, &rb_parse_options);
 
+  if (!rb_obj_is_kind_of(rb_document, cNokogiriXmlNode)) {
+    rb_raise(rb_eTypeError,
+             "expected parameter to be a Nokogiri::XML::Document, received %"PRIsVALUE,
+             rb_obj_class(rb_document));
+  }
+
   if (!rb_obj_is_kind_of(rb_document, cNokogiriXmlDocument)) {
     xmlNodePtr deprecated_node_type_arg;
     // TODO: deprecate allowing Node

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -203,7 +203,7 @@ read_memory(int argc, VALUE *argv, VALUE klass)
  * [Returns] Nokogiri::XML::Schema
  */
 static VALUE
-from_document(int argc, VALUE *argv, VALUE klass)
+rb_xml_schema_s_from_document(int argc, VALUE *argv, VALUE klass)
 {
   VALUE rb_document;
   VALUE rb_parse_options;
@@ -214,14 +214,14 @@ from_document(int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "11", &rb_document, &rb_parse_options);
 
-  if (rb_obj_is_kind_of(rb_document, cNokogiriXmlDocument)) {
-    c_document = noko_xml_document_unwrap(rb_document);
-  } else {
+  if (!rb_obj_is_kind_of(rb_document, cNokogiriXmlDocument)) {
     xmlNodePtr deprecated_node_type_arg;
     // TODO: deprecate allowing Node
     NOKO_WARN_DEPRECATION("Passing a Node as the first parameter to Schema.from_document is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
     Noko_Node_Get_Struct(rb_document, xmlNode, deprecated_node_type_arg);
     c_document = deprecated_node_type_arg->doc;
+  } else {
+    c_document = noko_xml_document_unwrap(rb_document);
   }
 
   if (noko_xml_document_has_wrapped_blank_nodes_p(c_document)) {
@@ -249,7 +249,7 @@ noko_init_xml_schema(void)
   rb_undef_alloc_func(cNokogiriXmlSchema);
 
   rb_define_singleton_method(cNokogiriXmlSchema, "read_memory", read_memory, -1);
-  rb_define_singleton_method(cNokogiriXmlSchema, "from_document", from_document, -1);
+  rb_define_singleton_method(cNokogiriXmlSchema, "from_document", rb_xml_schema_s_from_document, -1);
 
   rb_define_private_method(cNokogiriXmlSchema, "validate_document", validate_document, 1);
   rb_define_private_method(cNokogiriXmlSchema, "validate_file",     validate_file, 1);

--- a/ext/nokogiri/xml_text.c
+++ b/ext/nokogiri/xml_text.c
@@ -20,6 +20,12 @@ rb_xml_text_s_new(int argc, VALUE *argv, VALUE klass)
 
   rb_scan_args(argc, argv, "2*", &rb_string, &rb_document, &rb_rest);
 
+  if (!rb_obj_is_kind_of(rb_document, cNokogiriXmlNode)) {
+    rb_raise(rb_eTypeError,
+             "expected second parameter to be a Nokogiri::XML::Document, received %"PRIsVALUE,
+             rb_obj_class(rb_document));
+  }
+
   if (!rb_obj_is_kind_of(rb_document, cNokogiriXmlDocument)) {
     xmlNodePtr deprecated_node_type_arg;
     // TODO: deprecate allowing Node

--- a/ext/nokogiri/xml_text.c
+++ b/ext/nokogiri/xml_text.c
@@ -9,33 +9,33 @@ VALUE cNokogiriXmlText ;
  * Create a new Text element on the +document+ with +content+
  */
 static VALUE
-new (int argc, VALUE *argv, VALUE klass)
+rb_xml_text_s_new(int argc, VALUE *argv, VALUE klass)
 {
-  xmlDocPtr doc;
-  xmlNodePtr node;
-  VALUE string;
-  VALUE document;
-  VALUE rest;
+  xmlDocPtr c_document;
+  xmlNodePtr c_node;
+  VALUE rb_string;
+  VALUE rb_document;
+  VALUE rb_rest;
   VALUE rb_node;
 
-  rb_scan_args(argc, argv, "2*", &string, &document, &rest);
+  rb_scan_args(argc, argv, "2*", &rb_string, &rb_document, &rb_rest);
 
-  if (rb_obj_is_kind_of(document, cNokogiriXmlDocument)) {
-    doc = noko_xml_document_unwrap(document);
-  } else {
+  if (!rb_obj_is_kind_of(rb_document, cNokogiriXmlDocument)) {
     xmlNodePtr deprecated_node_type_arg;
     // TODO: deprecate allowing Node
     NOKO_WARN_DEPRECATION("Passing a Node as the second parameter to Text.new is deprecated. Please pass a Document instead. This will become an error in a future release of Nokogiri.");
-    Noko_Node_Get_Struct(document, xmlNode, deprecated_node_type_arg);
-    doc = deprecated_node_type_arg->doc;
+    Noko_Node_Get_Struct(rb_document, xmlNode, deprecated_node_type_arg);
+    c_document = deprecated_node_type_arg->doc;
+  } else {
+    c_document = noko_xml_document_unwrap(rb_document);
   }
 
-  node = xmlNewText((xmlChar *)StringValueCStr(string));
-  node->doc = doc;
+  c_node = xmlNewText((xmlChar *)StringValueCStr(rb_string));
+  c_node->doc = c_document;
 
-  noko_xml_document_pin_node(node);
+  noko_xml_document_pin_node(c_node);
 
-  rb_node = noko_xml_node_wrap(klass, node) ;
+  rb_node = noko_xml_node_wrap(klass, c_node) ;
   rb_obj_call_init(rb_node, argc, argv);
 
   if (rb_block_given_p()) { rb_yield(rb_node); }
@@ -52,5 +52,5 @@ noko_init_xml_text(void)
    */
   cNokogiriXmlText = rb_define_class_under(mNokogiriXml, "Text", cNokogiriXmlCharacterData);
 
-  rb_define_singleton_method(cNokogiriXmlText, "new", new, -1);
+  rb_define_singleton_method(cNokogiriXmlText, "new", rb_xml_text_s_new, -1);
 }

--- a/test/xml/test_cdata.rb
+++ b/test/xml/test_cdata.rb
@@ -2,57 +2,59 @@
 
 require "helper"
 
-module Nokogiri
-  module XML
-    class TestCDATA < Nokogiri::TestCase
-      def setup
-        super
-        @xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE)
-      end
+describe Nokogiri::XML::CDATA do
+  describe ".new" do
+    it "acts like a constructor" do
+      doc = Nokogiri::XML::Document.new
+      node = Nokogiri::XML::CDATA.new(doc, "foo")
 
-      def test_cdata_node
-        name = @xml.xpath("//employee[2]/name").first
-        assert(cdata = name.children[1])
-        assert_predicate(cdata, :cdata?)
-        assert_equal("#cdata-section", cdata.name)
-      end
-
-      def test_new
-        node = CDATA.new(@xml, "foo")
-        assert_equal("foo", node.content)
-
-        assert_output(nil, /Passing a Node as the first parameter to CDATA\.new is deprecated/) do
-          node = CDATA.new(@xml.root, "foo")
-        end
-        assert_equal("foo", node.content)
-      end
-
-      def test_new_with_nil
-        node = CDATA.new(@xml, nil)
-        assert_nil(node.content)
-      end
-
-      def test_new_with_non_string
-        assert_raises(TypeError) do
-          CDATA.new(@xml, 1.234)
-        end
-      end
-
-      def test_lots_of_new_cdata
-        assert(100.times { CDATA.new(@xml, "asdfasdf") })
-      end
-
-      def test_content=
-        node = CDATA.new(@xml, "foo")
-        assert_equal("foo", node.content)
-
-        node.content = "& <foo> &amp;"
-        assert_equal("& <foo> &amp;", node.content)
-        assert_equal("<![CDATA[& <foo> &amp;]]>", node.to_xml)
-
-        node.content = "foo ]]> bar"
-        assert_equal("foo ]]> bar", node.content)
-      end
+      assert_instance_of(Nokogiri::XML::CDATA, node)
+      assert_equal("foo", node.content)
+      assert_same(doc, node.document)
+      assert_predicate(node, :cdata?)
+      assert_equal("#cdata-section", node.name)
     end
+
+    it "accepts a node as the first parameter but warns about it" do
+      doc = Nokogiri::XML::Document.new
+      related_node = Nokogiri::XML::Element.new("foo", doc)
+      node = nil
+
+      assert_output(nil, /Passing a Node as the first parameter to CDATA\.new is deprecated/) do
+        node = Nokogiri::XML::CDATA.new(related_node, "foo")
+      end
+      assert_instance_of(Nokogiri::XML::CDATA, node)
+      assert_equal("foo", node.content)
+      assert_same(doc, node.document)
+    end
+
+    it "has nil content when passed nil" do
+      node = Nokogiri::XML::CDATA.new(Nokogiri::XML::Document.new, nil)
+
+      assert_instance_of(Nokogiri::XML::CDATA, node)
+      assert_nil(node.content)
+    end
+
+    it "does not accept anything but a string" do
+      doc = Nokogiri::XML::Document.new
+      assert_raises(TypeError) { Nokogiri::XML::CDATA.new(doc, 1.234) }
+      assert_raises(TypeError) { Nokogiri::XML::CDATA.new(doc, {}) }
+    end
+  end
+
+  it "supports #content and #content=" do
+    doc = Nokogiri::XML::Document.new
+    node = Nokogiri::XML::CDATA.new(doc, "foo")
+
+    assert_equal("foo", node.content)
+
+    node.content = "& <foo> &amp;"
+
+    assert_equal("& <foo> &amp;", node.content)
+    assert_equal("<![CDATA[& <foo> &amp;]]>", node.to_xml)
+
+    node.content = "foo ]]> bar"
+
+    assert_equal("foo ]]> bar", node.content)
   end
 end

--- a/test/xml/test_cdata.rb
+++ b/test/xml/test_cdata.rb
@@ -40,6 +40,13 @@ describe Nokogiri::XML::CDATA do
       assert_raises(TypeError) { Nokogiri::XML::CDATA.new(doc, 1.234) }
       assert_raises(TypeError) { Nokogiri::XML::CDATA.new(doc, {}) }
     end
+
+    it "does not accept anything other than Node or Document" do
+      assert_raises(TypeError) { Nokogiri::XML::CDATA.new(1234, "hello world") }
+      assert_raises(TypeError) { Nokogiri::XML::CDATA.new("asdf", "hello world") }.inspect
+      assert_raises(TypeError) { Nokogiri::XML::CDATA.new({}, "hello world") }
+      assert_raises(TypeError) { Nokogiri::XML::CDATA.new(nil, "hello world") }
+    end
   end
 
   it "supports #content and #content=" do

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -68,6 +68,13 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
         assert_instance_of(Nokogiri::XML::Schema, xsd)
       end
 
+      it ".from_document not accept anything other than Node or Document" do
+        assert_raises(TypeError) { Nokogiri::XML::Schema.from_document(1234) }
+        assert_raises(TypeError) { Nokogiri::XML::Schema.from_document("asdf") }
+        assert_raises(TypeError) { Nokogiri::XML::Schema.from_document({}) }
+        assert_raises(TypeError) { Nokogiri::XML::Schema.from_document(nil) }
+      end
+
       it "schema_validates_with_relative_paths" do
         xsd = File.join(ASSETS_DIR, "foo", "foo.xsd")
         xml = File.join(ASSETS_DIR, "valid_bar.xml")

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -2,58 +2,29 @@
 
 require "helper"
 
-module Nokogiri
-  module XML
-    class TestSchema < Nokogiri::TestCase
-      def setup
-        super
-        assert(@xsd = Nokogiri::XML::Schema(File.read(PO_SCHEMA_FILE)))
+class TestNokogiriXMLSchema < Nokogiri::TestCase
+  describe Nokogiri::XML::Schema do
+    let(:xsd) { Nokogiri::XML::Schema(File.read(PO_SCHEMA_FILE)) }
+
+    describe "construction" do
+      it ".new" do
+        assert(xsd = Nokogiri::XML::Schema.new(File.read(PO_SCHEMA_FILE)))
+        assert_instance_of(Nokogiri::XML::Schema, xsd)
       end
 
-      def test_issue_1985_schema_parse_modifying_underlying_document
-        skip_unless_libxml2("Pure Java version doesn't have this bug")
-
-        # This is a test for a workaround for a bug in LibXML2:
-        #
-        #   https://gitlab.gnome.org/GNOME/libxml2/issues/148
-        #
-        # Schema creation can modify the original document -- removal of blank text nodes -- which
-        # results in dangling pointers.
-        #
-        # If no nodes have been exposed, then it should be fine to create a schema. If nodes have
-        # been exposed to Ruby, then we need to make sure they won't be freed out from under us.
-        doc = <<~EOF
-          <?xml version="1.0" encoding="UTF-8" ?>
-          <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:element name="foo" type="xs:string"/>
-          </xs:schema>
-        EOF
-
-        # This is OK, no nodes have been exposed
-        xsd_doc = Nokogiri::XML(doc)
-        assert(Nokogiri::XML::Schema.from_document(xsd_doc))
-
-        # This is not OK, nodes have been exposed to Ruby
-        xsd_doc = Nokogiri::XML(doc)
-        child = xsd_doc.root.children.find(&:blank?) # Find a blank node that would be freed without the fix
-
-        Nokogiri::XML::Schema.from_document(xsd_doc)
-        assert(child.to_s) # This will raise a valgrind error if the node was freed
-      end
-
-      def test_schema_read_memory
+      it ".read_memory" do
         xsd = Nokogiri::XML::Schema.read_memory(File.read(PO_SCHEMA_FILE))
         assert_instance_of(Nokogiri::XML::Schema, xsd)
       end
 
-      def test_schema_from_document
+      it ".from_document" do
         doc = Nokogiri::XML(File.open(PO_SCHEMA_FILE))
         assert(doc)
         xsd = Nokogiri::XML::Schema.from_document(doc)
         assert_instance_of(Nokogiri::XML::Schema, xsd)
       end
 
-      def test_invalid_schema_do_not_raise_exceptions
+      it "invalid_schema_do_not_raise_exceptions" do
         xsd = Nokogiri::XML::Schema.new(<<~EOF)
           <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
             <xs:group name="foo1">
@@ -86,7 +57,7 @@ module Nokogiri
         end
       end
 
-      def test_schema_from_document_node
+      it ".from_document accepts a node, but warns about it" do
         doc = Nokogiri::XML(File.open(PO_SCHEMA_FILE))
         assert(doc)
         xsd = nil
@@ -97,7 +68,7 @@ module Nokogiri
         assert_instance_of(Nokogiri::XML::Schema, xsd)
       end
 
-      def test_schema_validates_with_relative_paths
+      it "schema_validates_with_relative_paths" do
         xsd = File.join(ASSETS_DIR, "foo", "foo.xsd")
         xml = File.join(ASSETS_DIR, "valid_bar.xml")
         doc = Nokogiri::XML(File.open(xsd))
@@ -107,17 +78,12 @@ module Nokogiri
         assert(xsd.valid?(doc))
       end
 
-      def test_parse_with_memory
-        assert_instance_of(Nokogiri::XML::Schema, @xsd)
-        assert_equal(0, @xsd.errors.length)
-      end
-
-      def test_new
-        assert(xsd = Nokogiri::XML::Schema.new(File.read(PO_SCHEMA_FILE)))
+      it "parse_with_memory" do
         assert_instance_of(Nokogiri::XML::Schema, xsd)
+        assert_equal(0, xsd.errors.length)
       end
 
-      def test_schema_method_with_parse_options
+      it "schema_method_with_parse_options" do
         schema = Nokogiri::XML::Schema(File.read(PO_SCHEMA_FILE))
         assert_equal(Nokogiri::XML::ParseOptions::DEFAULT_SCHEMA, schema.parse_options)
 
@@ -125,7 +91,7 @@ module Nokogiri
         assert_equal(Nokogiri::XML::ParseOptions.new.recover, schema.parse_options)
       end
 
-      def test_schema_new_with_parse_options
+      it "schema_new_with_parse_options" do
         schema = Nokogiri::XML::Schema.new(File.read(PO_SCHEMA_FILE))
         assert_equal(Nokogiri::XML::ParseOptions::DEFAULT_SCHEMA, schema.parse_options)
 
@@ -133,7 +99,7 @@ module Nokogiri
         assert_equal(Nokogiri::XML::ParseOptions.new.recover, schema.parse_options)
       end
 
-      def test_schema_from_document_with_parse_options
+      it "schema_from_document_with_parse_options" do
         schema = Nokogiri::XML::Schema.from_document(Nokogiri::XML::Document.parse(File.read(PO_SCHEMA_FILE)))
         assert_equal(Nokogiri::XML::ParseOptions::DEFAULT_SCHEMA, schema.parse_options)
 
@@ -144,7 +110,7 @@ module Nokogiri
         assert_equal(Nokogiri::XML::ParseOptions.new.recover, schema.parse_options)
       end
 
-      def test_schema_read_memory_with_parse_options
+      it "schema_read_memory_with_parse_options" do
         schema = Nokogiri::XML::Schema.read_memory(File.read(PO_SCHEMA_FILE))
         assert_equal(Nokogiri::XML::ParseOptions::DEFAULT_SCHEMA, schema.parse_options)
 
@@ -152,7 +118,7 @@ module Nokogiri
         assert_equal(Nokogiri::XML::ParseOptions.new.recover, schema.parse_options)
       end
 
-      def test_parse_with_io
+      it "parse_with_io" do
         xsd = nil
         File.open(PO_SCHEMA_FILE, "rb") do |f|
           assert(xsd = Nokogiri::XML::Schema(f))
@@ -160,33 +126,35 @@ module Nokogiri
         assert_equal(0, xsd.errors.length)
       end
 
-      def test_parse_with_errors
+      it "parse_with_errors" do
         xml = File.read(PO_SCHEMA_FILE).sub('name="', "name=")
         assert_raises(Nokogiri::XML::SyntaxError) do
           Nokogiri::XML::Schema(xml)
         end
       end
+    end
 
-      def test_validate_document
+    describe "validation" do
+      it "validate_document" do
         doc = Nokogiri::XML(File.read(PO_XML_FILE))
-        assert(errors = @xsd.validate(doc))
+        assert(errors = xsd.validate(doc))
         assert_equal(0, errors.length)
       end
 
-      def test_validate_file
-        assert(errors = @xsd.validate(PO_XML_FILE))
+      it "validate_file" do
+        assert(errors = xsd.validate(PO_XML_FILE))
         assert_equal(0, errors.length)
       end
 
-      def test_validate_invalid_document
+      it "validate_invalid_document" do
         doc = Nokogiri::XML(File.read(PO_XML_FILE))
         doc.css("city").unlink
 
-        assert(errors = @xsd.validate(doc))
+        assert(errors = xsd.validate(doc))
         assert_equal(2, errors.length)
       end
 
-      def test_validate_invalid_file
+      it "validate_invalid_file" do
         tempfile = Tempfile.new("xml")
 
         doc = Nokogiri::XML(File.read(PO_XML_FILE))
@@ -194,156 +162,187 @@ module Nokogiri
         tempfile.write(doc.to_xml)
         tempfile.close
 
-        assert(errors = @xsd.validate(tempfile.path))
+        assert(errors = xsd.validate(tempfile.path))
         assert_equal(2, errors.length)
       end
 
-      def test_validate_non_document
+      it "validate_non_document" do
         string = File.read(PO_XML_FILE)
-        assert_raises(ArgumentError) { @xsd.validate(string) }
+        assert_raises(ArgumentError) { xsd.validate(string) }
       end
 
-      def test_validate_empty_document
+      it "validate_empty_document" do
         doc = Nokogiri::XML("")
-        assert(errors = @xsd.validate(doc))
+        assert(errors = xsd.validate(doc))
 
         pending_if("https://github.com/sparklemotion/nokogiri/issues/783", Nokogiri.jruby?) do
           assert_equal(1, errors.length)
         end
       end
 
-      def test_valid?
+      it "valid?" do
         valid_doc = Nokogiri::XML(File.read(PO_XML_FILE))
 
         invalid_doc = Nokogiri::XML(
           File.read(PO_XML_FILE).gsub(%r{<city>[^<]*</city>}, ""),
         )
 
-        assert(@xsd.valid?(valid_doc))
-        refute(@xsd.valid?(invalid_doc))
+        assert(xsd.valid?(valid_doc))
+        refute(xsd.valid?(invalid_doc))
       end
+    end
 
-      def test_xsd_with_dtd
-        Dir.chdir(File.join(ASSETS_DIR, "saml")) do
-          # works
-          Nokogiri::XML::Schema(File.read("xmldsig_schema.xsd"))
-          # was not working
-          Nokogiri::XML::Schema(File.read("saml20protocol_schema.xsd"))
-        end
+    it "xsd_with_dtd" do
+      Dir.chdir(File.join(ASSETS_DIR, "saml")) do
+        # works
+        Nokogiri::XML::Schema(File.read("xmldsig_schema.xsd"))
+        # was not working
+        Nokogiri::XML::Schema(File.read("saml20protocol_schema.xsd"))
       end
+    end
 
-      def test_xsd_import_with_no_systemid
-        # https://github.com/sparklemotion/nokogiri/pull/2296
-        xsd = <<~EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <xs:schema
-            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-            xmlns="http://www.w3.org/1998/Math/MathML"
-            targetNamespace="http://www.w3.org/1998/Math/MathML"
-          >
-          <xs:import/>
+    it "xsd_import_with_no_systemid" do
+      # https://github.com/sparklemotion/nokogiri/pull/2296
+      xsd = <<~EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xs:schema
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns="http://www.w3.org/1998/Math/MathML"
+          targetNamespace="http://www.w3.org/1998/Math/MathML"
+        >
+        <xs:import/>
+        </xs:schema>
+      EOF
+      Nokogiri::XML::Schema(xsd) # assert_nothing_raised
+    end
+
+    it "issue_1985_schema_parse_modifying_underlying_document" do
+      skip_unless_libxml2("Pure Java version doesn't have this bug")
+
+      # This is a test for a workaround for a bug in LibXML2:
+      #
+      #   https://gitlab.gnome.org/GNOME/libxml2/issues/148
+      #
+      # Schema creation can modify the original document -- removal of blank text nodes -- which
+      # results in dangling pointers.
+      #
+      # If no nodes have been exposed, then it should be fine to create a schema. If nodes have
+      # been exposed to Ruby, then we need to make sure they won't be freed out from under us.
+      doc = <<~EOF
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+          <xs:element name="foo" type="xs:string"/>
+        </xs:schema>
+      EOF
+
+      # This is OK, no nodes have been exposed
+      xsd_doc = Nokogiri::XML(doc)
+      assert(Nokogiri::XML::Schema.from_document(xsd_doc))
+
+      # This is not OK, nodes have been exposed to Ruby
+      xsd_doc = Nokogiri::XML(doc)
+      child = xsd_doc.root.children.find(&:blank?) # Find a blank node that would be freed without the fix
+
+      Nokogiri::XML::Schema.from_document(xsd_doc)
+      assert(child.to_s) # This will raise a valgrind error if the node was freed
+    end
+
+    describe "CVE-2020-26247" do
+      # https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m
+      let(:schema) do
+        <<~EOSCHEMA
+          <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:import namespace="test" schemaLocation="http://localhost:8000/making-a-request"/>
           </xs:schema>
-        EOF
-        Nokogiri::XML::Schema(xsd) # assert_nothing_raised
+        EOSCHEMA
       end
 
-      describe "CVE-2020-26247" do
-        # https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m
-        let(:schema) do
-          <<~EOSCHEMA
-            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-              <xs:import namespace="test" schemaLocation="http://localhost:8000/making-a-request"/>
-            </xs:schema>
-          EOSCHEMA
-        end
-
-        if Nokogiri.uses_libxml?
-          describe "with default parse options" do
-            it "XML::Schema parsing does not attempt to access external DTDs" do
-              doc = Nokogiri::XML::Schema.new(schema)
-              errors = doc.errors.map(&:to_s)
-              assert_equal(
-                1,
-                errors.grep(/ERROR: Attempt to load network entity/).length,
-                "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-              )
-              assert_empty(
-                errors.grep(/WARNING: failed to load HTTP resource/),
-                "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
-              )
-              assert_empty(
-                errors.grep(/WARNING: failed to load external entity/),
-                "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
-              )
-            end
-
-            it "XML::Schema parsing of memory does not attempt to access external DTDs" do
-              doc = Nokogiri::XML::Schema.read_memory(schema)
-              errors = doc.errors.map(&:to_s)
-              assert_equal(
-                1,
-                errors.grep(/ERROR: Attempt to load network entity/).length,
-                "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-              )
-              assert_empty(
-                errors.grep(/WARNING: failed to load HTTP resource/),
-                "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
-              )
-              assert_empty(
-                errors.grep(/WARNING: failed to load external entity/),
-                "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
-              )
-            end
+      if Nokogiri.uses_libxml?
+        describe "with default parse options" do
+          it "XML::Schema parsing does not attempt to access external DTDs" do
+            doc = Nokogiri::XML::Schema.new(schema)
+            errors = doc.errors.map(&:to_s)
+            assert_equal(
+              1,
+              errors.grep(/ERROR: Attempt to load network entity/).length,
+              "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
+            )
+            assert_empty(
+              errors.grep(/WARNING: failed to load HTTP resource/),
+              "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
+            )
+            assert_empty(
+              errors.grep(/WARNING: failed to load external entity/),
+              "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
+            )
           end
 
-          describe "with NONET turned off" do
-            it "XML::Schema parsing attempts to access external DTDs" do
-              doc = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions.new.nononet)
-              errors = doc.errors.map(&:to_s)
-              assert_equal(
-                0,
-                errors.grep(/ERROR: Attempt to load network entity/).length,
-                "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-              )
-              assert_equal(1, errors.grep(/WARNING: failed to load HTTP resource|WARNING: failed to load external entity/).length)
-            end
-
-            it "XML::Schema parsing of memory attempts to access external DTDs" do
-              doc = Nokogiri::XML::Schema.read_memory(schema, Nokogiri::XML::ParseOptions.new.nononet)
-              errors = doc.errors.map(&:to_s)
-              assert_equal(
-                0,
-                errors.grep(/ERROR: Attempt to load network entity/).length,
-                "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-              )
-              assert_equal(1, errors.grep(/WARNING: failed to load HTTP resource|WARNING: failed to load external entity/).length)
-            end
+          it "XML::Schema parsing of memory does not attempt to access external DTDs" do
+            doc = Nokogiri::XML::Schema.read_memory(schema)
+            errors = doc.errors.map(&:to_s)
+            assert_equal(
+              1,
+              errors.grep(/ERROR: Attempt to load network entity/).length,
+              "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
+            )
+            assert_empty(
+              errors.grep(/WARNING: failed to load HTTP resource/),
+              "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
+            )
+            assert_empty(
+              errors.grep(/WARNING: failed to load external entity/),
+              "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
+            )
           end
         end
 
-        if Nokogiri.jruby?
-          describe "with default parse options" do
-            it "XML::Schema parsing does not attempt to access external DTDs" do
-              doc = Nokogiri::XML::Schema.new(schema)
-              assert_equal 1, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-            end
-
-            it "XML::Schema parsing of memory does not attempt to access external DTDs" do
-              doc = Nokogiri::XML::Schema.read_memory(schema)
-              assert_equal 1, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-            end
+        describe "with NONET turned off" do
+          it "XML::Schema parsing attempts to access external DTDs" do
+            doc = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions.new.nononet)
+            errors = doc.errors.map(&:to_s)
+            assert_equal(
+              0,
+              errors.grep(/ERROR: Attempt to load network entity/).length,
+              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
+            )
+            assert_equal(1, errors.grep(/WARNING: failed to load HTTP resource|WARNING: failed to load external entity/).length)
           end
 
-          describe "with NONET turned off" do
-            it "XML::Schema parsing attempts to access external DTDs" do
-              doc = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions.new.nononet)
-              assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-            end
+          it "XML::Schema parsing of memory attempts to access external DTDs" do
+            doc = Nokogiri::XML::Schema.read_memory(schema, Nokogiri::XML::ParseOptions.new.nononet)
+            errors = doc.errors.map(&:to_s)
+            assert_equal(
+              0,
+              errors.grep(/ERROR: Attempt to load network entity/).length,
+              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
+            )
+            assert_equal(1, errors.grep(/WARNING: failed to load HTTP resource|WARNING: failed to load external entity/).length)
+          end
+        end
+      end
 
-            it "XML::Schema parsing of memory attempts to access external DTDs" do
-              doc = Nokogiri::XML::Schema.read_memory(schema, Nokogiri::XML::ParseOptions.new.nononet)
-              assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-            end
+      if Nokogiri.jruby?
+        describe "with default parse options" do
+          it "XML::Schema parsing does not attempt to access external DTDs" do
+            doc = Nokogiri::XML::Schema.new(schema)
+            assert_equal 1, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
+          end
+
+          it "XML::Schema parsing of memory does not attempt to access external DTDs" do
+            doc = Nokogiri::XML::Schema.read_memory(schema)
+            assert_equal 1, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
+          end
+        end
+
+        describe "with NONET turned off" do
+          it "XML::Schema parsing attempts to access external DTDs" do
+            doc = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions.new.nononet)
+            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
+          end
+
+          it "XML::Schema parsing of memory attempts to access external DTDs" do
+            doc = Nokogiri::XML::Schema.read_memory(schema, Nokogiri::XML::ParseOptions.new.nononet)
+            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
           end
         end
       end

--- a/test/xml/test_text.rb
+++ b/test/xml/test_text.rb
@@ -27,6 +27,13 @@ describe Nokogiri::XML::Text do
       assert_equal("hello world", node.content)
       assert_same(doc, node.document)
     end
+
+    it "does not accept anything other than Node or Document" do
+      assert_raises(TypeError) { Nokogiri::XML::Text.new("hello world", 1234) }
+      assert_raises(TypeError) { Nokogiri::XML::Text.new("hello world", "asdf") }
+      assert_raises(TypeError) { Nokogiri::XML::Text.new("hello world", {}) }
+      assert_raises(TypeError) { Nokogiri::XML::Text.new("hello world", nil) }
+    end
   end
 
   it "has a valid css path" do

--- a/test/xml/test_text.rb
+++ b/test/xml/test_text.rb
@@ -2,74 +2,75 @@
 
 require "helper"
 
-module Nokogiri
-  module XML
-    class TestText < Nokogiri::TestCase
-      def test_css_path
-        doc  = Nokogiri.XML("<root> foo <a>something</a> bar bazz </root>")
-        node = doc.root.children[2]
-        assert_instance_of(Nokogiri::XML::Text, node)
-        assert_equal(node, doc.at_css(node.css_path))
-      end
+describe Nokogiri::XML::Text do
+  describe ".new" do
+    it "does constructor things" do
+      doc = Nokogiri::XML::Document.new
+      node = Nokogiri::XML::Text.new("hello world", doc)
 
-      def test_inspect
-        node = Text.new("hello world", Document.new)
-        assert_equal("#<#{node.class.name}:#{format("0x%x", node.object_id)} #{node.text.inspect}>", node.inspect)
-      end
-
-      def test_new
-        node = Text.new("hello world", Document.new)
-        assert(node)
-        assert_equal("hello world", node.content)
-        assert_instance_of(Nokogiri::XML::Text, node)
-      end
-
-      def test_lots_of_text
-        100.times { Text.new("hello world", Document.new) }
-      end
-
-      def test_new_without_document
-        doc = Document.new
-        node = Nokogiri::XML::Element.new("foo", doc)
-        new_node = nil
-
-        assert_output(nil, /Passing a Node as the second parameter to Text.new is deprecated/) do
-          new_node = Text.new("hello world", node)
-        end
-        assert(new_node)
-      end
-
-      def test_content=
-        node = Text.new("foo", Document.new)
-        assert_equal("foo", node.content)
-        node.content = "& <foo> &amp;"
-        assert_equal("& <foo> &amp;", node.content)
-        assert_equal("&amp; &lt;foo&gt; &amp;amp;", node.to_xml)
-      end
-
-      def test_add_child
-        node = Text.new("foo", Document.new)
-        exc = if Nokogiri.jruby?
-          RuntimeError
-        else
-          ArgumentError
-        end
-        assert_raises(exc) do
-          node.add_child(Text.new("bar", Document.new))
-        end
-        assert_raises(exc) do
-          node << Text.new("bar", Document.new)
-        end
-      end
-
-      def test_wrap
-        xml = '<root><thing><div class="title">important thing</div></thing></root>'
-        doc = Nokogiri::XML(xml)
-        text = doc.at_css("div").children.first
-        text.wrap("<wrapper/>")
-        assert_equal("wrapper", text.parent.name)
-        assert_equal("wrapper", doc.at_css("div").children.first.name)
-      end
+      assert(node)
+      assert_instance_of(Nokogiri::XML::Text, node)
+      assert_equal("hello world", node.content)
+      assert_same(doc, node.document)
     end
+
+    it "accepts a node but warns about it" do
+      doc = Nokogiri::XML::Document.new
+      related_node = Nokogiri::XML::Element.new("foo", doc)
+      node = nil
+
+      assert_output(nil, /Passing a Node as the second parameter to Text.new is deprecated/) do
+        node = Nokogiri::XML::Text.new("hello world", related_node)
+      end
+      assert(node)
+      assert_instance_of(Nokogiri::XML::Text, node)
+      assert_equal("hello world", node.content)
+      assert_same(doc, node.document)
+    end
+  end
+
+  it "has a valid css path" do
+    doc  = Nokogiri.XML("<root> foo <a>something</a> bar bazz </root>")
+    node = doc.root.children[2]
+
+    assert_instance_of(Nokogiri::XML::Text, node)
+    assert_equal(node, doc.at_css(node.css_path))
+  end
+
+  it "supports #inspect" do
+    node = Nokogiri::XML::Text.new("hello world", Nokogiri::XML::Document.new)
+    assert_equal("#<#{node.class.name}:#{format("0x%x", node.object_id)} #{node.text.inspect}>", node.inspect)
+  end
+
+  it "supports #content and #content=" do
+    node = Nokogiri::XML::Text.new("foo", Nokogiri::XML::Document.new)
+
+    assert_equal("foo", node.content)
+
+    node.content = "& <foo> &amp;"
+
+    assert_equal("& <foo> &amp;", node.content)
+    assert_equal("&amp; &lt;foo&gt; &amp;amp;", node.to_xml)
+  end
+
+  it "raises when adding a child" do
+    doc = Nokogiri::XML::Document.new
+    node = Nokogiri::XML::Text.new("foo", doc)
+    exception_type = Nokogiri.jruby? ? RuntimeError : ArgumentError # TODO: make this consistent
+
+    assert_raises(exception_type) { node.add_child(Nokogiri::XML::Text.new("bar", doc)) }
+    assert_raises(exception_type) { node.add_child(Nokogiri::XML::Element.new("div", doc)) }
+    assert_raises(exception_type) { node << Nokogiri::XML::Text.new("bar", doc) }
+    assert_raises(exception_type) { node << Nokogiri::XML::Element.new("div", doc) }
+  end
+
+  it "supports #wrap" do
+    xml = "<root><thing><div>important thing</div></thing></root>"
+    doc = Nokogiri::XML(xml)
+    text = doc.at_css("div").children.first
+    text.wrap("<wrapper/>")
+
+    assert_equal("wrapper", text.parent.name)
+    assert_equal("wrapper", doc.at_css("div").children.first.name)
   end
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Hackerone user [nmb-se](https://hackerone.com/nmb-se?type=user) (Mikael Borg) reported an issue with typechecking arguments to `XML::Text.new` that could lead to a segfault.

This PR fixes the typechecking for `Text.new` as well as similar problems in `CDATA.new` and `Schema.from_document` in both the C and the Java implementations.

Related to #2825.

**Have you included adequate test coverage?**

Yes!

**Does this change affect the behavior of either the C or the Java implementations?**

Both implementations have been updated.