### PR TITLE
fix memsize_node when called on xmlAttrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ## next / unreleased
 
-...
+* [CRuby] `ObjectSpace.memsize_of` is now safe to call on `Document`s with complex DTDs. In previous versions, this debugging method could result in a segfault. [[#2923](https://github.com/sparklemotion/nokogiri/issues/2923), [#2924](https://github.com/sparklemotion/nokogiri/issues/2924)]
 
 
 ## 1.15.3 / 2023-07-05

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -103,8 +103,11 @@ memsize_node(const xmlNodePtr node)
   size_t memsize = 0;
 
   memsize += xmlStrlen(node->name);
-  for (child = (xmlNodePtr)node->properties; child; child = child->next) {
-    memsize += sizeof(xmlAttr) + memsize_node(child);
+
+  if (node->type == XML_ELEMENT_NODE) {
+    for (child = (xmlNodePtr)node->properties; child; child = child->next) {
+      memsize += sizeof(xmlAttr) + memsize_node(child);
+    }
   }
   if (node->type == XML_TEXT_NODE) {
     memsize += xmlStrlen(node->content);

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -100,13 +100,14 @@ memsize_node(const xmlNodePtr node)
 {
   /* note we don't count namespace definitions, just going for a good-enough number here */
   xmlNodePtr child;
+  xmlAttrPtr property;
   size_t memsize = 0;
 
   memsize += xmlStrlen(node->name);
 
   if (node->type == XML_ELEMENT_NODE) {
-    for (child = (xmlNodePtr)node->properties; child; child = child->next) {
-      memsize += sizeof(xmlAttr) + memsize_node(child);
+    for (property = node->properties; property; property = property->next) {
+      memsize += sizeof(xmlAttr) + memsize_node((xmlNodePtr)property);
     }
   }
   if (node->type == XML_TEXT_NODE) {

--- a/test/test_memory_leak.rb
+++ b/test/test_memory_leak.rb
@@ -313,6 +313,21 @@ class TestMemoryLeak < Nokogiri::TestCase
     assert(bigger_name_size > base_size, "longer tags should increase memsize")
   end
 
+  def test_object_space_memsize_with_dtd
+    # https://github.com/sparklemotion/nokogiri/issues/2923
+    require "objspace"
+    skip("memsize_of not defined") unless ObjectSpace.respond_to?(:memsize_of)
+
+    doc = Nokogiri::XML(<<~XML)
+      <?xml version="1.0"?>
+      <!DOCTYPE staff PUBLIC "staff.dtd" [
+        <!ATTLIST payment type CDATA "check">
+      ]>
+      <staff></staff>
+    XML
+    ObjectSpace.memsize_of(doc) # assert_does_not_crash
+  end
+
   module MemInfo
     # from https://stackoverflow.com/questions/7220896/get-current-ruby-process-memory-usage
     # this is only going to work on linux


### PR DESCRIPTION
The `properties` field of an `xmlNode` element points to an `xmlAttr`. The first few fields of `xmlAttr` are in common with `xmlNode`, but not the `properties` field which doesn't exist in an `xmlAttr`.

The `memsize_node` function was passing an `xmlAttr` to a recursive call and then trying to do the same with the properties of that.

This led to type confusion and subsequent crashes.

Fixes: #2923

<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

#2923

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

No. I don't know how to test this behavior. I'd appreciate help with this.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

It fixes a crash in the C implementation.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
