### PR TITLE
internal: remove mark function from XML::Document

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -51,17 +51,6 @@ remove_private(xmlNodePtr node)
 }
 
 static void
-mark(void *data)
-{
-  xmlDocPtr doc = (xmlDocPtr)data;
-  nokogiriTuplePtr tuple = (nokogiriTuplePtr)doc->_private;
-  if (tuple) {
-    rb_gc_mark(tuple->doc);
-    rb_gc_mark(tuple->node_cache);
-  }
-}
-
-static void
 dealloc(void *data)
 {
   xmlDocPtr doc = (xmlDocPtr)data;
@@ -132,7 +121,6 @@ memsize(const void *data)
 static const rb_data_type_t noko_xml_document_data_type = {
   .wrap_struct_name = "Nokogiri::XML::Document",
   .function = {
-    .dmark = mark,
     .dfree = dealloc,
     .dsize = memsize,
   },


### PR DESCRIPTION
**What problem is this PR intended to solve?**

remove mark function from XML::Document. originally introduced in dd07ce86, I don't think we need it anymore since cb1557d0 introduced TypedData conventions to support compaction.

cc @tenderlove and @byroot for a gut check


**Have you included adequate test coverage?**

existing coverage should be sufficient to detect if there's an issue with compaction.


**Does this change affect the behavior of either the C or the Java implementations?**

No behavior changes.