### PR TITLE
Add suppressions for ruby-3.3 inline cache references

### DIFF
--- a/suppressions/ruby-3.3.supp
+++ b/suppressions/ruby-3.3.supp
@@ -1,0 +1,26 @@
+{
+  https://github.com/sparklemotion/nokogiri/issues/2928 / https://github.com/Shopify/ruby_memcheck/issues/23
+  Memcheck:Leak
+  fun:malloc
+  fun:objspace_xmalloc0
+  fun:ary_heap_alloc
+  fun:ary_resize_capa
+  fun:ary_double_capa
+  fun:ary_ensure_room_for_push
+  fun:rb_ary_push
+  fun:noko_xml_node_wrap
+  ...
+}
+{
+  https://github.com/sparklemotion/nokogiri/issues/2928 / https://github.com/Shopify/ruby_memcheck/issues/23
+  Memcheck:Leak
+  fun:malloc
+  fun:objspace_xmalloc0
+  fun:ary_heap_alloc
+  fun:ary_resize_capa
+  fun:ary_double_capa
+  fun:ary_ensure_room_for_push
+  fun:rb_ary_push
+  fun:__xmlRaiseError
+  ...
+}


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See #2928 and https://github.com/Shopify/ruby_memcheck/issues/23
