### PR TITLE
Bump ruby_memcheck to 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development do
   # tests
   gem "minitest", "5.19.0"
   gem "minitest-reporters", "1.6.1"
-  gem "ruby_memcheck", "1.3.2"
+  gem "ruby_memcheck", "2.0.0"
   gem "rubyzip", "~> 2.3.2"
   gem "simplecov", "= 0.21.2"
 

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -24,10 +24,7 @@ class ValgrindTestTask < Rake::TestTask
   ]
 
   if defined?(RubyMemcheck)
-    RubyMemcheck.config(
-      binary_name: "nokogiri",
-      valgrind_generate_suppressions: true,
-    )
+    RubyMemcheck.config(valgrind_generate_suppressions: true)
   end
 
   def ruby(*args, **options, &block)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,10 +13,12 @@
 # - NOKOGIRI_GC: read more in test/test_memory_leak.rb
 #
 
-require "simplecov"
-SimpleCov.start do
-  add_filter "/test/"
-  enable_coverage :branch
+unless ENV["RUBY_MEMCHECK_RUNNING"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+    enable_coverage :branch
+  end
 end
 
 $VERBOSE = true


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Bumps ruby_memcheck to 2.0.0 which includes several breaking changes, one of which being that `binary_name` is no longer used in `RubyMemcheck.config`.

The new ruby_memcheck does not work well with SimpleCov, so it's disabled when ruby_memcheck is running. 

**Have you included adequate test coverage?**

N/A.

**Does this change affect the behavior of either the C or the Java implementations?**

No.
