### PR TITLE
dep: update libxml2 to v2.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ## next / unreleased
 
+### Dependencies
+
+* [CRuby] Vendored libxml2 is updated to v2.11.5 from v2.11.4. For details please see https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.5
+
+
+### Fixed
+
 * Fixed a typo in a HTML5 parser error message. [[#2927](https://github.com/sparklemotion/nokogiri/issues/2927)] (Thanks, [@anishathalye](https://github.com/anishathalye)!)
 * [CRuby] `ObjectSpace.memsize_of` is now safe to call on `Document`s with complex DTDs. In previous versions, this debugging method could result in a segfault. [[#2923](https://github.com/sparklemotion/nokogiri/issues/2923), [#2924](https://github.com/sparklemotion/nokogiri/issues/2924)]
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,7 +1,7 @@
 libxml2:
-  version: "2.11.4"
-  sha256: "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.4.sha256sum
+  version: "2.11.5"
+  sha256: "3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.5.sha256sum
 
 libxslt:
   version: "1.1.38"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#2948

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.5
