### PR TITLE
dep: update libxml2 to v2.11.5 (backport to v1.15.x)

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,7 +1,7 @@
 libxml2:
-  version: "2.11.4"
-  sha256: "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.4.sha256sum
+  version: "2.11.5"
+  sha256: "3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.5.sha256sum
 
 libxslt:
   version: "1.1.38"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#2948 - backported to v1.15.x

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.5
