### PR TITLE
test: update to handle upstream libxml2 error changes

### DIFF
--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -765,7 +765,12 @@ module Nokogiri
           e = assert_raises(Nokogiri::XML::SyntaxError) do
             reader.attribute_hash
           end
-          assert_includes(e.message, "FATAL: Extra content at the end of the document")
+          expected = if Nokogiri.uses_libxml?(">= 2.12.0") # upstream commit 53050b1d
+            "FATAL: Premature end of data in tag foo line 1"
+          else
+            "FATAL: Extra content at the end of the document"
+          end
+          assert_includes(e.message, expected)
         end
 
         assert_equal(1, reader.errors.length)
@@ -796,7 +801,12 @@ module Nokogiri
           e = assert_raises(Nokogiri::XML::SyntaxError) do
             reader.namespaces
           end
-          assert_includes(e.message, "FATAL: Extra content at the end of the document")
+          expected = if Nokogiri.uses_libxml?(">= 2.12.0") # upstream commit 53050b1d
+            "FATAL: Premature end of data in tag foo line 1"
+          else
+            "FATAL: Extra content at the end of the document"
+          end
+          assert_includes(e.message, expected)
         end
 
         assert_equal(1, reader.errors.length)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Upstream integration tests against libxml2 have been failing for a few days:

https://github.com/sparklemotion/nokogiri/actions/runs/6070705559/job/16467292067

Bisecting shows the behavior changed in libxml2 commit 53050b1d. Let's update the test to handle the different error message.
