### PR TITLE
dev: use minitest-parallel_fork to speed up the suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,14 @@ To run a focused test, use Minitest's `TESTOPTS`:
 bundle exec rake compile test TESTOPTS="-n/test_last_element_child/"
 ```
 
+To run the test suite in parallel, set the `NCPU` environment variable; and to compile in parallel, set the `MAKEFLAGS` environment variable (you may want to set these in something like your .bashrc):
+
+``` sh
+export NCPU=8
+export MAKEFLAGS=-j8
+bundle exec rake compile test
+```
+
 
 ### CRuby advanced usage
 
@@ -173,9 +181,6 @@ bundle exec rake compile test:memcheck
 Note that by you can run the test suite with a variety of GC behaviors. For example, running a major after each test completes has, on occasion, been useful for localizing some classes of memory bugs, but does slow the suite down. Some variations of the test suite behavior are available (see `test/helper.rb` for more info):
 
 ``` sh
-# see failure messages immediately
-NOKOGIRI_TEST_FAIL_FAST=t bundle exec rake compile test
-
 # ordinary GC behavior
 NOKOGIRI_TEST_GC_LEVEL=normal bundle exec rake compile test
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development do
 
   # tests
   gem "minitest", "5.20.0"
+  gem "minitest-parallel_fork", "1.3.1"
   gem "minitest-reporters", "1.6.1"
   gem "ruby_memcheck", "2.2.0"
   gem "rubyzip", "~> 2.3.2"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -80,14 +80,6 @@ module Nokogiri
     XSLT_FILE            = File.join(ASSETS_DIR, "staff.xslt")
     XPATH_FILE           = File.join(ASSETS_DIR, "slow-xpath.xml")
 
-    def i_am_ruby_matching(gem_version_requirement_string)
-      Gem::Requirement.new(gem_version_requirement_string).satisfied_by?(Gem::Version.new(RUBY_VERSION))
-    end
-
-    def i_am_in_a_systemd_container
-      File.exist?("/proc/self/cgroup") && File.read("/proc/self/cgroup") =~ %r(/docker/|/garden/)
-    end
-
     def i_am_running_in_valgrind
       # https://stackoverflow.com/questions/365458/how-can-i-detect-if-a-program-is-running-from-within-valgrind/62364698#62364698
       ENV["LD_PRELOAD"] =~ /valgrind|vgpreload/
@@ -203,7 +195,6 @@ module Nokogiri
           end
         when "verify"
           if @@test_count % COMPACT_EVERY == 0
-            # https://alanwu.space/post/check-compaction/
             gc_verify_compaction_references
           end
           GC.start(full_mark: true)
@@ -220,6 +211,7 @@ module Nokogiri
     end
 
     def gc_verify_compaction_references
+      # https://alanwu.space/post/check-compaction/
       if Gem::Requirement.new(">= 3.2.0").satisfied_by?(Gem::Version.new(RUBY_VERSION))
         GC.verify_compaction_references(expand_heap: true, toward: :empty)
       else
@@ -266,14 +258,6 @@ module Nokogiri
       document.decorators(XML::NodeSet) << decorator_module
       document.decorate!
     end
-
-    def assert_not_send(send_ary, m = nil)
-      recv, msg, *args = send_ary
-      m = message(m) do
-        "Expected #{mu_pp(recv)}.#{msg}(*#{mu_pp(args)}) to return false"
-      end
-      refute(recv.__send__(msg, *args), m)
-    end unless method_defined?(:assert_not_send)
 
     def pending(msg)
       begin


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Faster test suite in development!

With NCPU=7 I can usually get the suite done in under 1.8 seconds on my laptop (inspired by [tldr](https://github.com/tendersearls/tldr))

Note that I dropped minitest-reporters because the two gems aren't compatible. I wasn't often using minitest-reporters features, anyhow.
