### PR TITLE
dep: drop minitest-reporters, avoid psych 5.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ group :development do
   # tests
   gem "minitest", "5.20.0"
   gem "minitest-parallel_fork", "1.3.1"
-  gem "minitest-reporters", "1.6.1"
   gem "ruby_memcheck", "2.2.0"
   gem "rubyzip", "~> 2.3.2"
   gem "simplecov", "= 0.21.2"

--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,5 @@ end
 group :rdoc do
   gem "rdoc", "6.5.0"
 end
+
+gem "psych", "!= 5.1.1", "!= 5.1.0" # https://github.com/ruby/psych/issues/655

--- a/scripts/test-gem-file-contents
+++ b/scripts/test-gem-file-contents
@@ -16,7 +16,6 @@ require "bundler/inline"
 gemfile do
   source "https://rubygems.org"
   gem "minitest"
-  gem "minitest-reporters"
 end
 
 require "yaml"
@@ -66,8 +65,6 @@ if ARGV.include?("-v")
 end
 
 require "minitest/autorun"
-require "minitest/reporters"
-Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
 
 puts "Testing '#{gemfile}' (#{gemspec.platform})"
 describe File.basename(gemfile) do

--- a/scripts/test-gem-installation
+++ b/scripts/test-gem-installation
@@ -22,7 +22,6 @@ require "bundler/inline"
 gemfile do
   source "https://rubygems.org"
   gem "minitest"
-  gem "minitest-reporters"
   gem "nokogiri"
 end
 
@@ -39,8 +38,6 @@ if ARGV.include?("-v")
 end
 
 require "minitest/autorun"
-require "minitest/reporters"
-Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
 
 puts "Testing #{gemspec.full_name} installed in #{gemspec.base_dir}"
 describe gemspec.full_name do

--- a/scripts/test-nokogumbo-compatibility
+++ b/scripts/test-nokogumbo-compatibility
@@ -41,7 +41,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
   gem "minitest"
-  gem "minitest-reporters"
   gem "nokogiri", "=#{gemspec.version}"
   if nokogumbo_version
     gem "nokogumbo", "=#{nokogumbo_version}"
@@ -68,8 +67,6 @@ if ARGV.include?("-v")
 end
 
 require "minitest/autorun"
-require "minitest/reporters"
-Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
 
 puts "Testing #{gemspec.full_name} installed in #{gemspec.base_dir}"
 describe gemspec.full_name do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

drop minitest-reporters, because even having it in the Gemfile messes with
minitest-parallel_fork, sigh.

For context, see:

- https://github.com/minitest-reporters/minitest-reporters/issues/247
- https://github.com/jeremyevans/minitest-parallel_fork/pull/3

Also, avoid psych 5.1.1 because of https://github.com/ruby/psych/issues/655
