### PR TITLE
test: remove psych from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,5 +43,3 @@ end
 group :rdoc do
   gem "rdoc", "6.5.0"
 end
-
-gem "psych", "!= 5.1.1", "!= 5.1.0" # https://github.com/ruby/psych/issues/655

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -50,7 +50,7 @@ warn
 
 require "minitest/autorun"
 require "minitest/benchmark"
-if ENV["NCPU"]
+if ENV["NCPU"] && !Nokogiri.jruby?
   require "minitest/parallel_fork"
   warn "Running parallel tests with NCPU=#{ENV["NCPU"].inspect}"
 end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Revert commit https://github.com/sparklemotion/nokogiri/commit/59e4981a4fe68e1fa0372451f7950f6aebb2d8eb which avoided versions of psych that don't work on JRuby

