### PR TITLE
dev: handle upcoming libxml2's use of const for xmlError pointers

### DIFF
--- a/ext/nokogiri/html4_sax_push_parser.c
+++ b/ext/nokogiri/html4_sax_push_parser.c
@@ -32,7 +32,7 @@ native_write(VALUE self, VALUE _chunk, VALUE _last_chunk)
 
   if ((status != 0) && !(ctx->options & XML_PARSE_RECOVER)) {
     // TODO: there appear to be no tests for this block
-    xmlErrorPtr e = xmlCtxtGetLastError(ctx);
+    xmlErrorConstPtr e = xmlCtxtGetLastError(ctx);
     Nokogiri_error_raise(NULL, e);
   }
 

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -66,6 +66,9 @@ xmlNodePtr xmlLastElementChild(xmlNodePtr parent);
 #define XMLNS_PREFIX "xmlns"
 #define XMLNS_PREFIX_LEN 6 /* including either colon or \0 */
 
+#ifndef xmlErrorConstPtr
+#  define xmlErrorConstPtr const xmlError *
+#endif
 
 #include <ruby.h>
 #include <ruby/st.h>
@@ -227,9 +230,9 @@ void Nokogiri_structured_error_func_save(libxmlStructuredErrorHandlerState *hand
 void Nokogiri_structured_error_func_save_and_set(libxmlStructuredErrorHandlerState *handler_state, void *user_data,
     xmlStructuredErrorFunc handler);
 void Nokogiri_structured_error_func_restore(libxmlStructuredErrorHandlerState *handler_state);
-VALUE Nokogiri_wrap_xml_syntax_error(xmlErrorPtr error);
-void Nokogiri_error_array_pusher(void *ctx, xmlErrorPtr error);
-NORETURN_DECL void Nokogiri_error_raise(void *ctx, xmlErrorPtr error);
+VALUE Nokogiri_wrap_xml_syntax_error(xmlErrorConstPtr error);
+void Nokogiri_error_array_pusher(void *ctx, xmlErrorConstPtr error);
+NORETURN_DECL void Nokogiri_error_raise(void *ctx, xmlErrorConstPtr error);
 void Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr ctx, int nargs, VALUE handler,
     const char *function_name) ;
 

--- a/ext/nokogiri/test_global_handlers.c
+++ b/ext/nokogiri/test_global_handlers.c
@@ -3,7 +3,7 @@
 static VALUE foreign_error_handler_block = Qnil;
 
 static void
-foreign_error_handler(void *user_data, xmlErrorPtr c_error)
+foreign_error_handler(void *user_data, xmlErrorConstPtr c_error)
 {
   rb_funcall(foreign_error_handler_block, rb_intern("call"), 0);
 }

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -337,7 +337,7 @@ read_io(VALUE klass,
   xmlSetStructuredErrorFunc(NULL, NULL);
 
   if (doc == NULL) {
-    xmlErrorPtr error;
+    xmlErrorConstPtr error;
 
     xmlFreeDoc(doc);
 
@@ -383,7 +383,7 @@ read_memory(VALUE klass,
   xmlSetStructuredErrorFunc(NULL, NULL);
 
   if (doc == NULL) {
-    xmlErrorPtr error;
+    xmlErrorConstPtr error;
 
     xmlFreeDoc(doc);
 
@@ -537,7 +537,7 @@ create_entity(int argc, VALUE *argv, VALUE self)
         );
 
   if (NULL == ptr) {
-    xmlErrorPtr error = xmlGetLastError();
+    xmlErrorConstPtr error = xmlGetLastError();
     if (error) {
       rb_exc_raise(Nokogiri_wrap_xml_syntax_error(error));
     } else {

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -2138,7 +2138,7 @@ process_xincludes(VALUE self, VALUE options)
   xmlSetStructuredErrorFunc(NULL, NULL);
 
   if (rcode < 0) {
-    xmlErrorPtr error;
+    xmlErrorConstPtr error;
 
     error = xmlGetLastError();
     if (error) {

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -554,7 +554,7 @@ static VALUE
 read_more(VALUE self)
 {
   xmlTextReaderPtr reader;
-  xmlErrorPtr error;
+  xmlErrorConstPtr error;
   VALUE error_list;
   int ret;
 

--- a/ext/nokogiri/xml_relax_ng.c
+++ b/ext/nokogiri/xml_relax_ng.c
@@ -93,7 +93,7 @@ xml_relax_ng_parse_schema(
   xmlRelaxNGFreeParserCtxt(c_parser_context);
 
   if (NULL == c_schema) {
-    xmlErrorPtr error = xmlGetLastError();
+    xmlErrorConstPtr error = xmlGetLastError();
     if (error) {
       Nokogiri_error_raise(NULL, error);
     } else {

--- a/ext/nokogiri/xml_sax_push_parser.c
+++ b/ext/nokogiri/xml_sax_push_parser.c
@@ -59,7 +59,7 @@ native_write(VALUE self, VALUE _chunk, VALUE _last_chunk)
 
   if (xmlParseChunk(ctx, chunk, size, Qtrue == _last_chunk ? 1 : 0)) {
     if (!(ctx->options & XML_PARSE_RECOVER)) {
-      xmlErrorPtr e = xmlCtxtGetLastError(ctx);
+      xmlErrorConstPtr e = xmlCtxtGetLastError(ctx);
       Nokogiri_error_raise(NULL, e);
     }
   }

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -146,7 +146,7 @@ xml_schema_parse_schema(
   xmlSchemaFreeParserCtxt(c_parser_context);
 
   if (NULL == c_schema) {
-    xmlErrorPtr error = xmlGetLastError();
+    xmlErrorConstPtr error = xmlGetLastError();
     if (error) {
       Nokogiri_error_raise(NULL, error);
     } else {

--- a/ext/nokogiri/xml_syntax_error.c
+++ b/ext/nokogiri/xml_syntax_error.c
@@ -26,7 +26,7 @@ Nokogiri_structured_error_func_restore(libxmlStructuredErrorHandlerState *handle
 }
 
 void
-Nokogiri_error_array_pusher(void *ctx, xmlErrorPtr error)
+Nokogiri_error_array_pusher(void *ctx, xmlErrorConstPtr error)
 {
   VALUE list = (VALUE)ctx;
   Check_Type(list, T_ARRAY);
@@ -34,13 +34,13 @@ Nokogiri_error_array_pusher(void *ctx, xmlErrorPtr error)
 }
 
 void
-Nokogiri_error_raise(void *ctx, xmlErrorPtr error)
+Nokogiri_error_raise(void *ctx, xmlErrorConstPtr error)
 {
   rb_exc_raise(Nokogiri_wrap_xml_syntax_error(error));
 }
 
 VALUE
-Nokogiri_wrap_xml_syntax_error(xmlErrorPtr error)
+Nokogiri_wrap_xml_syntax_error(xmlErrorConstPtr error)
 {
   VALUE msg, e, klass;
 


### PR DESCRIPTION

**What problem is this PR intended to solve?**

upcoming libxml 2.12.0 will use `const xmlError *` as the data type for many function signatures where it's `xmlErrorPtr` today.

let's update our code to use the new convention.

see https://gitlab.gnome.org/GNOME/libxml2/-/commit/45470611b047db78106dcb2fdbd4164163c15ab7 and other upstream commits
