### PR TITLE
fix: strip spaces from the operator when translating nth css to xpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Documentation on what can be matched:
 * [`XML::NodeSet#deconstruct`](https://nokogiri.org/rdoc/Nokogiri/XML/NodeSet.html?h=deconstruct#method-i-deconstruct)
 
 
+### Fixed
+
+* CSS `nth` pseudo-classes now handle spaces, e.g. `"2n + 1"`. [#3018] @fusion2004
+
 
 ## 1.15.4 / 2023-08-11
 

--- a/lib/nokogiri/css/xpath_visitor.rb
+++ b/lib/nokogiri/css/xpath_visitor.rb
@@ -302,7 +302,7 @@ module Nokogiri
       end
 
       def read_a_and_positive_b(values)
-        op = values[2]
+        op = values[2].strip
         if op == "+"
           a = values[0].to_i
           b = values[3].to_i

--- a/test/css/test_css_integration.rb
+++ b/test/css/test_css_integration.rb
@@ -194,6 +194,7 @@ class TestNokogiriCssIntegration < Nokogiri::TestCase
           assert_result_rows([5], subject.search("table//tr:nth-child(5)"))
           assert_result_rows([1, 3], subject.search("div/h1.c:nth-child(2)"), "header")
           assert_result_rows([3, 4], subject.search("div/i.b:nth-child(2n+1)"), "italic")
+          assert_result_rows([3, 4], subject.search("div/i.b:nth-child(2n + 1)"), "italic")
         end
 
         it "selects first_of_type" do

--- a/test/css/test_tokenizer.rb
+++ b/test/css/test_tokenizer.rb
@@ -226,6 +226,21 @@ module Nokogiri
           @scanner,
         )
 
+        @scanner.scan("x:nth-child(5n + 3)")
+        assert_tokens(
+          [
+            [:IDENT, "x"],
+            [":", ":"],
+            [:FUNCTION, "nth-child("],
+            [:NUMBER, "5"],
+            [:IDENT, "n"],
+            [:PLUS, " + "],
+            [:NUMBER, "3"],
+            [:RPAREN, ")"],
+          ],
+          @scanner,
+        )
+
         @scanner.scan("x:nth-child(-1n+3)")
         assert_tokens(
           [

--- a/test/css/test_xpath_visitor.rb
+++ b/test/css/test_xpath_visitor.rb
@@ -289,10 +289,12 @@ class TestNokogiri < Nokogiri::TestCase
       it ":nth(an+b)" do
         assert_xpath("//a[(position() mod 2)=0]", parser.parse("a:nth-of-type(2n)"))
         assert_xpath("//a[(position()>=1) and (((position()-1) mod 2)=0)]", parser.parse("a:nth-of-type(2n+1)"))
+        assert_xpath("//a[(position()>=1) and (((position()-1) mod 2)=0)]", parser.parse("a:nth-of-type(2n + 1)"))
         assert_xpath("//a[(position() mod 2)=0]", parser.parse("a:nth-of-type(even)"))
         assert_xpath("//a[(position()>=1) and (((position()-1) mod 2)=0)]", parser.parse("a:nth-of-type(odd)"))
         assert_xpath("//a[(position()>=3) and (((position()-3) mod 4)=0)]", parser.parse("a:nth-of-type(4n+3)"))
         assert_xpath("//a[position()<=3]", parser.parse("a:nth-of-type(-1n+3)"))
+        assert_xpath("//a[position()<=3]", parser.parse("a:nth-of-type(-1n +  3)"))
         assert_xpath("//a[position()<=3]", parser.parse("a:nth-of-type(-n+3)"))
         assert_xpath("//a[position()>=3]", parser.parse("a:nth-of-type(1n+3)"))
         assert_xpath("//a[position()>=3]", parser.parse("a:nth-of-type(n+3)"))


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

Prevent errors when nokogiri is translating nth css to xpath and there are spaces in it. (E.g. `2n + 1` instead of `2n+1`)

Background: This came up because prettier started rewriting my email css from `li:nth-child(2n+1)` to `li:nth-child(2n + 1)` (which is perfectly valid in browsers) and this caused a `expected an+b node to have either + or - as the operator, but is " + " (ArgumentError)` error from https://github.com/Mange/roadie using nokogiri as part of inlining the css.

**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

I believe so!

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

Since I only modified ruby code, I'm assuming not?