### PR TITLE
ci: add ruby version to vendored libs cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -141,7 +141,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
@@ -202,7 +202,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -227,7 +227,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
@@ -378,7 +378,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:memcheck

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -27,37 +27,46 @@ jobs:
           - url: https://github.com/flavorjones/loofah
             name: loofah
             command: "bundle exec rake test"
+            ruby: "3.2"
           - url: https://github.com/rails/rails-html-sanitizer
             name: rails-html-sanitizer
             command: "bundle exec rake test"
+            ruby: "3.2"
           - url: https://github.com/rgrove/sanitize
             name: sanitize
             command: "bundle exec rake test"
+            ruby: "3.2"
           - url: https://github.com/ebeigarts/signer
             name: signer
             command: "bundle exec rake spec"
+            ruby: "3.2"
           - url: https://github.com/WinRb/Viewpoint
             name: viewpoint
             command: "bundle exec rspec spec"
+            ruby: "3.1"
           - url: https://github.com/rails/rails
             name: xmlmini
             command: "cd activesupport && bundle exec rake test TESTOPTS=-n/XmlMini/"
+            ruby: "3.2"
           - url: https://github.com/pythonicrubyist/creek
             name: creek
             command: "bundle exec rake spec"
+            ruby: "3.2"
           - url: https://github.com/SAML-Toolkits/ruby-saml
             name: ruby-saml
             command: "bundle exec rake test MT_COMPAT=t"
+            ruby: "3.2"
           - url: https://github.com/sparklemotion/mechanize
             name: mechanize
             command: "bundle exec rake test"
+            ruby: "3.2"
           # - url: https://github.com/instructure/nokogiri-xmlsec-instructure
           #   name: nokogiri-xmlsec-instructure
           #   precommand: "apt install -y libxmlsec1-dev"
           #   command: "bundle exec rake compile rspec"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,7 +74,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ports
-          key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - if: matrix.precommand
         run: ${{matrix.precommand}}
       - run: gem install bundler -v ">= 2.3.22" # for "add --path"

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -142,7 +142,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-head-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
       - run: bundle exec rake test:memcheck
@@ -164,7 +164,7 @@ jobs:
   html5lib-tests:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.2
     steps:
       - uses: actions/checkout@v4
         with:
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ports
-          key: ports-ubuntu-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-3.2-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
       - name: Update html5lib-tests
         run: |
           cd test/html5lib-tests


### PR DESCRIPTION
**What problem is this PR intended to solve?**

In CI, add ruby version to vendored libs cache key. The ruby 2.7 and 3.0 base images are old enough
to generate binaries that are not compatible with later base images, and vice versa. CI is failing
with libxml 2.12.0 in particular.
