### PR TITLE
dep: update libxml to 2.11.5 and libxslt to 1.1.39 (main branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ Documentation on what can be matched:
 * CSS `nth` pseudo-classes now handle spaces, e.g. `"2n + 1"`. [#3018] @fusion2004
 
 
+## 1.15.next / UNRELEASED
+
+### Dependencies
+
+* [CRuby] Vendored libxml2 is updated to v2.11.6 from v2.11.5. For details please see https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.6
+* [CRuby] Vendored libxslt is updated to v1.1.39 from v1.1.38. For details please see https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.39
+
+
 ## 1.15.4 / 2023-08-11
 
 ### Dependencies

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,12 +1,13 @@
+
 libxml2:
-  version: "2.11.5"
-  sha256: "3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.5.sha256sum
+  version: "2.11.6"
+  sha256: "c90eee7506764abbe07bb616b82da452529609815aefef423d66ef080eb0c300"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.6.sha256sum
 
 libxslt:
-  version: "1.1.38"
-  sha256: "1f32450425819a09acaff2ab7a5a7f8a2ec7956e505d7beeb45e843d0e1ecab1"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.38.sha256sum
+  version: "1.1.39"
+  sha256: "2a20ad621148339b0759c4d4e96719362dee64c9a096dbba625ba053846349f0"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.39.sha256sum
 
 zlib:
   version: "1.3"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

update libxml to 2.11.5 and libxslt to 1.1.39

- https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.6
- https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.39

(forward ported from #3025 / aa3208bc908aa69a940479b0cfb8ebe0162c8d0f)
