### PR TITLE
dep: libxml 2.12.0 upgrade (with libxml2 patch for weakref)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -141,7 +141,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
@@ -202,7 +202,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
@@ -227,7 +227,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
@@ -253,7 +253,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-macos-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-macos-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 
@@ -283,7 +283,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-windows-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-windows-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 
@@ -378,7 +378,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - run: bundle install --local || bundle install
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:memcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sys: ["enable"]
+        sys: ["enable", "disable"]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:alpine

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ports
-          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-${{matrix.ruby}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - if: matrix.precommand
         run: ${{matrix.precommand}}
       - run: gem install bundler -v ">= 2.3.22" # for "add --path"

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -118,7 +118,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-${{matrix.plat}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-${{matrix.plat}}-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 
@@ -142,7 +142,7 @@ jobs:
         if: matrix.sys == 'disable'
         with:
           path: ports
-          key: ports-ubuntu-head-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-head-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test:valgrind
       - run: bundle exec rake test:memcheck
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ports
-          key: ports-ubuntu-3.2-${{hashFiles('dependencies.yml', 'patches/**/*.patch')}}
+          key: ports-ubuntu-3.2-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - name: Update html5lib-tests
         run: |
           cd test/html5lib-tests

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 
 libxml2:
-  version: "2.11.6"
-  sha256: "c90eee7506764abbe07bb616b82da452529609815aefef423d66ef080eb0c300"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.6.sha256sum
+  version: "2.12.0"
+  sha256: "431521c8e19ca396af4fa97743b5a6bfcccddbba90e16426a15e5374cd64fe0d"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.0.sha256sum
 
 libxslt:
   version: "1.1.39"

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -919,6 +919,7 @@ else
       "--with-c14n",
       "--with-debug",
       "--with-threads",
+      "--without-tls", # see https://github.com/sparklemotion/nokogiri/issues/3031
       "CPPFLAGS=#{cppflags}",
       "CFLAGS=#{cflags}",
     ]

--- a/ext/nokogiri/html4_sax_push_parser.c
+++ b/ext/nokogiri/html4_sax_push_parser.c
@@ -32,7 +32,7 @@ native_write(VALUE self, VALUE _chunk, VALUE _last_chunk)
 
   if ((status != 0) && !(ctx->options & XML_PARSE_RECOVER)) {
     // TODO: there appear to be no tests for this block
-    xmlErrorPtr e = xmlCtxtGetLastError(ctx);
+    xmlErrorConstPtr e = xmlCtxtGetLastError(ctx);
     Nokogiri_error_raise(NULL, e);
   }
 

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -66,6 +66,9 @@ xmlNodePtr xmlLastElementChild(xmlNodePtr parent);
 #define XMLNS_PREFIX "xmlns"
 #define XMLNS_PREFIX_LEN 6 /* including either colon or \0 */
 
+#ifndef xmlErrorConstPtr
+#  define xmlErrorConstPtr const xmlError *
+#endif
 
 #include <ruby.h>
 #include <ruby/st.h>
@@ -227,9 +230,9 @@ void Nokogiri_structured_error_func_save(libxmlStructuredErrorHandlerState *hand
 void Nokogiri_structured_error_func_save_and_set(libxmlStructuredErrorHandlerState *handler_state, void *user_data,
     xmlStructuredErrorFunc handler);
 void Nokogiri_structured_error_func_restore(libxmlStructuredErrorHandlerState *handler_state);
-VALUE Nokogiri_wrap_xml_syntax_error(xmlErrorPtr error);
-void Nokogiri_error_array_pusher(void *ctx, xmlErrorPtr error);
-NORETURN_DECL void Nokogiri_error_raise(void *ctx, xmlErrorPtr error);
+VALUE Nokogiri_wrap_xml_syntax_error(xmlErrorConstPtr error);
+void Nokogiri_error_array_pusher(void *ctx, xmlErrorConstPtr error);
+NORETURN_DECL void Nokogiri_error_raise(void *ctx, xmlErrorConstPtr error);
 void Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr ctx, int nargs, VALUE handler,
     const char *function_name) ;
 

--- a/ext/nokogiri/test_global_handlers.c
+++ b/ext/nokogiri/test_global_handlers.c
@@ -3,7 +3,7 @@
 static VALUE foreign_error_handler_block = Qnil;
 
 static void
-foreign_error_handler(void *user_data, xmlErrorPtr c_error)
+foreign_error_handler(void *user_data, xmlErrorConstPtr c_error)
 {
   rb_funcall(foreign_error_handler_block, rb_intern("call"), 0);
 }

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -337,7 +337,7 @@ read_io(VALUE klass,
   xmlSetStructuredErrorFunc(NULL, NULL);
 
   if (doc == NULL) {
-    xmlErrorPtr error;
+    xmlErrorConstPtr error;
 
     xmlFreeDoc(doc);
 
@@ -383,7 +383,7 @@ read_memory(VALUE klass,
   xmlSetStructuredErrorFunc(NULL, NULL);
 
   if (doc == NULL) {
-    xmlErrorPtr error;
+    xmlErrorConstPtr error;
 
     xmlFreeDoc(doc);
 
@@ -537,7 +537,7 @@ create_entity(int argc, VALUE *argv, VALUE self)
         );
 
   if (NULL == ptr) {
-    xmlErrorPtr error = xmlGetLastError();
+    xmlErrorConstPtr error = xmlGetLastError();
     if (error) {
       rb_exc_raise(Nokogiri_wrap_xml_syntax_error(error));
     } else {

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -2138,7 +2138,7 @@ process_xincludes(VALUE self, VALUE options)
   xmlSetStructuredErrorFunc(NULL, NULL);
 
   if (rcode < 0) {
-    xmlErrorPtr error;
+    xmlErrorConstPtr error;
 
     error = xmlGetLastError();
     if (error) {

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -554,7 +554,7 @@ static VALUE
 read_more(VALUE self)
 {
   xmlTextReaderPtr reader;
-  xmlErrorPtr error;
+  xmlErrorConstPtr error;
   VALUE error_list;
   int ret;
 

--- a/ext/nokogiri/xml_relax_ng.c
+++ b/ext/nokogiri/xml_relax_ng.c
@@ -93,7 +93,7 @@ xml_relax_ng_parse_schema(
   xmlRelaxNGFreeParserCtxt(c_parser_context);
 
   if (NULL == c_schema) {
-    xmlErrorPtr error = xmlGetLastError();
+    xmlErrorConstPtr error = xmlGetLastError();
     if (error) {
       Nokogiri_error_raise(NULL, error);
     } else {

--- a/ext/nokogiri/xml_sax_push_parser.c
+++ b/ext/nokogiri/xml_sax_push_parser.c
@@ -59,7 +59,7 @@ native_write(VALUE self, VALUE _chunk, VALUE _last_chunk)
 
   if (xmlParseChunk(ctx, chunk, size, Qtrue == _last_chunk ? 1 : 0)) {
     if (!(ctx->options & XML_PARSE_RECOVER)) {
-      xmlErrorPtr e = xmlCtxtGetLastError(ctx);
+      xmlErrorConstPtr e = xmlCtxtGetLastError(ctx);
       Nokogiri_error_raise(NULL, e);
     }
   }

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -146,7 +146,7 @@ xml_schema_parse_schema(
   xmlSchemaFreeParserCtxt(c_parser_context);
 
   if (NULL == c_schema) {
-    xmlErrorPtr error = xmlGetLastError();
+    xmlErrorConstPtr error = xmlGetLastError();
     if (error) {
       Nokogiri_error_raise(NULL, error);
     } else {

--- a/ext/nokogiri/xml_syntax_error.c
+++ b/ext/nokogiri/xml_syntax_error.c
@@ -26,7 +26,7 @@ Nokogiri_structured_error_func_restore(libxmlStructuredErrorHandlerState *handle
 }
 
 void
-Nokogiri_error_array_pusher(void *ctx, xmlErrorPtr error)
+Nokogiri_error_array_pusher(void *ctx, xmlErrorConstPtr error)
 {
   VALUE list = (VALUE)ctx;
   Check_Type(list, T_ARRAY);
@@ -34,13 +34,13 @@ Nokogiri_error_array_pusher(void *ctx, xmlErrorPtr error)
 }
 
 void
-Nokogiri_error_raise(void *ctx, xmlErrorPtr error)
+Nokogiri_error_raise(void *ctx, xmlErrorConstPtr error)
 {
   rb_exc_raise(Nokogiri_wrap_xml_syntax_error(error));
 }
 
 VALUE
-Nokogiri_wrap_xml_syntax_error(xmlErrorPtr error)
+Nokogiri_wrap_xml_syntax_error(xmlErrorConstPtr error)
 {
   VALUE msg, e, klass;
 

--- a/patches/libxml2/0012-fix-pthread-weak-references-in-globals.c.patch
+++ b/patches/libxml2/0012-fix-pthread-weak-references-in-globals.c.patch
@@ -1,0 +1,29 @@
+diff --git a/globals.c b/globals.c
+index a786a4b9..1b2b9ad0 100644
+--- a/globals.c
++++ b/globals.c
+@@ -118,6 +118,13 @@ static XML_THREAD_LOCAL xmlGlobalState globalState;
+     defined(__GLIBC__) && \
+     __GLIBC__ * 100 + __GLIBC_MINOR__ < 234
+ 
++#pragma weak pthread_getspecific
++#pragma weak pthread_setspecific
++#pragma weak pthread_key_create
++#pragma weak pthread_key_delete
++#pragma weak pthread_equal
++#pragma weak pthread_self
++
+ #define XML_PTHREAD_WEAK
+ 
+ static int libxml_is_threaded = -1;
+@@ -566,7 +573,9 @@ void xmlInitGlobalsInternal(void) {
+             (pthread_getspecific != NULL) &&
+             (pthread_setspecific != NULL) &&
+             (pthread_key_create != NULL) &&
+-            (pthread_key_delete != NULL);
++            (pthread_key_delete != NULL) &&
++            (pthread_equal != NULL) &&
++            (pthread_self != NULL);
+     if (libxml_is_threaded == 0)
+         return;
+ #endif /* XML_PTHREAD_WEAK */


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#3031

This approach uses the patches submitted upstream at:

- https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/229
- https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/230

and turns off libxml2's thread-local storage feature, which is an issue when precompiling for musl on glibc systems. If and when we can build a separate musl native gem, we can revisit this decision.
