### PR TITLE
test: don't run valgrind in parallel

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -30,6 +30,7 @@ class ValgrindTestTask < Rake::TestTask
   def ruby(*args, **options, &block)
     valgrind_options = check_for_suppression_file(VALGRIND_OPTIONS)
     command = "ulimit -s unlimited && valgrind #{valgrind_options.join(" ")} #{RUBY} #{args.join(" ")}"
+    ENV["NCPU"] = nil # don't run valgrind in parallel (minitest-parallel_fork)
     sh(command, **options, &block)
   end
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

In development, I have the `NCPU` environment variable set to run tests in parallel with minitest-parallel_fork.

If I run `rake test:valgrind`, it will run multiple valgrind processes, which I don't want. This change limits the run to one process.
