### PR TITLE
ext: ruby 3.3 support

### DIFF
--- a/.cross_rubies
+++ b/.cross_rubies
@@ -30,3 +30,11 @@
 3.2.0:x86-mingw32
 3.2.0:x86_64-darwin
 3.2.0:x86_64-linux
+3.3.0:aarch64-linux
+3.3.0:arm-linux
+3.3.0:arm64-darwin
+3.3.0:x64-mingw-ucrt
+3.3.0:x86-linux
+3.3.0:x86-mingw32
+3.3.0:x86_64-darwin
+3.3.0:x86_64-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,7 +431,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -453,7 +453,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -497,7 +497,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["3.1", "3.2"]
+        ruby: ["3.1", "3.2", "head"]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -556,7 +556,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -578,7 +578,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -600,7 +600,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -622,7 +622,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -659,7 +659,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -700,7 +700,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2"]
+        ruby: ["3.1", "3.2", "head"]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3-rc"]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
@@ -238,7 +238,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3.0-preview3"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -263,7 +263,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["2.7", "3.0", "3.1", "3.2", "mingw"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "head", "mingw"]
     runs-on: windows-2022
     steps:
       - name: configure git crlf

--- a/.github/workflows/generate-ci-images.yml
+++ b/.github/workflows/generate-ci-images.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["alpine", "mri-2.7", "mri-3.0", "mri-3.1", "mri-3.2", "truffle-nightly", "ubuntu", "ubuntu32"]
+        tag: ["alpine", "mri-2.7", "mri-3.0", "mri-3.1", "mri-3.2", "mri-3.3-rc", "truffle-nightly", "ubuntu", "ubuntu32"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - uses: ruby/setup-ruby@v1
@@ -22,14 +22,14 @@ jobs:
           ruby-version: "3.1"
           bundler-cache: true
           bundler: latest
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
       - name: ${{matrix.tag}}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v3
         with:
           context: "."
           push: true

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
 
   # building extensions
   gem "rake-compiler", "1.2.5"
-  gem "rake-compiler-dock", "1.3.1"
+  gem "rake-compiler-dock", "1.4.0.rc1"
 
   # parser generator
   gem "rexical", "= 1.0.7"

--- a/oci-images/nokogiri-test/mri-3.3-rc.dockerfile
+++ b/oci-images/nokogiri-test/mri-3.3-rc.dockerfile
@@ -1,0 +1,40 @@
+FROM ruby:3.3-rc
+
+# include_file debian-prelude.step
+# -*- dockerfile -*-
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y apt-utils
+
+
+# include_file debian-valgrind.step
+# -*- dockerfile -*-
+
+RUN apt-get install -y valgrind
+
+
+# include_file debian-libxml-et-al.step
+# -*- dockerfile -*-
+
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libyaml-dev # for psych 5
+
+
+# include_file update-bundler.step
+# -*- dockerfile -*-
+
+RUN gem install bundler
+
+
+# include_file bundle-install.step
+# -*- dockerfile -*-
+
+COPY Gemfile nokogiri/
+COPY Gemfile.lock nokogiri/
+COPY nokogiri.gemspec nokogiri/
+
+RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" nokogiri/Gemfile.lock | tail -n 1)"
+RUN cd nokogiri && bundle install
+

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -8,7 +8,7 @@ module DockerHelper
   IMAGE_DIR = "oci-images/nokogiri-test"
   IMAGE_NAME = "ghcr.io/sparklemotion/nokogiri-test"
   RUBIES = {
-    mri: ["2.7", "3.0", "3.1", "3.2"],
+    mri: ["2.7", "3.0", "3.1", "3.2", "3.3-rc"],
     truffle: ["nightly"],
   }
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Add precompiled native support for Ruby 3.3.

Note that this is still experimental! It is precompiling using a rake-compiler-dock prerelease that uses 3.3.0-preview3.


**Have you included adequate test coverage?**

Testing against 3.3.0-preview3 or head


**Does this change affect the behavior of either the C or the Java implementations?**

N/A