### PR TITLE
ci: remove BUNDLE_CACHE_PATH hack

### DIFF
--- a/scripts/test-gem-install
+++ b/scripts/test-gem-install
@@ -25,10 +25,6 @@ pushd $GEMS_DIR
 
 popd
 
-if [ -n "${BUNDLE_APP_CONFIG:-}" ] ; then
-  export BUNDLE_CACHE_PATH="${BUNDLE_APP_CONFIG}/cache"
-fi
-
 # 2.3.21 because https://github.com/rubygems/rubygems/issues/5914
 # 2.3.22 because https://github.com/rubygems/rubygems/issues/5940
 gem install bundler -v "~> 2.2, != 2.3.21, != 2.3.22"


### PR DESCRIPTION

**What problem is this PR intended to solve?**

remove BUNDLE_CACHE_PATH hack. it looks like the jruby images no longer have the problem this was working around, and in the ruby:3.3.0-preview3 images, it interferes with built-in gems like stringio.
