### PR TITLE
dep: update libxml2 to v2.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Documentation on what can be matched:
 
 ### Dependencies
 
-* [CRuby] Vendored libxml2 is updated to v2.12.1 from v2.11.6. For details please see https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.0 and https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.1 (@flavorjones)
+* [CRuby] Vendored libxml2 is updated to v2.12.2 from v2.11.6. For details please see https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.0, https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.1, and https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.2 (@flavorjones)
 
 
 ### Fixed

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 
 libxml2:
-  version: "2.12.1"
-  sha256: "8982b9ccdf7f456e30d8f7012d50858c6623e495333b6191def455c7e95427eb"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.1.sha256sum
+  version: "2.12.2"
+  sha256: "3f2e6464fa15073eb8f3d18602d54fafc489b7715171064615a40490c6be9f4f"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.2.sha256sum
 
 libxslt:
   version: "1.1.39"


### PR DESCRIPTION

**What problem is this PR intended to solve?**

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.2

