### PR TITLE
dep: update libxml2 to 2.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@ Documentation on what can be matched:
 
 ### Dependencies
 
-* [CRuby] Vendored libxml2 is updated to v2.12.2 from v2.11.6. For details please see https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.0, https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.1, and https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.2 (@flavorjones)
+* [CRuby] Vendored libxml2 is updated to v2.12.3 from v2.11.6. (@flavorjones)
+  * https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.0
+  * https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.1
+  * https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.2
+  * https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.3
 
 
 ### Fixed

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 
 libxml2:
-  version: "2.12.2"
-  sha256: "3f2e6464fa15073eb8f3d18602d54fafc489b7715171064615a40490c6be9f4f"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.2.sha256sum
+  version: "2.12.3"
+  sha256: "8c8f1092340a89ff32bc44ad5c9693aff9bc8a7a3e161bb239666e5d15ac9aaa"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.3.sha256sum
 
 libxslt:
   version: "1.1.39"


### PR DESCRIPTION

**What problem is this PR intended to solve?**

dep: update libxml2 to 2.12.3

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.3
