### PR TITLE
ci: ruby 3.3.0 rc1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3.0-rc1"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -577,7 +577,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -599,7 +599,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -621,7 +621,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3.0-preview3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3.0-rc1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
 
   # building extensions
   gem "rake-compiler", "1.2.5"
-  gem "rake-compiler-dock", "1.4.0.rc1"
+  gem "rake-compiler-dock", "1.4.0.rc2"
 
   # parser generator
   gem "rexical", "= 1.0.7"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

This PR has two changes

- build native gems using rake-compiler-dock v1.4.0.rc2 images using ruby 3.3.0-rc1
- test against ruby 3.3.0-rc1 in CI pipelines, including native gems


**Have you included adequate test coverage?**

N/A


**Does this change affect the behavior of either the C or the Java implementations?**

N/A