### PR TITLE
handle upstream libxml2 changes

### DIFF
--- a/ext/nokogiri/xml_sax_parser_context.c
+++ b/ext/nokogiri/xml_sax_parser_context.c
@@ -59,6 +59,10 @@ parse_io(VALUE klass, VALUE io, VALUE encoding)
                                (xmlInputReadCallback)noko_io_read,
                                (xmlInputCloseCallback)noko_io_close,
                                (void *)io, enc);
+  if (!ctxt) {
+    rb_raise(rb_eRuntimeError, "failed to create xml sax parser context");
+  }
+
   if (ctxt->sax) {
     xmlFree(ctxt->sax);
     ctxt->sax = NULL;


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Upstream libxml2 test failures.

- work around a bug/merge-request filed upstream [(on master) fix: support ASCII encoding on input buffers (!231) · Merge requests · GNOME / libxml2 · GitLab](https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/231)
- looks like in-context parser recovery now works? updating `XML::Node#parse` behavior to accommodate it in a backwards-compatible fashion. See #2092 which might be fixed in future versions of libxml2.


**Have you included adequate test coverage?**

Making existing tests pass (or not segfault while we wait for an upstream fix).


**Does this change affect the behavior of either the C or the Java implementations?**

No.
