### PR TITLE
tests: updated for upstream libxml support

### DIFF
--- a/test/test_xslt_transforms.rb
+++ b/test/test_xslt_transforms.rb
@@ -357,16 +357,10 @@ module Nokogiri
         exception = assert_raises(RuntimeError) do
           xslt.transform(doc)
         end
-        if truffleruby_system_libraries?
-          assert_equal(
-            "xslt_generic_error_handler: xmlXPathCompOpEval: function %s not found\nxslt_generic_error_handler: %s",
-            exception.message,
-          )
+        if Nokogiri.uses_libxml?(">= 2.13") # upstream commit 954b8984
+          assert_includes(exception.message, "Unregistered function")
         else
-          assert_match(
-            /xmlXPathCompOpEval: function decimal not found/,
-            exception.message,
-          )
+          assert_match(/xmlXPathCompOpEval: function .* not found/, exception.message)
         end
       end
 

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -312,7 +312,7 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
               errors.grep(/ERROR: Attempt to load network entity/).length,
               "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
             )
-            assert_equal(1, errors.grep(/WARNING: failed to load HTTP resource|WARNING: failed to load external entity/).length)
+            assert_equal(1, errors.grep(/WARNING: failed to load/).length)
           end
 
           it "XML::Schema parsing of memory attempts to access external DTDs" do
@@ -323,7 +323,7 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
               errors.grep(/ERROR: Attempt to load network entity/).length,
               "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
             )
-            assert_equal(1, errors.grep(/WARNING: failed to load HTTP resource|WARNING: failed to load external entity/).length)
+            assert_equal(1, errors.grep(/WARNING: failed to load/).length)
           end
         end
       end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Upstream error handling changed for XPath and IO in 954b8984 and 7e511f35.

This PR updates the tests to accept the new behavior.


**Have you included adequate test coverage?**

Yes.


**Does this change affect the behavior of either the C or the Java implementations?**

No behavioral changes.