### PR TITLE
fix(libxml): default Reader node encoding to UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## v1.16.next / unreleased
+
+### Fixed
+
+* [CRuby] `XML::Reader` defaults the encoding to UTF-8 if it's not specified in either the document or as a method parameter. Previously non-ASCII characters were serialized as NCRs in this case. [#2891] (@flavorjones)
+
+
 ## v1.16.0 / 2023-12-27
 
 ### Notable Changes


### PR DESCRIPTION

**What problem is this PR intended to solve?**

default Reader node encoding to UTF-8 when it's not specified either as a method param or in the document

Fixes #2891


**Have you included adequate test coverage?**

Yes, I've added coverage.


**Does this change affect the behavior of either the C or the Java implementations?**

Yes, this updates the C implementation but does not update the Java implementation because Reader encoding is already wonky there in a few edge cases.