### PR TITLE
ci: libxml2 callstack changed, so updating the suppression

### DIFF
--- a/suppressions/ruby.supp
+++ b/suppressions/ruby.supp
@@ -127,18 +127,20 @@
 }
 {
   https://github.com/sparklemotion/nokogiri/actions/runs/4845701723/jobs/8634781681
-  # same as previous warning but on libxml 2.11, I think?
-  # 240 (120 direct, 120 indirect) bytes in 1 blocks are definitely lost in loss record 30,974 of 40,320
-  #   malloc (at /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
-  #   objspace_xmalloc0 (gc.c:12258)
-  #   xmlNewDocNodeEatName (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
-  #   xmlSAX2StartElementNs (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
-  #   <unknown stack frame>
-  #   <unknown stack frame>
-  #   xmlParseContent (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
-  #   xmlParseDocument (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
-  #   xmlReadMemory (at /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.10)
-  #  *read_memory (xml_document.c:369)
+  # 240 (120 direct, 120 indirect) bytes in 1 blocks are definitely lost in loss record 28,576 of 36,831
+  #   malloc (vg_replace_malloc.c:381)
+  #   objspace_xmalloc0 (gc.c:12298)
+  #   xmlNewNodeEatName (tree.c:2257)
+  #   xmlNewDocNodeEatName (tree.c:2329)
+  #   xmlSAX2StartElementNs (SAX2.c:2085)
+  #   xmlParseStartTag2 (parser.c:9459)
+  #   xmlParseElementStart (parser.c:9848)
+  #   xmlParseContentInternal (parser.c:9697)
+  #   xmlParseElement (parser.c:9786)
+  #   xmlParseDocument (parser.c:10572)
+  #   xmlCtxtParseDocument (parser.c:13508)
+  #   xmlReadMemory (parser.c:13646)
+  #  *read_memory (xml_document.c:382)
   Memcheck:Leak
   fun:malloc
   fun:objspace_xmalloc0
@@ -146,9 +148,8 @@
   fun:xmlNewDocNodeEatName
   fun:xmlSAX2StartElementNs
   ...
-  fun:xmlParseContent
   fun:xmlParseDocument
-  fun:xmlReadMemory
+  ...
   fun:read_memory
 }
 {


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Upstream libxml valgrind (memcheck) test is failing. This callstack is changed on upstream master as of 2024-01-02.

This PR updates the suppression.
