### PR TITLE
Allow compilation on older gcc versions

### DIFF
--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -74,8 +74,10 @@ dealloc(void *data)
 
   ruby_xfree(doc->_private);
 
+#if defined(__GNUC__) && __GNUC__ >= 5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations" // xmlDeregisterNodeDefault is deprecated as of libxml2 2.11.0
+#endif
   /*
    * libxml-ruby < 3.0.0 uses xmlDeregisterNodeDefault. If the user is using one of those older
    * versions, the registered callback from libxml-ruby will access the _private pointers set by
@@ -90,7 +92,9 @@ dealloc(void *data)
   if (xmlDeregisterNodeDefaultValue) {
     remove_private((xmlNodePtr)doc);
   }
+#if defined(__GNUC__) && __GNUC__ >= 5
 #pragma GCC diagnostic pop
+#endif
 
   xmlFreeDoc(doc);
 }


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Compiling Nokogiri with older versions of GCC and centos causes the following error:

```
12:06:09 checking for gumbo_parse_with_options() in nokogiri_gumbo.h... yes
12:06:09 checking for xmlHasFeature()... yes
12:06:09 checking for xmlFirstElementChild()... yes
12:06:09 checking for xmlRelaxNGSetParserStructuredErrors()... yes
12:06:09 checking for xmlRelaxNGSetValidStructuredErrors()... yes
12:06:09 checking for xmlSchemaSetValidStructuredErrors()... yes
12:06:09 checking for xmlSchemaSetParserStructuredErrors()... yes
12:06:09 checking for rb_category_warning()... yes
12:06:09 checking for whether
12:06:09 -DNOKOGIRI_OTHER_LIBRARY_VERSIONS="\"libgumbo:1.0.0-nokogiri\"" is accepted as
12:06:09 CPPFLAGS... yes
12:06:09 creating Makefile
12:06:09 
12:06:09 current directory:
12:06:09 /opt/dev/embedded/lib/ruby/gems/3.0.0/gems/nokogiri-1.16.0/ext/nokogiri
12:06:09 make DESTDIR\= clean
12:06:09 
12:06:09 current directory:
12:06:09 /opt/dev/embedded/lib/ruby/gems/3.0.0/gems/nokogiri-1.16.0/ext/nokogiri
12:06:09 make DESTDIR\=
12:06:09 compiling gumbo.c
12:06:09 compiling html4_document.c
12:06:09 compiling html4_element_description.c
12:06:09 compiling html4_entity_lookup.c
12:06:09 compiling html4_sax_parser_context.c
12:06:09 compiling html4_sax_push_parser.c
12:06:09 compiling libxml2_backwards_compat.c
12:06:09 compiling nokogiri.c
12:06:09 compiling test_global_handlers.c
12:06:09 compiling xml_attr.c
12:06:09 compiling xml_attribute_decl.c
12:06:09 compiling xml_cdata.c
12:06:09 compiling xml_comment.c
12:06:09 compiling xml_document.c
12:06:09 xml_document.c: In function 'dealloc':
12:06:09 xml_document.c:77: error: #pragma GCC diagnostic not allowed inside functions
12:06:09 xml_document.c:78: error: #pragma GCC diagnostic not allowed inside functions
12:06:09 xml_document.c:90: warning: '__xmlDeregisterNodeDefaultValue' is deprecated
12:06:09 (declared at
12:06:09 /opt/dev/embedded/lib/ruby/gems/3.0.0/gems/nokogiri-1.16.0/ports/x86_64-linux/libxml2/2.12.3/include/libxml2/libxml/tree.h:684)
12:06:09 xml_document.c:93: error: #pragma GCC diagnostic not allowed inside functions
12:06:09 make: *** [xml_document.o] Error 1
12:06:09 
12:06:09 make failed, exit code 2
12:06:09 
12:06:09 Gem files will remain installed in
12:06:09 /opt/dev/embedded/lib/ruby/gems/3.0.0/gems/nokogiri-1.16.0 for
12:06:09 inspection.
12:06:09 Results logged to
12:06:09 /opt/dev/embedded/lib/ruby/gems/3.0.0/extensions/x86_64-linux/3.0.0/nokogiri-1.16.0/gem_make.out
12:06:09 
12:06:09 An error occurred while installing nokogiri (1.16.0), and Bundler cannot
12:06:09 continue.
12:06:09 Make sure that `gem install nokogiri -v '1.16.0' --source
12:06:09 'https://rubygems.org/'` succeeds before bundling.
12:06:09 
12:06:09 In Gemfile:
12:06:09   factory_bot_rails was resolved to 6.2.0, which depends on
12:06:09     railties was resolved to 7.0.8, which depends on
12:06:09       actionpack was resolved to 7.0.8, which depends on
12:06:09         actionview was resolved to 7.0.8, which depends on
12:06:09           rails-dom-testing was resolved to 2.2.0, which depends on
12:06:09             nokogiri
```

**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

No tests have been added; the solution implemented is similar to https://github.com/redis/redis/issues/5394 - and has been verified as working locally in a fresh docker container

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

Impacts the C behavior