### PR TITLE
ci: drop mingw from ci.yml because it's upstream ruby-head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ["3.0", "3.1", "3.2", "3.3", "mingw"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: windows-2022
     steps:
       - name: configure git crlf


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Realized today, because of some CI failures, that `mingw` is a ruby HEAD version (3.4.0 today), and we removed HEAD builds from the main CI pipeline back in 2021 (0fcbe1e4). The `upstream.yml` pipeline should be sufficient for testing ruby HEAD.


