### PR TITLE
maintain oss-fuzz target building upstream

### DIFF
--- a/gumbo-parser/Makefile
+++ b/gumbo-parser/Makefile
@@ -13,6 +13,9 @@ LDFLAGS := -pthread
 
 all: check
 
+oss-fuzz:
+	./fuzzer/build-ossfuzz.sh
+
 fuzzers: fuzzer-normal fuzzer-asan fuzzer-ubsan fuzzer-msan
 
 fuzzer-normal:

--- a/gumbo-parser/fuzzer/build-ossfuzz.sh
+++ b/gumbo-parser/fuzzer/build-ossfuzz.sh
@@ -1,0 +1,7 @@
+cd src
+make
+cd ../
+
+$CXX $CXXFLAGS -o $OUT/parse_fuzzer fuzzer/parse_fuzzer.cc src/libgumbo.a $LIB_FUZZING_ENGINE
+cp fuzzer/gumbo.dict $OUT/parse_fuzzer.dict
+cp fuzzer/gumbo_corpus.zip $OUT/parse_fuzzer_seed_corpus.zip

--- a/gumbo-parser/fuzzer/build-ossfuzz.sh
+++ b/gumbo-parser/fuzzer/build-ossfuzz.sh
@@ -5,3 +5,4 @@ cd ../
 $CXX $CXXFLAGS -o $OUT/parse_fuzzer fuzzer/parse_fuzzer.cc src/libgumbo.a $LIB_FUZZING_ENGINE
 cp fuzzer/gumbo.dict $OUT/parse_fuzzer.dict
 cp fuzzer/gumbo_corpus.zip $OUT/parse_fuzzer_seed_corpus.zip
+

--- a/gumbo-parser/fuzzer/build-ossfuzz.sh
+++ b/gumbo-parser/fuzzer/build-ossfuzz.sh
@@ -5,4 +5,3 @@ cd ../
 $CXX $CXXFLAGS -o $OUT/parse_fuzzer fuzzer/parse_fuzzer.cc src/libgumbo.a $LIB_FUZZING_ENGINE
 cp fuzzer/gumbo.dict $OUT/parse_fuzzer.dict
 cp fuzzer/gumbo_corpus.zip $OUT/parse_fuzzer_seed_corpus.zip
-


### PR DESCRIPTION

This pull request is needed so that i can update the oss-fuzz builder located at https://github.com/fuzzy-boiii23a/oss-fuzz/tree/master/projects/nokogiri which makes it much more seamless to add new fuzz targets in this nokogiri repo which will automatically be pulled by oss-fuzz and fuzzed instead of maintaining the fuzzer in the oss-fuzz repo.