### PR TITLE
dep: update libxml2 to 2.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ## v1.16.next / unreleased
 
+### Dependencies
+
+* [CRuby] Vendored libxml2 is updated to [v2.12.4](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.4) from v2.12.3. (@flavorjones)
+
+
 ### Fixed
 
 * [CRuby] `XML::Reader` defaults the encoding to UTF-8 if it's not specified in either the document or as a method parameter. Previously non-ASCII characters were serialized as NCRs in this case. [#2891] (@flavorjones)

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 
 libxml2:
-  version: "2.12.3"
-  sha256: "8c8f1092340a89ff32bc44ad5c9693aff9bc8a7a3e161bb239666e5d15ac9aaa"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.3.sha256sum
+  version: "2.12.4"
+  sha256: "497360e423cf0bd99eacdb7c6215dea92e6d6e89ee940393c2bae0e77cb9b7d0"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.4.sha256sum
 
 libxslt:
   version: "1.1.39"


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Update vendored libxml2 to v2.12.4.

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.4
