### PR TITLE
Delay breaking out of the parse loop when max_tree_depth is hit

### DIFF
--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -4826,14 +4826,17 @@ GumboOutput* gumbo_parse_with_options (
       // to a token.
       if (token.type == GUMBO_TOKEN_END_TAG &&
           token.v.end_tag.tag == GUMBO_TAG_UNKNOWN)
+      {
         gumbo_free(token.v.end_tag.name);
+        token.v.end_tag.name = NULL;
+      }
+      if (unlikely(state->_open_elements.length > max_tree_depth)) {
+        parser._output->status = GUMBO_STATUS_TREE_TOO_DEEP;
+        gumbo_debug("Tree depth limit exceeded.\n");
+        break;
+      }
     }
 
-    if (unlikely(state->_open_elements.length > max_tree_depth)) {
-      parser._output->status = GUMBO_STATUS_TREE_TOO_DEEP;
-      gumbo_debug("Tree depth limit exceeded.\n");
-      break;
-    }
 
     ++loop_count;
     assert(loop_count < 1000000000UL);

--- a/test/test_memory_usage.rb
+++ b/test/test_memory_usage.rb
@@ -301,5 +301,15 @@ class TestMemoryUsage < Nokogiri::TestCase
         Nokogiri::HTML5::Document.parse(html)
       end
     end
+
+    it "libgumbo max depth exceeded" do
+      html = "<html><body>"
+
+      memwatch(__method__) do
+        Nokogiri::HTML5.parse(html, max_tree_depth: 1)
+      rescue ArgumentError
+        # Expected error. This comment makes rubocop happy.
+      end
+    end
   end if ENV["NOKOGIRI_MEMORY_SUITE"] && Nokogiri.uses_libxml?
 end


### PR DESCRIPTION
When a token causes a node to be added to the DOM which increases the depth of the DOM to exceed the `max_tree_depth` _and_ the token needs to be reprocessed, memory is leaked. By delaying breaking out of the loop until after the token has been completely handled, this appears to fix the leak.

Fixes #3098

<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**
#3098
<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**
No! I don't know how to test this. Help is appreciated here.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

Fixes a bug in the C implementation.

More investigation is needed to be sure it actually fixes the issue, however.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
