### PR TITLE
test: handle upstream libxml2 error message changes

### DIFF
--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -312,7 +312,8 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
               errors.grep(/ERROR: Attempt to load network entity/).length,
               "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
             )
-            assert_equal(1, errors.grep(/WARNING: failed to load/).length)
+            # changed from "WARNING" to "FATAL" in libxml2 2.13
+            assert_equal(1, errors.grep(/(WARNING|FATAL): failed to load/).length)
           end
 
           it "XML::Schema parsing of memory attempts to access external DTDs" do
@@ -323,7 +324,8 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
               errors.grep(/ERROR: Attempt to load network entity/).length,
               "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
             )
-            assert_equal(1, errors.grep(/WARNING: failed to load/).length)
+            # changed from "WARNING" to "FATAL" in libxml2 2.13
+            assert_equal(1, errors.grep(/(WARNING|FATAL): failed to load/).length)
           end
         end
       end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Upstream libxml2 (pre-2.13) is changing some error messages. Let's make the tests more robust around those messages.

