### PR TITLE
Implement `#clone` correctly with respect to singleton classes

### DIFF
--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -414,20 +414,13 @@ public class XmlDocument extends XmlNode
     return getCachedNodeOrCreate(context.runtime, rootNode);
   }
 
-  protected IRubyObject
-  dup_implementation(Ruby runtime, boolean deep)
+  @JRubyMethod(visibility = Visibility.PROTECTED)
+  public IRubyObject
+  initialize_copy_with_args(ThreadContext context, IRubyObject other, IRubyObject level, IRubyObject _ignored)
   {
-    XmlDocument doc = (XmlDocument) super.dup_implementation(runtime, deep);
-    // Avoid creating a new XmlDocument since we cloned one
-    // already. Otherwise the following test will fail:
-    //
-    //   dup = doc.dup
-    //   dup.equal?(dup.children[0].document)
-    //
-    // Since `dup.children[0].document' will end up creating a new
-    // XmlDocument.  See #1060.
-    doc.resetCache();
-    return doc;
+    super.initialize_copy_with_args(context, other, level, _ignored);
+    resetCache();
+    return this;
   }
 
   @JRubyMethod(name = "root=")

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -416,9 +416,9 @@ public class XmlDocument extends XmlNode
 
   @JRubyMethod(visibility = Visibility.PROTECTED)
   public IRubyObject
-  initialize_copy_with_args(ThreadContext context, IRubyObject other, IRubyObject level, IRubyObject _ignored)
+  initialize_copy_with_args(ThreadContext context, IRubyObject other, IRubyObject level)
   {
-    super.initialize_copy_with_args(context, other, level, _ignored);
+    super.initialize_copy_with_args(context, other, level, null);
     resetCache();
     return this;
   }

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -966,45 +966,13 @@ public class XmlNode extends RubyObject
     return doc;
   }
 
+  @JRubyMethod(visibility = Visibility.PROTECTED)
   public IRubyObject
-  dup()
+  initialize_copy_with_args(ThreadContext context, IRubyObject other, IRubyObject level, IRubyObject _ignored)
   {
-    return dup_implementation(getMetaClass().getClassRuntime(), true);
-  }
-
-  @JRubyMethod
-  public IRubyObject
-  dup(ThreadContext context)
-  {
-    return dup_implementation(context, true);
-  }
-
-  @JRubyMethod
-  public IRubyObject
-  dup(ThreadContext context, IRubyObject depth)
-  {
-    boolean deep = depth instanceof RubyInteger && RubyFixnum.fix2int(depth) != 0;
-    return dup_implementation(context, deep);
-  }
-
-  protected final IRubyObject
-  dup_implementation(ThreadContext context, boolean deep)
-  {
-    return dup_implementation(context.runtime, deep);
-  }
-
-  protected IRubyObject
-  dup_implementation(Ruby runtime, boolean deep)
-  {
-    XmlNode clone;
-    try {
-      clone = (XmlNode) clone();
-    } catch (CloneNotSupportedException e) {
-      throw runtime.newRuntimeError(e.toString());
-    }
-    Node newNode = node.cloneNode(deep);
-    clone.node = newNode;
-    return clone;
+    boolean deep = level instanceof RubyInteger && RubyFixnum.fix2int(level) != 0;
+    this.node = asXmlNode(context, other).node.cloneNode(deep);
+    return this;
   }
 
   public static RubyString

--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -15,6 +15,7 @@ import org.jruby.RubyRange;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -201,13 +202,21 @@ public class XmlNodeSet extends RubyObject implements NodeList
     return context.nil;
   }
 
-  @JRubyMethod
   public IRubyObject
   dup(ThreadContext context)
   {
     XmlNodeSet dup = newNodeSet(context.runtime, nodes.clone());
     dup.initializeFrom(context, this);
     return dup;
+  }
+
+  @JRubyMethod(visibility = Visibility.PROTECTED)
+  public IRubyObject
+  initialize_copy(ThreadContext context, IRubyObject other)
+  {
+    setNodes(getNodes(context, other));
+    initializeFrom(context, (XmlNodeSet)other);
+    return this;
   }
 
   @JRubyMethod(name = "include?")

--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -135,7 +135,7 @@ public class XsltStylesheet extends RubyObject
     XmlDocument xmlDoc = (XmlDocument) args[0];
     ensureDocumentHasNoError(context, xmlDoc);
 
-    Document doc = ((XmlDocument) xmlDoc.dup_implementation(context, true)).getDocument();
+    Document doc = ((XmlDocument)xmlDoc.callMethod(context, "dup", runtime.newFixnum(1))).getDocument();
 
     XsltStylesheet xslt =
       (XsltStylesheet) NokogiriService.XSLT_STYLESHEET_ALLOCATOR.allocate(runtime, (RubyClass)klazz);

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -2274,6 +2274,15 @@ in_context(VALUE self, VALUE _str, VALUE _options)
   return noko_xml_node_set_wrap(set, doc);
 }
 
+/* :nodoc: */
+VALUE
+rb_xml_node_data_ptr_eh(VALUE self)
+{
+  xmlNodePtr c_node;
+  Noko_Node_Get_Struct(self, xmlNode, c_node);
+  return c_node ? Qtrue : Qfalse;
+}
+
 VALUE
 noko_xml_node_wrap(VALUE rb_class, xmlNodePtr c_node)
 {
@@ -2390,6 +2399,7 @@ noko_init_xml_node(void)
   rb_define_method(cNokogiriXmlNode, "content", rb_xml_node_content, 0);
   rb_define_method(cNokogiriXmlNode, "create_external_subset", create_external_subset, 3);
   rb_define_method(cNokogiriXmlNode, "create_internal_subset", create_internal_subset, 3);
+  rb_define_method(cNokogiriXmlNode, "data_ptr?", rb_xml_node_data_ptr_eh, 0);
   rb_define_method(cNokogiriXmlNode, "document", rb_xml_node_document, 0);
   rb_define_method(cNokogiriXmlNode, "dup", duplicate_node, -1);
   rb_define_method(cNokogiriXmlNode, "element_children", rb_xml_node_element_children, 0);

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -47,6 +47,24 @@ static const rb_data_type_t nokogiri_node_type = {
   .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
+static VALUE
+_xml_node_alloc(VALUE klass)
+{
+  return TypedData_Wrap_Struct(klass, &nokogiri_node_type, NULL);
+}
+
+static void
+_xml_node_data_ptr_set(VALUE rb_node, xmlNodePtr c_node)
+{
+  assert(DATA_PTR(rb_node) == NULL);
+  assert(c_node->_private == NULL);
+
+  DATA_PTR(rb_node) = c_node;
+  c_node->_private = (void *)rb_node;
+
+  return;
+}
+
 static void
 relink_namespace(xmlNodePtr reparented)
 {
@@ -2321,8 +2339,8 @@ noko_xml_node_wrap(VALUE rb_class, xmlNodePtr c_node)
     }
   }
 
-  rb_node = TypedData_Wrap_Struct(rb_class, &nokogiri_node_type, c_node) ;
-  c_node->_private = (void *)rb_node;
+  rb_node = _xml_node_alloc(rb_class);
+  _xml_node_data_ptr_set(rb_node, c_node);
 
   if (node_has_a_document) {
     rb_document = DOC_RUBY_OBJECT(c_doc);

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -19,6 +19,10 @@ module Nokogiri
       NCNAME_CHAR       = NCNAME_START_CHAR + "\\-\\.0-9"
       NCNAME_RE         = /^xmlns(?::([#{NCNAME_START_CHAR}][#{NCNAME_CHAR}]*))?$/
 
+      OBJECT_DUP_METHOD = Object.instance_method(:dup)
+      OBJECT_CLONE_METHOD = Object.instance_method(:clone)
+      private_constant :OBJECT_DUP_METHOD, :OBJECT_CLONE_METHOD
+
       class << self
         # Parse an XML file.
         #
@@ -178,6 +182,38 @@ module Nokogiri
         @errors     = []
         @decorators = nil
         @namespace_inheritance = false
+      end
+
+      #
+      # :call-seq:
+      #   dup → Nokogiri::XML::Document
+      #   dup(level) → Nokogiri::XML::Document
+      #
+      # Duplicate this node.
+      #
+      # [Parameters]
+      # - +level+ (optional Integer). 0 is a shallow copy, 1 (the default) is a deep copy.
+      # [Returns] The new Nokogiri::XML::Document
+      #
+      def dup(level = 1)
+        copy = OBJECT_DUP_METHOD.bind_call(self)
+        copy.initialize_copy_with_args(self, level)
+      end
+
+      #
+      # :call-seq:
+      #   clone → Nokogiri::XML::Document
+      #   clone(level) → Nokogiri::XML::Document
+      #
+      # Clone this node.
+      #
+      # [Parameters]
+      # - +level+ (optional Integer). 0 is a shallow copy, 1 (the default) is a deep copy.
+      # [Returns] The new Nokogiri::XML::Document
+      #
+      def clone(level = 1)
+        copy = OBJECT_CLONE_METHOD.bind_call(self)
+        copy.initialize_copy_with_args(self, level)
       end
 
       # :call-seq:
@@ -372,7 +408,6 @@ module Nokogiri
       end
 
       alias_method :to_xml, :serialize
-      alias_method :clone, :dup
 
       # Get the hash of namespaces on the root Nokogiri::XML::Node
       def namespaces

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -127,6 +127,42 @@ module Nokogiri
         # This is intentionally empty, and sets the method signature for subclasses.
       end
 
+      #
+      # :call-seq:
+      #   dup → Nokogiri::XML::Node
+      #   dup(level) → Nokogiri::XML::Node
+      #   dup(level, new_parent_doc) → Nokogiri::XML::Node
+      #
+      # Duplicate this node.
+      #
+      # [Parameters]
+      # - +level+ (optional Integer). 0 is a shallow copy, 1 (the default) is a deep copy.
+      # - +new_parent_doc+ (optional Nokogiri::XML::Document)
+      #   The new node's parent Document. Defaults to the the Document of the current node.
+      # [Returns] The new Nokogiri::XML::Node
+      #
+      def dup(level = 1, new_parent_doc = document)
+        super().initialize_copy_with_args(self, level, new_parent_doc)
+      end
+
+      #
+      # :call-seq:
+      #   clone → Nokogiri::XML::Node
+      #   clone(level) → Nokogiri::XML::Node
+      #   clone(level, new_parent_doc) → Nokogiri::XML::Node
+      #
+      # Clone this node.
+      #
+      # [Parameters]
+      # - +level+ (optional Integer). 0 is a shallow copy, 1 (the default) is a deep copy.
+      # - +new_parent_doc+
+      #   The new node's parent Document. Defaults to the the Document of the current node.
+      # [Returns] The new Nokogiri::XML::Node
+      #
+      def clone(level = 1, new_parent_doc = document)
+        super().initialize_copy_with_args(self, level, new_parent_doc)
+      end
+
       ###
       # Decorate this node with the decorators set up in this node's Document
       def decorate!
@@ -474,7 +510,6 @@ module Nokogiri
       alias_method :to_str, :content
       alias_method :name, :node_name
       alias_method :type, :node_type
-      alias_method :clone, :dup
       alias_method :elements, :element_children
 
       # :section: Working With Node Attributes

--- a/lib/nokogiri/xml/node_set.rb
+++ b/lib/nokogiri/xml/node_set.rb
@@ -4,17 +4,19 @@
 module Nokogiri
   module XML
     ####
-    # A NodeSet contains a list of Nokogiri::XML::Node objects.  Typically
-    # a NodeSet is return as a result of searching a Document via
-    # Nokogiri::XML::Searchable#css or Nokogiri::XML::Searchable#xpath
+    # A NodeSet is an Enumerable that contains a list of Nokogiri::XML::Node objects.
+    #
+    # Typically a NodeSet is returned as a result of searching a Document via
+    # Nokogiri::XML::Searchable#css or Nokogiri::XML::Searchable#xpath.
+    #
+    # Note that the `#dup` and `#clone` methods perform shallow copies; these methods do not copy
+    # the Nodes contained in the NodeSet (similar to how Array and other Enumerable classes work).
     class NodeSet
       include Nokogiri::XML::Searchable
       include Enumerable
 
       # The Document this NodeSet is associated with
       attr_accessor :document
-
-      alias_method :clone, :dup
 
       # Create a NodeSet with +document+ defaulting to +list+
       def initialize(document, list = [])

--- a/lib/nokogiri/xml/pp/node.rb
+++ b/lib/nokogiri/xml/pp/node.rb
@@ -8,6 +8,11 @@ module Nokogiri
         COLLECTIONS = [:attribute_nodes, :children]
 
         def inspect
+          # handle the case where an exception is thrown during object construction
+          if respond_to?(:data_ptr?) && !data_ptr?
+            return "#<#{self.class}:#{format("0x%x", object_id)} (no data)>"
+          end
+
           attributes = inspect_attributes.reject do |x|
             attribute = send(x)
             !attribute || (attribute.respond_to?(:empty?) && attribute.empty?)
@@ -21,7 +26,7 @@ module Nokogiri
               "#{attribute}=#{send(attribute).inspect}"
             end.join(" ")
           end
-          "#<#{self.class.name}:#{format("0x%x", object_id)} #{attributes}>"
+          "#<#{self.class}:#{format("0x%x", object_id)} #{attributes}>"
         end
 
         def pretty_print(pp)

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -478,6 +478,16 @@ module Nokogiri
           end
         end
 
+        def test_inspect_object_with_no_data_ptr
+          # test for the edge case when an exception is thrown during object construction/copy
+          node = Nokogiri::XML("<root>").root
+          refute_includes(node.inspect, "(no data)")
+
+          node.stub :data_ptr?, false do
+            assert_includes(node.inspect, "(no data)")
+          end
+        end
+
         def test_fragment_creates_appropriate_class
           frag = Nokogiri.XML("<root><child/></root>").at_css("child").fragment("<thing/>")
           assert_instance_of(Nokogiri::XML::DocumentFragment, frag)

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -368,6 +368,32 @@ module Nokogiri
           end
         end
 
+        specify "test_dup_should_not_copy_singleton_class" do
+          # https://github.com/sparklemotion/nokogiri/issues/316
+          m = Module.new do
+            def foo; end
+          end
+
+          set = Nokogiri::XML::Document.parse("<root/>").css("root")
+          set.extend(m)
+
+          assert_respond_to(set, :foo)
+          refute_respond_to(set.dup, :foo)
+        end
+
+        specify "test_clone_should_copy_singleton_class" do
+          # https://github.com/sparklemotion/nokogiri/issues/316
+          m = Module.new do
+            def foo; end
+          end
+
+          set = Nokogiri::XML::Document.parse("<root/>").css("root")
+          set.extend(m)
+
+          assert_respond_to(set, :foo)
+          assert_respond_to(set.clone, :foo)
+        end
+
         specify "#dup on empty set" do
           empty_set = Nokogiri::XML::NodeSet.new(xml, [])
           assert_equal(0, empty_set.dup.length) # this shouldn't raise null pointer exception


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes #316

Classes this PR updates:

- [x] `XML::Node`
- [x] `XML::Document`
- [x] `XML::NodeSet`

**Have you included adequate test coverage?**

Yes.


**Does this change affect the behavior of either the C or the Java implementations?**

The fix applies to both implementations.