### PR TITLE
cleanup: improve typeddata naming, improve `Node#dup` tests, action upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
           docker run --rm -v "$(pwd):/nokogiri" -w /nokogiri \
             ${DOCKER_IMAGE} \
             ./scripts/test-gem-build gems ruby
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: generic-gem
           path: gems
@@ -462,7 +462,7 @@ jobs:
         with:
           ruby-version: "${{matrix.ruby}}"
           apt-get: "libxml2-dev libxslt1-dev pkg-config"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: generic-gem
           path: gems
@@ -483,7 +483,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{matrix.ruby}}"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: generic-gem
           path: gems
@@ -505,7 +505,7 @@ jobs:
         with:
           ruby-version: "${{matrix.ruby}}"
           mingw: "libxml2 libxslt"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: generic-gem
           path: gems
@@ -528,7 +528,7 @@ jobs:
         with:
           ruby-version: "${{matrix.ruby}}"
           mingw: "libxml2 libxslt"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: generic-gem
           path: gems
@@ -566,7 +566,7 @@ jobs:
           docker run --rm -v "$(pwd):/nokogiri" -w /nokogiri \
             ${DOCKER_IMAGE} \
             ./scripts/test-gem-build gems ${{matrix.plat}}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "cruby-${{matrix.plat}}-gem"
           path: gems
@@ -583,7 +583,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cruby-x86-linux-gem
           path: gems
@@ -605,7 +605,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cruby-aarch64-linux-gem
           path: gems
@@ -627,7 +627,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cruby-arm-linux-gem
           path: gems
@@ -652,7 +652,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{matrix.ruby}}"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cruby-x86_64-linux-gem
           path: gems
@@ -669,7 +669,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cruby-x86_64-linux-gem
           path: gems
@@ -689,7 +689,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{matrix.ruby}}"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cruby-x86_64-darwin-gem
           path: gems
@@ -709,7 +709,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{matrix.ruby}}"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cruby-x64-mingw32-gem
           path: gems
@@ -730,7 +730,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{matrix.ruby}}"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cruby-x64-mingw-ucrt-gem
           path: gems
@@ -747,7 +747,7 @@ jobs:
         with:
           submodules: true
       - run: ./scripts/test-gem-build gems java
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: jruby-gem
           path: gems
@@ -766,7 +766,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: jruby-gem
           path: gems

--- a/ext/nokogiri/html4_element_description.c
+++ b/ext/nokogiri/html4_element_description.c
@@ -1,7 +1,7 @@
 #include <nokogiri.h>
 
-static const rb_data_type_t html4_element_description_type = {
-  .wrap_struct_name = "Nokogiri::HTML4::ElementDescription",
+static const rb_data_type_t html_elem_desc_type = {
+  .wrap_struct_name = "htmlElemDesc",
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
@@ -20,7 +20,7 @@ required_attributes(VALUE self)
   VALUE list;
   int i;
 
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   list = rb_ary_new();
 
@@ -46,7 +46,7 @@ deprecated_attributes(VALUE self)
   VALUE list;
   int i;
 
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   list = rb_ary_new();
 
@@ -72,7 +72,7 @@ optional_attributes(VALUE self)
   VALUE list;
   int i;
 
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   list = rb_ary_new();
 
@@ -95,7 +95,7 @@ static VALUE
 default_sub_element(VALUE self)
 {
   const htmlElemDesc *description;
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   if (description->defaultsubelt) {
     return NOKOGIRI_STR_NEW2(description->defaultsubelt);
@@ -117,7 +117,7 @@ sub_elements(VALUE self)
   VALUE list;
   int i;
 
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   list = rb_ary_new();
 
@@ -140,7 +140,7 @@ static VALUE
 description(VALUE self)
 {
   const htmlElemDesc *description;
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   return NOKOGIRI_STR_NEW2(description->desc);
 }
@@ -155,7 +155,7 @@ static VALUE
 inline_eh(VALUE self)
 {
   const htmlElemDesc *description;
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   if (description->isinline) { return Qtrue; }
   return Qfalse;
@@ -171,7 +171,7 @@ static VALUE
 deprecated_eh(VALUE self)
 {
   const htmlElemDesc *description;
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   if (description->depr) { return Qtrue; }
   return Qfalse;
@@ -187,7 +187,7 @@ static VALUE
 empty_eh(VALUE self)
 {
   const htmlElemDesc *description;
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   if (description->empty) { return Qtrue; }
   return Qfalse;
@@ -203,7 +203,7 @@ static VALUE
 save_end_tag_eh(VALUE self)
 {
   const htmlElemDesc *description;
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   if (description->saveEndTag) { return Qtrue; }
   return Qfalse;
@@ -219,7 +219,7 @@ static VALUE
 implied_end_tag_eh(VALUE self)
 {
   const htmlElemDesc *description;
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   if (description->endTag) { return Qtrue; }
   return Qfalse;
@@ -235,7 +235,7 @@ static VALUE
 implied_start_tag_eh(VALUE self)
 {
   const htmlElemDesc *description;
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   if (description->startTag) { return Qtrue; }
   return Qfalse;
@@ -251,7 +251,7 @@ static VALUE
 name(VALUE self)
 {
   const htmlElemDesc *description;
-  TypedData_Get_Struct(self, htmlElemDesc, &html4_element_description_type, description);
+  TypedData_Get_Struct(self, htmlElemDesc, &html_elem_desc_type, description);
 
   if (NULL == description->name) { return Qnil; }
   return NOKOGIRI_STR_NEW2(description->name);
@@ -271,7 +271,7 @@ get_description(VALUE klass, VALUE tag_name)
                                     );
 
   if (NULL == description) { return Qnil; }
-  return TypedData_Wrap_Struct(klass, &html4_element_description_type, DISCARD_CONST_QUAL(void *, description));
+  return TypedData_Wrap_Struct(klass, &html_elem_desc_type, DISCARD_CONST_QUAL(void *, description));
 }
 
 void

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -133,8 +133,8 @@ memsize(const void *data)
   return memsize;
 }
 
-static const rb_data_type_t noko_xml_document_data_type = {
-  .wrap_struct_name = "Nokogiri::XML::Document",
+static const rb_data_type_t xml_doc_type = {
+  .wrap_struct_name = "xmlDoc",
   .function = {
     .dmark = mark,
     .dfree = dealloc,
@@ -146,7 +146,7 @@ static const rb_data_type_t noko_xml_document_data_type = {
 static VALUE
 _xml_document_alloc(VALUE klass)
 {
-  return TypedData_Wrap_Struct(klass, &noko_xml_document_data_type, NULL);
+  return TypedData_Wrap_Struct(klass, &xml_doc_type, NULL);
 }
 
 static void
@@ -707,7 +707,7 @@ xmlDocPtr
 noko_xml_document_unwrap(VALUE rb_document)
 {
   xmlDocPtr c_document;
-  TypedData_Get_Struct(rb_document, xmlDoc, &noko_xml_document_data_type, c_document);
+  TypedData_Get_Struct(rb_document, xmlDoc, &xml_doc_type, c_document);
   return c_document;
 }
 

--- a/ext/nokogiri/xml_element_content.c
+++ b/ext/nokogiri/xml_element_content.c
@@ -2,8 +2,8 @@
 
 VALUE cNokogiriXmlElementContent;
 
-static const rb_data_type_t element_content_data_type = {
-  .wrap_struct_name = "Nokogiri::XML::ElementContent",
+static const rb_data_type_t xml_element_content_type = {
+  .wrap_struct_name = "xmlElementContent",
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
@@ -17,7 +17,7 @@ static VALUE
 get_name(VALUE self)
 {
   xmlElementContentPtr elem;
-  TypedData_Get_Struct(self, xmlElementContent, &element_content_data_type, elem);
+  TypedData_Get_Struct(self, xmlElementContent, &xml_element_content_type, elem);
 
   if (!elem->name) { return Qnil; }
   return NOKOGIRI_STR_NEW2(elem->name);
@@ -33,7 +33,7 @@ static VALUE
 get_type(VALUE self)
 {
   xmlElementContentPtr elem;
-  TypedData_Get_Struct(self, xmlElementContent, &element_content_data_type, elem);
+  TypedData_Get_Struct(self, xmlElementContent, &xml_element_content_type, elem);
 
   return INT2NUM(elem->type);
 }
@@ -45,7 +45,7 @@ static VALUE
 get_c1(VALUE self)
 {
   xmlElementContentPtr elem;
-  TypedData_Get_Struct(self, xmlElementContent, &element_content_data_type, elem);
+  TypedData_Get_Struct(self, xmlElementContent, &xml_element_content_type, elem);
 
   if (!elem->c1) { return Qnil; }
   return noko_xml_element_content_wrap(rb_iv_get(self, "@document"), elem->c1);
@@ -58,7 +58,7 @@ static VALUE
 get_c2(VALUE self)
 {
   xmlElementContentPtr elem;
-  TypedData_Get_Struct(self, xmlElementContent, &element_content_data_type, elem);
+  TypedData_Get_Struct(self, xmlElementContent, &xml_element_content_type, elem);
 
   if (!elem->c2) { return Qnil; }
   return noko_xml_element_content_wrap(rb_iv_get(self, "@document"), elem->c2);
@@ -74,7 +74,7 @@ static VALUE
 get_occur(VALUE self)
 {
   xmlElementContentPtr elem;
-  TypedData_Get_Struct(self, xmlElementContent, &element_content_data_type, elem);
+  TypedData_Get_Struct(self, xmlElementContent, &xml_element_content_type, elem);
 
   return INT2NUM(elem->ocur);
 }
@@ -89,7 +89,7 @@ static VALUE
 get_prefix(VALUE self)
 {
   xmlElementContentPtr elem;
-  TypedData_Get_Struct(self, xmlElementContent, &element_content_data_type, elem);
+  TypedData_Get_Struct(self, xmlElementContent, &xml_element_content_type, elem);
 
   if (!elem->prefix) { return Qnil; }
 
@@ -104,7 +104,7 @@ noko_xml_element_content_wrap(VALUE rb_document, xmlElementContentPtr c_element_
 {
   VALUE elem = TypedData_Wrap_Struct(
                  cNokogiriXmlElementContent,
-                 &element_content_data_type,
+                 &xml_element_content_type,
                  c_element_content
                );
 

--- a/ext/nokogiri/xml_encoding_handler.c
+++ b/ext/nokogiri/xml_encoding_handler.c
@@ -10,8 +10,8 @@ xml_encoding_handler_dealloc(void *data)
   xmlCharEncCloseFunc(c_handler);
 }
 
-static const rb_data_type_t xml_encoding_handler_type = {
-  .wrap_struct_name = "Nokogiri::EncodingHandler",
+static const rb_data_type_t xml_char_encoding_handler_type = {
+  .wrap_struct_name = "xmlCharEncodingHandler",
   .function = {
     .dfree = xml_encoding_handler_dealloc,
   },
@@ -31,7 +31,7 @@ rb_xml_encoding_handler_s_get(VALUE klass, VALUE key)
 
   handler = xmlFindCharEncodingHandler(StringValueCStr(key));
   if (handler) {
-    return TypedData_Wrap_Struct(klass, &xml_encoding_handler_type, handler);
+    return TypedData_Wrap_Struct(klass, &xml_char_encoding_handler_type, handler);
   }
 
   return Qnil;
@@ -90,7 +90,7 @@ rb_xml_encoding_handler_name(VALUE self)
 {
   xmlCharEncodingHandlerPtr handler;
 
-  TypedData_Get_Struct(self, xmlCharEncodingHandler, &xml_encoding_handler_type, handler);
+  TypedData_Get_Struct(self, xmlCharEncodingHandler, &xml_char_encoding_handler_type, handler);
 
   return NOKOGIRI_STR_NEW2(handler->name);
 }

--- a/ext/nokogiri/xml_namespace.c
+++ b/ext/nokogiri/xml_namespace.c
@@ -51,8 +51,8 @@ _xml_namespace_update_references(void *ptr)
   }
 }
 
-static const rb_data_type_t nokogiri_xml_namespace_type_with_dealloc = {
-  .wrap_struct_name = "Nokogiri::XML::Namespace#with_dealloc",
+static const rb_data_type_t xml_ns_type_with_free = {
+  .wrap_struct_name = "xmlNs (with free)",
   .function = {
     .dfree = _xml_namespace_dealloc,
     .dcompact = _xml_namespace_update_references,
@@ -60,8 +60,8 @@ static const rb_data_type_t nokogiri_xml_namespace_type_with_dealloc = {
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
-static const rb_data_type_t nokogiri_xml_namespace_type_without_dealloc = {
-  .wrap_struct_name = "Nokogiri::XML::Namespace#without_dealloc",
+static const rb_data_type_t xml_ns_type_without_free = {
+  .wrap_struct_name = "xmlNs (without free)",
   .function = {
     .dcompact = _xml_namespace_update_references,
   },
@@ -145,7 +145,7 @@ noko_xml_namespace_wrap(xmlNsPtr c_namespace, xmlDocPtr c_document)
 
   if (c_document) {
     rb_namespace = TypedData_Wrap_Struct(cNokogiriXmlNamespace,
-                                         &nokogiri_xml_namespace_type_without_dealloc,
+                                         &xml_ns_type_without_free,
                                          c_namespace);
 
     if (DOC_RUBY_OBJECT_TEST(c_document)) {
@@ -154,7 +154,7 @@ noko_xml_namespace_wrap(xmlNsPtr c_namespace, xmlDocPtr c_document)
     }
   } else {
     rb_namespace = TypedData_Wrap_Struct(cNokogiriXmlNamespace,
-                                         &nokogiri_xml_namespace_type_with_dealloc,
+                                         &xml_ns_type_with_free,
                                          c_namespace);
   }
 

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -38,8 +38,8 @@ _xml_node_update_references(void *ptr)
   }
 }
 
-static const rb_data_type_t nokogiri_node_type = {
-  .wrap_struct_name = "Nokogiri::XML::Node",
+static const rb_data_type_t xml_node_type = {
+  .wrap_struct_name = "xmlNode",
   .function = {
     .dmark = _xml_node_mark,
     .dcompact = _xml_node_update_references,
@@ -50,7 +50,7 @@ static const rb_data_type_t nokogiri_node_type = {
 static VALUE
 _xml_node_alloc(VALUE klass)
 {
-  return TypedData_Wrap_Struct(klass, &nokogiri_node_type, NULL);
+  return TypedData_Wrap_Struct(klass, &xml_node_type, NULL);
 }
 
 static void

--- a/ext/nokogiri/xml_node_set.c
+++ b/ext/nokogiri/xml_node_set.c
@@ -69,7 +69,7 @@ xml_node_set_deallocate(void *data)
 }
 
 static const rb_data_type_t xml_node_set_type = {
-  .wrap_struct_name = "Nokogiri::XML::NodeSet",
+  .wrap_struct_name = "xmlNodeSet",
   .function = {
     .dmark = xml_node_set_mark,
     .dfree = xml_node_set_deallocate,

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -15,8 +15,8 @@ xml_reader_deallocate(void *data)
   }
 }
 
-static const rb_data_type_t xml_reader_type = {
-  .wrap_struct_name = "Nokogiri::XML::Reader",
+static const rb_data_type_t xml_text_reader_type = {
+  .wrap_struct_name = "xmlTextReader",
   .function = {
     .dfree = xml_reader_deallocate,
   },
@@ -84,7 +84,7 @@ default_eh(VALUE self)
   xmlTextReaderPtr reader;
   int eh;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   eh = xmlTextReaderIsDefault(reader);
   if (eh == 0) { return Qfalse; }
   if (eh == 1) { return Qtrue; }
@@ -104,7 +104,7 @@ value_eh(VALUE self)
   xmlTextReaderPtr reader;
   int eh;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   eh = xmlTextReaderHasValue(reader);
   if (eh == 0) { return Qfalse; }
   if (eh == 1) { return Qtrue; }
@@ -124,7 +124,7 @@ attributes_eh(VALUE self)
   xmlTextReaderPtr reader;
   int eh;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   eh = has_attributes(reader);
   if (eh == 0) { return Qfalse; }
   if (eh == 1) { return Qtrue; }
@@ -146,7 +146,7 @@ rb_xml_reader_namespaces(VALUE rb_reader)
   xmlNodePtr c_node;
   VALUE rb_errors;
 
-  TypedData_Get_Struct(rb_reader, xmlTextReader, &xml_reader_type, c_reader);
+  TypedData_Get_Struct(rb_reader, xmlTextReader, &xml_text_reader_type, c_reader);
 
   if (! has_attributes(c_reader)) {
     return rb_namespaces ;
@@ -188,7 +188,7 @@ rb_xml_reader_attribute_hash(VALUE rb_reader)
   xmlAttrPtr c_property;
   VALUE rb_errors;
 
-  TypedData_Get_Struct(rb_reader, xmlTextReader, &xml_reader_type, c_reader);
+  TypedData_Get_Struct(rb_reader, xmlTextReader, &xml_text_reader_type, c_reader);
 
   if (!has_attributes(c_reader)) {
     return rb_attributes;
@@ -241,7 +241,7 @@ attribute_at(VALUE self, VALUE index)
   xmlChar *value;
   VALUE rb_value;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
 
   if (NIL_P(index)) { return Qnil; }
   index = rb_Integer(index);
@@ -270,7 +270,7 @@ reader_attribute(VALUE self, VALUE name)
   xmlChar *value ;
   VALUE rb_value;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
 
   if (NIL_P(name)) { return Qnil; }
   name = StringValue(name) ;
@@ -295,7 +295,7 @@ attribute_count(VALUE self)
   xmlTextReaderPtr reader;
   int count;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   count = xmlTextReaderAttributeCount(reader);
   if (count == -1) { return Qnil; }
 
@@ -314,7 +314,7 @@ depth(VALUE self)
   xmlTextReaderPtr reader;
   int depth;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   depth = xmlTextReaderDepth(reader);
   if (depth == -1) { return Qnil; }
 
@@ -333,7 +333,7 @@ xml_version(VALUE self)
   xmlTextReaderPtr reader;
   const char *version;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   version = (const char *)xmlTextReaderConstXmlVersion(reader);
   if (version == NULL) { return Qnil; }
 
@@ -352,7 +352,7 @@ lang(VALUE self)
   xmlTextReaderPtr reader;
   const char *lang;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   lang = (const char *)xmlTextReaderConstXmlLang(reader);
   if (lang == NULL) { return Qnil; }
 
@@ -371,7 +371,7 @@ value(VALUE self)
   xmlTextReaderPtr reader;
   const char *value;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   value = (const char *)xmlTextReaderConstValue(reader);
   if (value == NULL) { return Qnil; }
 
@@ -390,7 +390,7 @@ prefix(VALUE self)
   xmlTextReaderPtr reader;
   const char *prefix;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   prefix = (const char *)xmlTextReaderConstPrefix(reader);
   if (prefix == NULL) { return Qnil; }
 
@@ -409,7 +409,7 @@ namespace_uri(VALUE self)
   xmlTextReaderPtr reader;
   const char *uri;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   uri = (const char *)xmlTextReaderConstNamespaceUri(reader);
   if (uri == NULL) { return Qnil; }
 
@@ -428,7 +428,7 @@ local_name(VALUE self)
   xmlTextReaderPtr reader;
   const char *name;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   name = (const char *)xmlTextReaderConstLocalName(reader);
   if (name == NULL) { return Qnil; }
 
@@ -447,7 +447,7 @@ name(VALUE self)
   xmlTextReaderPtr reader;
   const char *name;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   name = (const char *)xmlTextReaderConstName(reader);
   if (name == NULL) { return Qnil; }
 
@@ -467,7 +467,7 @@ rb_xml_reader_base_uri(VALUE rb_reader)
   xmlTextReaderPtr c_reader;
   xmlChar *c_base_uri;
 
-  TypedData_Get_Struct(rb_reader, xmlTextReader, &xml_reader_type, c_reader);
+  TypedData_Get_Struct(rb_reader, xmlTextReader, &xml_text_reader_type, c_reader);
 
   c_base_uri = xmlTextReaderBaseUri(c_reader);
   if (c_base_uri == NULL) {
@@ -490,7 +490,7 @@ static VALUE
 state(VALUE self)
 {
   xmlTextReaderPtr reader;
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   return INT2NUM(xmlTextReaderReadState(reader));
 }
 
@@ -504,7 +504,7 @@ static VALUE
 node_type(VALUE self)
 {
   xmlTextReaderPtr reader;
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
   return INT2NUM(xmlTextReaderNodeType(reader));
 }
 
@@ -523,7 +523,7 @@ read_more(VALUE self)
   int ret;
   xmlDocPtr c_document;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
 
   error_list = rb_funcall(self, rb_intern("errors"), 0);
 
@@ -568,7 +568,7 @@ inner_xml(VALUE self)
   xmlChar *value;
   VALUE str;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
 
   value = xmlTextReaderReadInnerXml(reader);
 
@@ -595,7 +595,7 @@ outer_xml(VALUE self)
   xmlChar *value;
   VALUE str = Qnil;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
 
   value = xmlTextReaderReadOuterXml(reader);
 
@@ -642,7 +642,7 @@ from_memory(int argc, VALUE *argv, VALUE klass)
     rb_raise(rb_eRuntimeError, "couldn't create a parser");
   }
 
-  rb_reader = TypedData_Wrap_Struct(klass, &xml_reader_type, reader);
+  rb_reader = TypedData_Wrap_Struct(klass, &xml_text_reader_type, reader);
   args[0] = rb_buffer;
   args[1] = rb_url;
   args[2] = encoding;
@@ -688,7 +688,7 @@ from_io(int argc, VALUE *argv, VALUE klass)
     rb_raise(rb_eRuntimeError, "couldn't create a parser");
   }
 
-  rb_reader = TypedData_Wrap_Struct(klass, &xml_reader_type, reader);
+  rb_reader = TypedData_Wrap_Struct(klass, &xml_text_reader_type, reader);
   args[0] = rb_io;
   args[1] = rb_url;
   args[2] = encoding;
@@ -708,7 +708,7 @@ empty_element_p(VALUE self)
 {
   xmlTextReaderPtr reader;
 
-  TypedData_Get_Struct(self, xmlTextReader, &xml_reader_type, reader);
+  TypedData_Get_Struct(self, xmlTextReader, &xml_text_reader_type, reader);
 
   if (xmlTextReaderIsEmptyElement(reader)) {
     return Qtrue;
@@ -724,7 +724,7 @@ rb_xml_reader_encoding(VALUE rb_reader)
   const char *parser_encoding;
   VALUE constructor_encoding;
 
-  TypedData_Get_Struct(rb_reader, xmlTextReader, &xml_reader_type, c_reader);
+  TypedData_Get_Struct(rb_reader, xmlTextReader, &xml_text_reader_type, c_reader);
   parser_encoding = (const char *)xmlTextReaderConstEncoding(c_reader);
   if (parser_encoding) {
     return NOKOGIRI_STR_NEW2(parser_encoding);

--- a/ext/nokogiri/xml_relax_ng.c
+++ b/ext/nokogiri/xml_relax_ng.c
@@ -10,7 +10,7 @@ xml_relax_ng_deallocate(void *data)
 }
 
 static const rb_data_type_t xml_relax_ng_type = {
-  .wrap_struct_name = "Nokogiri::XML::RelaxNG",
+  .wrap_struct_name = "xmlRelaxNG",
   .function = {
     .dfree = xml_relax_ng_deallocate,
   },

--- a/ext/nokogiri/xml_sax_parser.c
+++ b/ext/nokogiri/xml_sax_parser.c
@@ -272,8 +272,8 @@ memsize(const void *data)
 }
 
 /* Used by Nokogiri::XML::SAX::Parser and Nokogiri::HTML::SAX::Parser */
-static const rb_data_type_t noko_sax_handler_type = {
-  .wrap_struct_name = "Nokogiri::SAXHandler",
+static const rb_data_type_t xml_sax_handler_type = {
+  .wrap_struct_name = "xmlSAXHandler",
   .function = {
     .dfree = RUBY_TYPED_DEFAULT_FREE,
     .dsize = memsize
@@ -285,7 +285,7 @@ static VALUE
 allocate(VALUE klass)
 {
   xmlSAXHandlerPtr handler;
-  VALUE self = TypedData_Make_Struct(klass, xmlSAXHandler, &noko_sax_handler_type, handler);
+  VALUE self = TypedData_Make_Struct(klass, xmlSAXHandler, &xml_sax_handler_type, handler);
 
   handler->startDocument = start_document;
   handler->endDocument = end_document;
@@ -308,7 +308,7 @@ xmlSAXHandlerPtr
 noko_sax_handler_unwrap(VALUE rb_sax_handler)
 {
   xmlSAXHandlerPtr c_sax_handler;
-  TypedData_Get_Struct(rb_sax_handler, xmlSAXHandler, &noko_sax_handler_type, c_sax_handler);
+  TypedData_Get_Struct(rb_sax_handler, xmlSAXHandler, &xml_sax_handler_type, c_sax_handler);
   return c_sax_handler;
 }
 

--- a/ext/nokogiri/xml_sax_parser_context.c
+++ b/ext/nokogiri/xml_sax_parser_context.c
@@ -16,8 +16,8 @@ xml_sax_parser_context_free(void *data)
  *  note that htmlParserCtxtPtr == xmlParserCtxtPtr and xmlFreeParserCtxt() == htmlFreeParserCtxt()
  *  so we use this type for both XML::SAX::ParserContext and HTML::SAX::ParserContext
  */
-static const rb_data_type_t xml_sax_parser_context_type = {
-  .wrap_struct_name = "Nokogiri::XML::SAX::ParserContext",
+static const rb_data_type_t xml_parser_ctxt_type = {
+  .wrap_struct_name = "xmlParserCtxt",
   .function = {
     .dfree = xml_sax_parser_context_free,
   },
@@ -28,14 +28,14 @@ xmlParserCtxtPtr
 noko_xml_sax_parser_context_unwrap(VALUE rb_context)
 {
   xmlParserCtxtPtr c_context;
-  TypedData_Get_Struct(rb_context, xmlParserCtxt, &xml_sax_parser_context_type, c_context);
+  TypedData_Get_Struct(rb_context, xmlParserCtxt, &xml_parser_ctxt_type, c_context);
   return c_context;
 }
 
 VALUE
 noko_xml_sax_parser_context_wrap(VALUE klass, xmlParserCtxtPtr c_context)
 {
-  return TypedData_Wrap_Struct(klass, &xml_sax_parser_context_type, c_context);
+  return TypedData_Wrap_Struct(klass, &xml_parser_ctxt_type, c_context);
 }
 
 

--- a/ext/nokogiri/xml_sax_push_parser.c
+++ b/ext/nokogiri/xml_sax_push_parser.c
@@ -12,8 +12,8 @@ xml_sax_push_parser_free(void *data)
   }
 }
 
-static const rb_data_type_t xml_sax_push_parser_type = {
-  .wrap_struct_name = "Nokogiri::XML::SAX::PushParser",
+static const rb_data_type_t xml_parser_ctxt_type = {
+  .wrap_struct_name = "xmlParserCtxt",
   .function = {
     .dfree = xml_sax_push_parser_free,
   },
@@ -23,14 +23,14 @@ static const rb_data_type_t xml_sax_push_parser_type = {
 static VALUE
 allocate(VALUE klass)
 {
-  return TypedData_Wrap_Struct(klass, &xml_sax_push_parser_type, NULL);
+  return TypedData_Wrap_Struct(klass, &xml_parser_ctxt_type, NULL);
 }
 
 xmlParserCtxtPtr
 noko_xml_sax_push_parser_unwrap(VALUE rb_parser)
 {
   xmlParserCtxtPtr c_parser;
-  TypedData_Get_Struct(rb_parser, xmlParserCtxt, &xml_sax_push_parser_type, c_parser);
+  TypedData_Get_Struct(rb_parser, xmlParserCtxt, &xml_parser_ctxt_type, c_parser);
   return c_parser;
 }
 

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -10,7 +10,7 @@ xml_schema_deallocate(void *data)
 }
 
 static const rb_data_type_t xml_schema_type = {
-  .wrap_struct_name = "Nokogiri::XML::Schema",
+  .wrap_struct_name = "xmlSchema",
   .function = {
     .dfree = xml_schema_deallocate,
   },

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -19,7 +19,7 @@ xml_xpath_context_deallocate(void *data)
 }
 
 static const rb_data_type_t xml_xpath_context_type = {
-  .wrap_struct_name = "Nokogiri::XML::XPathContext",
+  .wrap_struct_name = "xmlXPathContext",
   .function = {
     .dfree = xml_xpath_context_deallocate,
   },

--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -1,6 +1,6 @@
 #include <nokogiri.h>
 
-VALUE cNokogiriXsltStylesheet ;
+VALUE cNokogiriXsltStylesheet;
 
 static void
 mark(void *data)
@@ -18,8 +18,8 @@ dealloc(void *data)
   ruby_xfree(wrapper);
 }
 
-static const rb_data_type_t xslt_stylesheet_type = {
-  .wrap_struct_name = "Nokogiri::XSLT::Stylesheet",
+static const rb_data_type_t nokogiri_xslt_stylesheet_tuple_type = {
+  .wrap_struct_name = "nokogiriXsltStylesheetTuple",
   .function = {
     .dmark = mark,
     .dfree = dealloc,
@@ -56,7 +56,7 @@ Nokogiri_wrap_xslt_stylesheet(xsltStylesheetPtr ss)
   self = TypedData_Make_Struct(
            cNokogiriXsltStylesheet,
            nokogiriXsltStylesheetTuple,
-           &xslt_stylesheet_type,
+           &nokogiri_xslt_stylesheet_tuple_type,
            wrapper
          );
 
@@ -124,7 +124,7 @@ rb_xslt_stylesheet_serialize(VALUE self, VALUE xmlobj)
   TypedData_Get_Struct(
     self,
     nokogiriXsltStylesheetTuple,
-    &xslt_stylesheet_type,
+    &nokogiri_xslt_stylesheet_tuple_type,
     wrapper
   );
   xsltSaveResultToString(&doc_ptr, &doc_len, xml, wrapper->ss);
@@ -273,7 +273,7 @@ rb_xslt_stylesheet_transform(int argc, VALUE *argv, VALUE self)
   Check_Type(rb_param, T_ARRAY);
 
   c_document = noko_xml_document_unwrap(rb_document);
-  TypedData_Get_Struct(self, nokogiriXsltStylesheetTuple, &xslt_stylesheet_type, wrapper);
+  TypedData_Get_Struct(self, nokogiriXsltStylesheetTuple, &nokogiri_xslt_stylesheet_tuple_type, wrapper);
 
   param_len = RARRAY_LEN(rb_param);
   params = ruby_xcalloc((size_t)param_len + 1, sizeof(char *));
@@ -362,7 +362,7 @@ initFunc(xsltTransformContextPtr ctxt, const xmlChar *uri)
   TypedData_Get_Struct(
     (VALUE)ctxt->style->_private,
     nokogiriXsltStylesheetTuple,
-    &xslt_stylesheet_type,
+    &nokogiri_xslt_stylesheet_tuple_type,
     wrapper
   );
   inst = rb_class_new_instance(0, NULL, obj);
@@ -380,7 +380,7 @@ shutdownFunc(xsltTransformContextPtr ctxt,
   TypedData_Get_Struct(
     (VALUE)ctxt->style->_private,
     nokogiriXsltStylesheetTuple,
-    &xslt_stylesheet_type,
+    &nokogiri_xslt_stylesheet_tuple_type,
     wrapper
   );
 

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -204,18 +204,28 @@ module Nokogiri
           assert_equal(0, node.children.length)
         end
 
-        def test_dup_to_another_document
+        def test_dup_same_parent_document_is_default
+          doc = XML::Document.parse("<root><div><p>hello</p></div></root>")
+          div = doc.at_css("div")
+          node = div.dup
+          assert_same(div.document, node.document)
+        end
+
+        def test_dup_different_parent_document
           skip_unless_libxml2("Node.dup with new_parent arg is only implemented on CRuby")
-          doc1 = Nokogiri::HTML4::Document.parse("<root><div><p>hello</p></div></root>")
-          doc2 = Nokogiri::HTML4::Document.parse("<div></div>")
+
+          doc1 = XML::Document.parse("<root><div><p>hello</p></div></root>")
+          doc2 = XML::Document.parse("<div></div>")
 
           div = doc1.at_css("div")
-          duplicate_div = div.dup(1, doc2)
+          copy = div.dup(1, doc2)
 
-          refute_nil(doc1.at_css("div"))
-          assert_equal(doc2, duplicate_div.document)
-          assert_equal(1, duplicate_div.children.length)
-          assert_equal("<p>hello</p>", duplicate_div.children.first.to_html)
+          assert_same(doc2, copy.document)
+          assert_equal(1, copy.children.length) # deep copy
+
+          copy = div.dup(0, doc2)
+
+          assert_equal(0, copy.children.length) # shallow copy
         end
 
         def test_subclass_dup


### PR DESCRIPTION
**What problem is this PR intended to solve?**

- some minor C code cleanup
- improved testing around `Node#dup` that should have been in #3117
- update CI to use `download-artifact` and `upload-artifact` v4

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

No functional changes.