### PR TITLE
feat: `Nokogiri::HTML5::Builder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## v1.next.0 / unreleased
+
+### Added
+
+* [CRuby] `Nokogiri::HTML5::Builder` is similar to `HTML4::Builder` but returns an `HTML5::Document`. (@flavorjones)
+
+
+
 ## v1.16.1 / 2024-02-03
 
 ### Dependencies

--- a/lib/nokogiri/html5.rb
+++ b/lib/nokogiri/html5.rb
@@ -20,6 +20,7 @@
 require_relative "html5/document"
 require_relative "html5/document_fragment"
 require_relative "html5/node"
+require_relative "html5/builder"
 
 module Nokogiri
   # Since v1.12.0

--- a/lib/nokogiri/html5/builder.rb
+++ b/lib/nokogiri/html5/builder.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Nokogiri
+  module HTML5
+    ###
+    # Nokogiri HTML5 builder is used for building HTML documents. It is very similar to the
+    # Nokogiri::XML::Builder.  In fact, you should go read the documentation for
+    # Nokogiri::XML::Builder before reading this documentation.
+    #
+    # The construction behavior is identical to HTML4::Builder, but HTML5 documents implement the
+    # [HTML5 standard's serialization
+    # algorithm](https://www.w3.org/TR/2008/WD-html5-20080610/serializing.html).
+    #
+    # == Synopsis:
+    #
+    # Create an HTML5 document with a body that has an onload attribute, and a
+    # span tag with a class of "bold" that has content of "Hello world".
+    #
+    #   builder = Nokogiri::HTML5::Builder.new do |doc|
+    #     doc.html {
+    #       doc.body(:onload => 'some_func();') {
+    #         doc.span.bold {
+    #           doc.text "Hello world"
+    #         }
+    #       }
+    #     }
+    #   end
+    #   puts builder.to_html
+    #
+    # The HTML5 builder inherits from the XML builder, so make sure to read the
+    # Nokogiri::XML::Builder documentation.
+    class Builder < Nokogiri::XML::Builder
+      ###
+      # Convert the builder to HTML
+      def to_html
+        @doc.to_html
+      end
+    end
+  end
+end

--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -254,6 +254,7 @@ Gem::Specification.new do |spec|
     "lib/nokogiri/html4/sax/parser_context.rb",
     "lib/nokogiri/html4/sax/push_parser.rb",
     "lib/nokogiri/html5.rb",
+    "lib/nokogiri/html5/builder.rb",
     "lib/nokogiri/html5/document.rb",
     "lib/nokogiri/html5/document_fragment.rb",
     "lib/nokogiri/html5/node.rb",

--- a/test/html4/test_builder.rb
+++ b/test/html4/test_builder.rb
@@ -11,6 +11,14 @@ module Nokogiri
         assert_instance_of(Nokogiri::HTML4::Builder, foo)
       end
 
+      def test_builder_returns_html4_document
+        html_doc = Nokogiri::HTML4::Builder.new do
+          div("hello")
+        end
+
+        assert_kind_of(Nokogiri::HTML4::Document, html_doc.doc)
+      end
+
       def test_builder_with_explicit_tags
         html_doc = Nokogiri::HTML4::Builder.new do
           div.slide(class: "another_class") do

--- a/test/html5/test_builder.rb
+++ b/test/html5/test_builder.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestHTML5Builder < Nokogiri::TestCase
+  def test_builder_returns_html5_document
+    html_doc = Nokogiri::HTML5::Builder.new do
+      div("hello")
+    end
+
+    assert_kind_of(Nokogiri::HTML5::Document, html_doc.doc)
+  end
+
+  def test_builder_with_explicit_tags
+    html_doc = Nokogiri::HTML5::Builder.new do
+      div.slide(class: "another_class") do
+        node = Nokogiri::XML::Node.new("id", doc)
+        node.content = "hello"
+        insert(node)
+      end
+    end.doc
+    assert_equal(1, html_doc.css("div.slide > id").length)
+    assert_equal("hello", html_doc.at("div.slide > id").content)
+  end
+
+  def test_hash_as_attributes_for_attribute_method
+    html = Nokogiri::HTML5::Builder.new do ||
+      div.slide(class: "another_class") do
+        span("Slide 1")
+      end
+    end.to_html
+    assert_match('class="slide another_class"', html)
+  end
+
+  def test_hash_as_attributes
+    builder = Nokogiri::HTML5::Builder.new do
+      div(id: "awesome") do
+        h1("america")
+      end
+    end
+    assert_equal(
+      '<div id="awesome"><h1>america</h1></div>',
+      builder.doc.root.to_html.delete("\n").gsub(/>\s*</, "><"),
+    )
+  end
+
+  def test_href_with_attributes
+    uri = "http://tenderlovemaking.com/"
+    built = Nokogiri::XML::Builder.new do
+      div do
+        a("King Khan & The Shrines", href: uri)
+      end
+    end
+    assert_equal(
+      "http://tenderlovemaking.com/",
+      built.doc.at("a")[:href],
+    )
+  end
+
+  def test_tag_nesting
+    builder = Nokogiri::HTML5::Builder.new do
+      body do
+        span.left("")
+        span.middle do
+          div.icon("")
+        end
+        span.right("")
+      end
+    end
+    assert(node = builder.doc.css("span.right").first)
+    assert_equal("middle", node.previous_sibling["class"])
+  end
+
+  def test_has_ampersand
+    builder = Nokogiri::HTML5::Builder.new do
+      div.rad.thing! do
+        text("<awe&some>")
+        b("hello & world")
+      end
+    end
+    assert_equal(
+      '<div class="rad" id="thing">&lt;awe&amp;some&gt;<b>hello &amp; world</b></div>',
+      builder.doc.root.to_html.delete("\n"),
+    )
+  end
+
+  def test_multi_tags
+    builder = Nokogiri::HTML5::Builder.new do
+      div.rad.thing! do
+        text("<awesome>")
+        b("hello")
+      end
+    end
+    assert_equal(
+      '<div class="rad" id="thing">&lt;awesome&gt;<b>hello</b></div>',
+      builder.doc.root.to_html.delete("\n"),
+    )
+  end
+
+  def test_attributes_plus_block
+    builder = Nokogiri::HTML5::Builder.new do
+      div.rad.thing! do
+        text("<awesome>")
+      end
+    end
+    assert_equal(
+      '<div class="rad" id="thing">&lt;awesome&gt;</div>',
+      builder.doc.root.to_html.chomp,
+    )
+  end
+
+  def test_builder_adds_attributes
+    builder = Nokogiri::HTML5::Builder.new do
+      div.rad.thing!("tender div")
+    end
+    assert_equal(
+      '<div class="rad" id="thing">tender div</div>',
+      builder.doc.root.to_html.chomp,
+    )
+  end
+
+  def test_bold_tag
+    builder = Nokogiri::HTML5::Builder.new do
+      b("bold tag")
+    end
+    assert_equal("<b>bold tag</b>", builder.doc.root.to_html.chomp)
+  end
+
+  def test_html_then_body_tag
+    builder = Nokogiri::HTML5::Builder.new do
+      html do
+        body do
+          b("bold tag")
+        end
+      end
+    end
+    assert_equal(
+      "<html><body><b>bold tag</b></body></html>",
+      builder.doc.root.to_html.chomp.gsub(/>\s*</, "><"),
+    )
+  end
+
+  def test_instance_eval_with_delegation_to_block_context
+    class << self
+      def foo
+        "foo!"
+      end
+    end
+
+    builder = Nokogiri::HTML5::Builder.new { text(foo) }
+    assert_includes(builder.to_html, "foo!")
+  end
+
+  def test_builder_with_param
+    doc = Nokogiri::HTML5::Builder.new do |html|
+      html.body do
+        html.p("hello world")
+      end
+    end.doc
+
+    assert(node = doc.xpath("//body/p").first)
+    assert_equal("hello world", node.content)
+  end
+
+  def test_builder_with_id
+    text = "hello world"
+    doc = Nokogiri::HTML5::Builder.new do |html|
+      html.body do
+        html.id_(text)
+      end
+    end.doc
+
+    assert(node = doc.xpath("//body/id").first)
+    assert_equal(text, node.content)
+  end
+end if Nokogiri.uses_gumbo?


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Provide a Builder class that generates HTML5 documents.

The construction behavior is identical to HTML4::Builder, but HTML5 documents serialize according to the HTML5 standard (see `xml_node.c:output_node()`).


**Have you included adequate test coverage?**

Added tests are a copied-and-modified version of the HTML4::Builder tests.


**Does this change affect the behavior of either the C or the Java implementations?**

The Java implementation still does not support HTML5.
