### PR TITLE
dep: update minimum java version from 7 to 8

### DIFF
--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -376,8 +376,8 @@ if java?
 
     ext.ext_dir = "ext/java"
     ext.lib_dir = "lib/nokogiri"
-    ext.source_version = "1.7"
-    ext.target_version = "1.7"
+    ext.source_version = "1.8"
+    ext.target_version = "1.8"
     ext.classpath = ext.gem_spec.files.select { |path| File.fnmatch?("**/*.jar", path) }.join(":")
     ext.debug = true if ENV["JAVA_DEBUG"]
   end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

- Modern OpenJDK (e.g., 21) won't build for Java 7 making development hard
- JRuby 9.4 only supports Java 8 and later, and Nokogiri only supports JRuby 9.4+
- Java 7 extended support finally ended in July 2022
  - https://support.oracle.com/knowledge/Middleware/2809708_1.html

See related commit 08e55603 which updated the minimum to 7 from 6 in 2020 (v1.11.0).

cc @headius for review


**Have you included adequate test coverage?**

Non-functional change.


**Does this change affect the behavior of either the C or the Java implementations?**

Non-functional change.