### PR TITLE
test: handle libxml2 master error message formatting

### DIFF
--- a/test/xml/test_entity_reference.rb
+++ b/test/xml/test_entity_reference.rb
@@ -187,7 +187,7 @@ module Nokogiri
         expected = if Nokogiri.uses_libxml?(">= 2.13")
           [
             "2:49: WARNING: failed to load \"http://foo.bar.com/\": Attempt to load network entity",
-            "ERROR: Attempt to load network entity http://foo.bar.com/",
+            "ERROR: Attempt to load network entity: http://foo.bar.com/",
             "4:14: ERROR: Entity 'bar' not defined",
           ]
         elsif Nokogiri.uses_libxml?


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Update tests to accept libxml2 master error message formatting that was changed in gnome/libxml2@67e475b7


**Have you included adequate test coverage?**

N/A

**Does this change affect the behavior of either the C or the Java implementations?**

Non-functional change