### PR TITLE
doc: update `ParseOptions::HUGE` warning

### DIFF
--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -140,7 +140,7 @@ module Nokogiri
 
       # Relax any hardcoded limit from the parser. Off by default.
       #
-      # ⚠ There may be a performance penalty when this option is set.
+      # ⚠ <b>It is UNSAFE to set this option</b> when parsing untrusted documents.
       HUGE        = 1 << 19
 
       # Support line numbers up to <code>long int</code> (default is a <code>short int</code>). On

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -109,7 +109,7 @@ end
 
 def nokogiri_test_task_configuration(t)
   t.libs << "test"
-  t.verbose = true
+  # t.verbose = true # This is noisier than we need. Commenting out 2024-03-07.
   # t.options = "-v" if ENV["CI"] # I haven't needed this in a long time. Commenting out 2023-12-10.
 end
 


### PR DESCRIPTION

**What problem is this PR intended to solve?**

We've long documented use of `HUGE` as a performance concern, when in reality it's a security concern. Large untrusted documents can cause OOM condition when the HUGE option is set.

Also: small developer change to lower verbosity of tests.