### PR TITLE
dep: update libxml 2.12.6 (branch v1.16.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## v1.16.3 / 2024-03-15
+
+### Dependencies
+
+* [CRuby] Vendored libxml2 is updated to [v2.12.6](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.6) from v2.12.5. (@flavorjones)
+
+
 ## v1.16.2 / 2024-02-04
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] Vendored libxml2 is updated to [v2.12.6](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.6) from v2.12.5. (@flavorjones)
 
 
+### Changed
+
+* [CRuby] `XML::Reader` sets the `@encoding` instance variable during reading if it is not passed into the initializer. Previously, it would remain `nil`. The behavior of `Reader#encoding` has not changed. This works around changes to how libxml2 reports the encoding used in v2.12.6.
+
+
 ## v1.16.2 / 2024-02-04
 
 ### Security

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 
 libxml2:
-  version: "2.12.5"
-  sha256: "a972796696afd38073e0f59c283c3a2f5a560b5268b4babc391b286166526b21"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.5.sha256sum
+  version: "2.12.6"
+  sha256: "889c593a881a3db5fdd96cc9318c87df34eb648edfc458272ad46fd607353fbb"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.6.sha256sum
 
 libxslt:
   version: "1.1.39"

--- a/ext/nokogiri/xml_reader.c
+++ b/ext/nokogiri/xml_reader.c
@@ -537,6 +537,7 @@ read_more(VALUE self)
     if (RTEST(constructor_encoding)) {
       c_document->encoding = xmlStrdup(BAD_CAST StringValueCStr(constructor_encoding));
     } else {
+      rb_iv_set(self, "@encoding", NOKOGIRI_STR_NEW2("UTF-8"));
       c_document->encoding = xmlStrdup(BAD_CAST "UTF-8");
     }
   }


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Update to v2.12.6, see https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.6

This also makes a small change to `XML::Reader` to accommodate changes in how libxml2 reports the encoding of the Reader (see https://gitlab.gnome.org/GNOME/libxml2/-/issues/697 for details).

Closes #3148