### PR TITLE
dep: update libxml to 2.11.7 (branch 1.15.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## 1.15.next / unreleased
+
+### Security
+
+* [CRuby] Vendored libxml2 is updated to address CVE-2024-25062. See [GHSA-xc9x-jj77-9p9j](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j) for more information.
+
+
+### Dependencies
+
+* [CRuby] Vendored libxml2 is updated to v2.11.7 from v2.11.6. For details please see https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.7
+
+
+
 ## 1.15.5 / 2023-11-17
 
 ### Dependencies

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,7 @@
-
 libxml2:
-  version: "2.11.6"
-  sha256: "c90eee7506764abbe07bb616b82da452529609815aefef423d66ef080eb0c300"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.6.sha256sum
+  version: "2.11.7"
+  sha256: "fb27720e25eaf457f94fd3d7189bcf2626c6dccf4201553bc8874d50e3560162"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.7.sha256sum
 
 libxslt:
   version: "1.1.39"

--- a/scripts/test-gem-install
+++ b/scripts/test-gem-install
@@ -29,9 +29,7 @@ if [ -n "${BUNDLE_APP_CONFIG:-}" ] ; then
   export BUNDLE_CACHE_PATH="${BUNDLE_APP_CONFIG}/cache"
 fi
 
-# 2.3.21 because https://github.com/rubygems/rubygems/issues/5914
-# 2.3.22 because https://github.com/rubygems/rubygems/issues/5940
-gem install bundler -v "~> 2.2, != 2.3.21, != 2.3.22"
+gem install bundler -v "2.4.22" # should work fine on ruby 2.7 and above
 bundle install --local || bundle install
 
 rm -rf lib ext # ensure we don't use the local files


### PR DESCRIPTION
**What problem is this PR intended to solve?**

In https://github.com/sparklemotion/nokogiri/discussions/3146, @jamiemccarthy requested a security release on the v1.15.x branch to address CVE-2024-25062 which was fixed in v1.16.2 with an upgrade to libxml 2.12.5.

This PR attempts to upgrade the v1.15.x branch to [libxml 2.11.7](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.7) (from 2.11.6) which also addresses that vulnerability.

Also see related https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j
