### PR TITLE
Make extconf.rb honor AR and LD variables in addition to CC

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -137,6 +137,9 @@ NOKOGIRI_HELP_MESSAGE = <<~HELP
       NOKOGIRI_USE_SYSTEM_LIBRARIES
           Equivalent to `--enable-system-libraries` when set, even if nil or blank.
 
+      AR
+          Use this path to invoke the library archiver instead of `RbConfig::CONFIG['AR']`
+
       CC
           Use this path to invoke the compiler instead of `RbConfig::CONFIG['CC']`
 
@@ -145,6 +148,9 @@ NOKOGIRI_HELP_MESSAGE = <<~HELP
 
       CFLAGS
           If this string is accepted by the compiler, add it to the flags passed to the compiler
+
+      LD
+          Use this path to invoke the linker instead of `RbConfig::CONFIG['LD']`
 
       LDFLAGS
           If this string is accepted by the linker, add it to the flags passed to the linker
@@ -626,12 +632,22 @@ if openbsd? && !config_system_libraries?
   append_cppflags "-I/usr/local/include"
 end
 
+if ENV["AR"]
+  RbConfig::CONFIG["AR"] = RbConfig::MAKEFILE_CONFIG["AR"] = ENV["AR"]
+end
+
 if ENV["CC"]
   RbConfig::CONFIG["CC"] = RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"]
 end
 
-# use same c compiler for libxml and libxslt
+if ENV["LD"]
+  RbConfig::CONFIG["LD"] = RbConfig::MAKEFILE_CONFIG["LD"] = ENV["LD"]
+end
+
+# use same toolchain for libxml and libxslt
+ENV["AR"] = RbConfig::CONFIG["AR"]
 ENV["CC"] = RbConfig::CONFIG["CC"]
+ENV["LD"] = RbConfig::CONFIG["LD"]
 
 if arg_config("--prevent-strip")
   old_cflags = $CFLAGS.split.join(" ")


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#3160

Note I also have branches that fix this on v1.16.x and v1.15.x, but I wanted to make sure I actioned feedback in one place before I opened additional MRs.

Also note that Nokogiri doesn't seem to honor variables passed as gem configuration args, and I didn't add that here because I'm not entirely sure what the "canonical" way to do this is with mkmf/mini_portile. In other situations where I need to provide the toolchain (rdkafka/karafka-rdkafka), there seems to be no special code to convert `FOO=BAR` to an env var.

That said, it's not actually necessary in my case because using `AR` and `LD` from `RbConfig` is sufficient. So one might say if you need to do something different from that, maybe it's actually a good thing that you would need to do `AR=x gem install nokogiri` rather than `gem install nokogiri -- AR=x`. I can take a stab at making this work, though, if the team thinks that both ways should work.

**Have you included adequate test coverage?**

N/A but I assume if it breaks the build in some configuration I didn't test, GitHub Actions will be mad about it :).

**Does this change affect the behavior of either the C or the Java implementations?**

No