### PR TITLE
libxml2 upstream tests (up to gnome/libxml2@5bb84b47)

### DIFF
--- a/test/xml/test_node_reparenting.rb
+++ b/test/xml/test_node_reparenting.rb
@@ -623,11 +623,7 @@ module Nokogiri
               assert_equal "after", after.content
               refute_nil after.parent, "unrelated node should not be affected"
 
-              if Nokogiri.uses_libxml?(">= 2.13.0")
-                assert_equal "beforex", before.content # coalescing fixed in gnome/libxml2@4ccd3eb8
-              else
-                assert_equal "before", before.content
-              end
+              assert_equal "before", before.content
               refute_nil before.parent, "no need to reparent"
             end
           end
@@ -666,11 +662,7 @@ module Nokogiri
               assert_equal "before", before.content
               refute_nil before.parent, "unrelated node should not be affected"
 
-              if Nokogiri.uses_libxml?(">= 2.13.0")
-                assert_equal "xafter", after.content # coalescing fixed in gnome/libxml2@4ccd3eb8
-              else
-                assert_equal "after", after.content
-              end
+              assert_equal "after", after.content
               refute_nil after.parent
             end
           end

--- a/test/xml/test_unparented_node.rb
+++ b/test/xml/test_unparented_node.rb
@@ -195,39 +195,51 @@ module Nokogiri
       end
 
       def test_add_previous_sibling_merge
-        xml = Nokogiri::XML(<<-eoxml)
-        <root>
-          <a>Hello world</a>
-        </root>
-        eoxml
-
-        assert(a_tag = xml.css("a").first)
-
+        xml = Nokogiri::XML("<root>  <a>Hello world</a>   </root>")
+        a_tag = xml.at_css("a")
         left_space = a_tag.previous
         right_space = a_tag.next
+
+        assert_equal("  ", left_space.content)
         assert_predicate(left_space, :text?)
+        assert_equal("   ", right_space.content)
         assert_predicate(right_space, :text?)
 
         left_space.add_previous_sibling(right_space)
-        assert_equal(left_space, right_space)
+
+        if Nokogiri.uses_libxml?(">= 2.13.0")
+          # after gnome/libxml2@f43197fc text nodes are never merged
+          assert_equal("  ", left_space.content)
+          assert_equal("   ", right_space.content)
+        else
+          # before gnome/libxml2@f43197fc blank text nodes are merged
+          assert_equal("     ", left_space.content)
+          assert_equal("     ", right_space.content)
+        end
       end
 
       def test_add_next_sibling_merge
-        xml = Nokogiri::XML(<<-eoxml)
-        <root>
-          <a>Hello world</a>
-        </root>
-        eoxml
-
-        assert(a_tag = xml.css("a").first)
-
+        xml = Nokogiri::XML("<root>  <a>Hello world</a>   </root>")
+        a_tag = xml.at_css("a")
         left_space = a_tag.previous
         right_space = a_tag.next
+
+        assert_equal("  ", left_space.content)
         assert_predicate(left_space, :text?)
+        assert_equal("   ", right_space.content)
         assert_predicate(right_space, :text?)
 
         right_space.add_next_sibling(left_space)
-        assert_equal(left_space, right_space)
+
+        if Nokogiri.uses_libxml?(">= 2.13.0")
+          # after gnome/libxml2@f43197fc text nodes are never merged
+          assert_equal("  ", left_space.content)
+          assert_equal("   ", right_space.content)
+        else
+          # before gnome/libxml2@f43197fc blank text nodes are merged
+          assert_equal("     ", left_space.content)
+          assert_equal("     ", right_space.content)
+        end
       end
 
       def test_add_next_sibling_to_root_raises_exception


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Get upstream libxml2 integration tests passing again. gnome/libxml2@5bb84b47 changed behavior around text node coalescing again. See related #3161.

Notably, with this change, blank text nodes are no longer merged by `#add_{next,previous}_sibling`. See the tests originally added in 3c8c21ec back in 2009 for some context.
