### PR TITLE
dep: update to zlib 1.3.1 (main)

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,4 +1,4 @@
-
+---
 libxml2:
   version: "2.12.6"
   sha256: "889c593a881a3db5fdd96cc9318c87df34eb648edfc458272ad46fd607353fbb"
@@ -10,8 +10,8 @@ libxslt:
   # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.39.sha256sum
 
 zlib:
-  version: "1.3"
-  sha256: "ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e"
+  version: "1.3.1"
+  sha256: "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
   # SHA-256 hash provided on http://zlib.net/
 
 libiconv:


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Update vendored zlib to 1.3.1.

See #3172 

Please note that Nokogiri is not vulnerable to the CVE patched in this version of zlib (which is related to the minizip library, which is not used by Nokogiri or its vendored libraries).
