### PR TITLE
Make a test depending on the rubyzip gem optional.

### DIFF
--- a/test/xml/test_document_encoding.rb
+++ b/test/xml/test_document_encoding.rb
@@ -91,7 +91,11 @@ module Nokogiri
         describe "pseudo-IO" do
           it "serializes correctly with Zip::OutputStream objects" do
             # https://github.com/sparklemotion/nokogiri/issues/2773
-            require "zip"
+            begin
+              require "zip"
+            rescue LoadError
+              skip("rubyzip is not installed")
+            end
 
             xml = <<~XML
               <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Because I still want to pass the nokogiri's unit tests in a downstream nokogiri package on a Linux distro such as CentOS 10 Stream and RHEL 10, where we don't want to manage the rubyzip gem[1].

[1] https://rubygems.org/gems/rubyzip

<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

We manage the nokogiri's downstream RPM package on a Linux distro such as CentOS 10 Stream and RHEL 10.
However, we don't want to manage the depending rubyzip gem RPM package in CentOS 10 Stream and RHEL 10. And we still want to pass the nokogiri's unit tests on the environments.

This PR is still to pass the nokogiri's unit tests where rubyzip is not maintained.


**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

This PR is just to make a test case optional. So, it doesn't affect the test coverage.

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

No. This PR is just for a test, not for an implementation.

---

## How I tested

I uninstalled the `rubyzip` gem on my local Bundler environment.

```
diff --git a/Gemfile b/Gemfile
index dd3c3b40..1556a554 100644
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development do
   gem "minitest", "5.22.3"
   gem "minitest-parallel_fork", "2.0.0"
   gem "ruby_memcheck", "2.3.0"
-  gem "rubyzip", "~> 2.3.2"
+  # gem "rubyzip", "~> 2.3.2"
   gem "simplecov", "= 0.21.2"

   # rubocop
```

```
$ bundle update

$ bundle list | grep zip
```

Then I confirmed the skipping message was printed.


```
$ bundle exec rake test TEST=test/xml/test_document_encoding.rb TESTOPTS="-v"
...
# Running:

Nokogiri::XML::Document encoding::#encoding#test_0001_describes the document's encoding correctly = 0.00 s = .
Nokogiri::XML::Document encoding::#encoding#test_0002_applies the specified encoding even if on empty documents = 0.00 s = .
Nokogiri::XML::Document encoding#test_0003_encodes the library versions as UTF-8 = 0.00 s = .
Nokogiri::XML::Document encoding#test_0002_encodes the encoding name as UTF-8 = 0.00 s = .
Nokogiri::XML::Document encoding#test_0001_encodes the URL as UTF-8 = 0.00 s = .
Nokogiri::XML::Document encoding#test_0005_serializes UTF-16 correctly across libxml2 buffer flushes = 0.00 s = .
Nokogiri::XML::Document encoding#test_0004_parses and serializes UTF-16 correctly = 0.00 s = .
Nokogiri::XML::Document encoding::#encoding=#test_0001_determines the document's encoding when serialized = 0.00 s = .
Nokogiri::XML::Document encoding::pseudo-IO#test_0001_serializes correctly with Zip::OutputStream objects = 0.00 s = S

Finished in 0.023078s, 389.9802 runs/s, 1126.6094 assertions/s.

  1) Skipped:
Nokogiri::XML::Document encoding::pseudo-IO#test_0001_serializes correctly with Zip::OutputStream objects [test/xml/test_document_encoding.rb:97]:
rubyzip is not installed

9 runs, 26 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for Unit Tests to /home/jaruga/var/git/nokogiri/coverage. 1346 / 2769 LOC (48.61%) covered.
```

Note that there is a similar case skipping unit tests depending on a specific gem in mysql2  project.

https://github.com/brianmario/mysql2/blob/43ea8af635f5e23f054294ef7759320d47f30e5f/spec/em/em_spec.rb#L133-L135

