### PR TITLE
ci: add arm64-darwin coverage using macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,7 +551,7 @@ jobs:
         plat:
           - "aarch64-linux"
           - "arm-linux"
-          - "arm64-darwin" # github actions does not support this runtime as of 2022-12, but let's build anyway
+          - "arm64-darwin"
           - "x64-mingw-ucrt"
           - "x64-mingw32"
           - "x86-linux"
@@ -688,7 +688,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2", "3.3"]
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:
@@ -699,6 +699,26 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: cruby-x86_64-darwin-gem
+          path: gems
+      - run: ./scripts/test-gem-install gems
+
+  cruby-arm64-darwin-install:
+    needs: ["cruby-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-arm64-darwin-gem
           path: gems
       - run: ./scripts/test-gem-install gems
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Add arm64-darwin coverage using macos-14. Also, pin the x86_64-darwin test to macos-13.

See flavorjones/ruby-c-extensions-explained#30 for more context.
