### PR TITLE
dep: update vendored libxml2 to v2.12.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,7 +544,7 @@ jobs:
         plat:
           - "aarch64-linux"
           - "arm-linux"
-          - "arm64-darwin" # github actions does not support this runtime as of 2022-12, but let's build anyway
+          - "arm64-darwin"
           - "x64-mingw-ucrt"
           - "x64-mingw32"
           - "x86-linux"
@@ -681,7 +681,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2", "3.3"]
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:
@@ -692,6 +692,26 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: cruby-x86_64-darwin-gem
+          path: gems
+      - run: ./scripts/test-gem-install gems
+
+  cruby-arm64-darwin-install:
+    needs: ["cruby-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-arm64-darwin-gem
           path: gems
       - run: ./scripts/test-gem-install gems
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## next
+
+### Security
+
+* [CRuby] Vendored libxml2 is updated to address CVE-2024-34459. See [GHSA-r95h-9x8f-r3f7](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-r95h-9x8f-r3f7) for more information.
+
+
+### Dependencies
+
+* [CRuby] Vendored libxml2 is updated to [v2.12.7](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.7) from v2.12.6. (@flavorjones)
+
+
 ## v1.16.4 / 2024-04-10
 
 ### Dependencies

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.12.6"
-  sha256: "889c593a881a3db5fdd96cc9318c87df34eb648edfc458272ad46fd607353fbb"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.6.sha256sum
+  version: "2.12.7"
+  sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.7.sha256sum
 
 libxslt:
   version: "1.1.39"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Vendored libxml2 is updated to address CVE-2024-34459. See [GHSA-r95h-9x8f-r3f7](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-r95h-9x8f-r3f7) for more information.