### PR TITLE
refactor: `Gumbo.parse` and `.fragment` now use keyword arguments

### DIFF
--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -338,7 +338,10 @@ common_options(VALUE kwargs)
   GumboOptions options = kGumboDefaultOptions;
   options.max_attributes = NUM2INT(values[0]);
   options.max_errors = NUM2INT(values[1]);
-  options.max_tree_depth = NUM2INT(values[2]);
+
+  // handle negative values
+  int depth = NUM2INT(values[2]);
+  options.max_tree_depth = depth < 0 ? UINT_MAX : (unsigned int)depth;
 
   return options;
 }
@@ -569,13 +572,14 @@ error:
   }
 
   // Perform a fragment parse.
-  // Add one to the max tree depth to account for the HTML element.
-  options.max_tree_depth = options.max_tree_depth < 0 ? -1 : (options.max_tree_depth + 1);
   options.fragment_context = ctx_tag;
   options.fragment_namespace = ctx_ns;
   options.fragment_encoding = encoding;
   options.quirks_mode = quirks_mode;
   options.fragment_context_has_form_ancestor = form;
+
+  // Add one to the max tree depth to account for the HTML element.
+  if (options.max_tree_depth < UINT_MAX) { options.max_tree_depth++; }
 
   GumboOutput *output = perform_parse(&options, tags);
   ParseArgs args = {

--- a/lib/nokogiri/html5/document.rb
+++ b/lib/nokogiri/html5/document.rb
@@ -119,7 +119,7 @@ module Nokogiri
           string = HTML5.read_and_encode(string_or_io, encoding)
 
           options[:max_attributes] ||= Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES
-          options[:max_errors] ||= options[:max_parse_errors] || Nokogiri::Gumbo::DEFAULT_MAX_ERRORS
+          options[:max_errors] ||= options.delete(:max_parse_errors) || Nokogiri::Gumbo::DEFAULT_MAX_ERRORS
           options[:max_tree_depth] ||= Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH
 
           doc = Nokogiri::Gumbo.parse(string, url, self, **options)

--- a/lib/nokogiri/html5/document.rb
+++ b/lib/nokogiri/html5/document.rb
@@ -92,7 +92,7 @@ module Nokogiri
             raise ArgumentError, "not a string or IO object"
           end
 
-          do_parse(string_or_io, url, encoding, options)
+          do_parse(string_or_io, url, encoding, **options)
         end
 
         # Create a new document from an IO object.
@@ -101,7 +101,7 @@ module Nokogiri
         def read_io(io, url = nil, encoding = nil, **options)
           raise ArgumentError, "io object doesn't respond to :read" unless io.respond_to?(:read)
 
-          do_parse(io, url, encoding, options)
+          do_parse(io, url, encoding, **options)
         end
 
         # Create a new document from a String.
@@ -110,17 +110,19 @@ module Nokogiri
         def read_memory(string, url = nil, encoding = nil, **options)
           raise ArgumentError, "string object doesn't respond to :to_str" unless string.respond_to?(:to_str)
 
-          do_parse(string, url, encoding, options)
+          do_parse(string, url, encoding, **options)
         end
 
         private
 
-        def do_parse(string_or_io, url, encoding, options)
+        def do_parse(string_or_io, url, encoding, **options)
           string = HTML5.read_and_encode(string_or_io, encoding)
-          max_attributes = options[:max_attributes] || Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES
-          max_errors = options[:max_errors] || options[:max_parse_errors] || Nokogiri::Gumbo::DEFAULT_MAX_ERRORS
-          max_depth = options[:max_tree_depth] || Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH
-          doc = Nokogiri::Gumbo.parse(string, url, max_attributes, max_errors, max_depth, self)
+
+          options[:max_attributes] ||= Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES
+          options[:max_errors] ||= options[:max_parse_errors] || Nokogiri::Gumbo::DEFAULT_MAX_ERRORS
+          options[:max_tree_depth] ||= Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH
+
+          doc = Nokogiri::Gumbo.parse(string, url, self, **options)
           doc.encoding = "UTF-8"
           doc
         end

--- a/lib/nokogiri/html5/document_fragment.rb
+++ b/lib/nokogiri/html5/document_fragment.rb
@@ -41,11 +41,13 @@ module Nokogiri
         self.errors = []
         return self unless tags
 
-        max_attributes = options[:max_attributes] || Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES
-        max_errors = options[:max_errors] || Nokogiri::Gumbo::DEFAULT_MAX_ERRORS
-        max_depth = options[:max_tree_depth] || Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH
         tags = Nokogiri::HTML5.read_and_encode(tags, nil)
-        Nokogiri::Gumbo.fragment(self, tags, ctx, max_attributes, max_errors, max_depth)
+
+        options[:max_attributes] ||= Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES
+        options[:max_errors] ||= options[:max_parse_errors] || Nokogiri::Gumbo::DEFAULT_MAX_ERRORS
+        options[:max_tree_depth] ||= Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH
+
+        Nokogiri::Gumbo.fragment(self, tags, ctx, **options)
       end
 
       def serialize(options = {}, &block) # :nodoc:

--- a/lib/nokogiri/html5/document_fragment.rb
+++ b/lib/nokogiri/html5/document_fragment.rb
@@ -44,7 +44,7 @@ module Nokogiri
         tags = Nokogiri::HTML5.read_and_encode(tags, nil)
 
         options[:max_attributes] ||= Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES
-        options[:max_errors] ||= options[:max_parse_errors] || Nokogiri::Gumbo::DEFAULT_MAX_ERRORS
+        options[:max_errors] ||= options.delete(:max_parse_errors) || Nokogiri::Gumbo::DEFAULT_MAX_ERRORS
         options[:max_tree_depth] ||= Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH
 
         Nokogiri::Gumbo.fragment(self, tags, ctx, **options)

--- a/test/html5/test_encoding.rb
+++ b/test/html5/test_encoding.rb
@@ -189,8 +189,19 @@ class TestHtml5Encoding < Nokogiri::TestCase
     define_method("test_parse_encoded_#{enc[0]}".to_sym) do
       html = "<!DOCTYPE html><span>#{enc[1]}</span>"
       encoded_html = round_trip_through(html, enc[0])
-      doc = Nokogiri::HTML5(encoded_html, encoding: enc[0])
+      doc = Nokogiri::HTML5(encoded_html)
       span = doc.at("/html/body/span")
+
+      refute_nil span
+      assert_equal enc[1], span.content
+    end
+
+    define_method("test_parse_encoded_#{enc[0]}_with_encoding".to_sym) do
+      html = "<!DOCTYPE html><span>#{enc[1]}</span>"
+      encoded_html = round_trip_through(html, enc[0])
+      doc = Nokogiri::HTML5(encoded_html, nil, enc[0])
+      span = doc.at("/html/body/span")
+
       refute_nil span
       assert_equal enc[1], span.content
     end
@@ -198,6 +209,7 @@ class TestHtml5Encoding < Nokogiri::TestCase
     define_method("test_inner_html_encoded_#{enc[0]}".to_sym) do
       encoded = round_trip_through(enc[1], enc[0])
       span = encodings_doc.at(%(/html/body/span[@id="#{enc[0]}"]))
+
       refute_nil span
       assert_equal encoded, span.inner_html(encoding: enc[0])
     end
@@ -208,9 +220,25 @@ class TestHtml5Encoding < Nokogiri::TestCase
       # multiple conversions have to happen. I'm not sure it's worth working
       # around. It impacts this test though.
       skip "https://bugs.ruby-lang.org/issues/15033" if enc[0] == "ISO-2022-JP"
+
       round_trip_through(enc[1], enc[0])
       encoded = encodings_doc.serialize(encoding: enc[0])
-      doc = Nokogiri::HTML5(encoded, encoding: enc[0])
+      doc = Nokogiri::HTML5(encoded)
+
+      assert_equal encodings_html, doc.serialize
+    end
+
+    define_method("test_roundtrip_through_#{enc[0]}_with_encoding".to_sym) do
+      # https://bugs.ruby-lang.org/issues/15033
+      # Ruby has a bug with the `:fallback` parameter passed to `#encode` when
+      # multiple conversions have to happen. I'm not sure it's worth working
+      # around. It impacts this test though.
+      skip "https://bugs.ruby-lang.org/issues/15033" if enc[0] == "ISO-2022-JP"
+
+      round_trip_through(enc[1], enc[0])
+      encoded = encodings_doc.serialize(encoding: enc[0])
+      doc = Nokogiri::HTML5(encoded, nil, enc[0])
+
       assert_equal encodings_html, doc.serialize
     end
   end

--- a/test/html5/test_nokogumbo.rb
+++ b/test/html5/test_nokogumbo.rb
@@ -340,6 +340,15 @@ class TestHtml5Nokogumbo < Nokogiri::TestCase
     assert_equal(expected, frag.at_css("div").children.map(&:type))
   end
 
+  it "raises an exception if an unexpected kwarg is provided" do
+    assert_raises(ArgumentError) do
+      Nokogiri::HTML5::Document.parse("<p>", foo: "bar")
+    end
+    assert_raises(ArgumentError) do
+      Nokogiri::HTML5::DocumentFragment.parse("<p>", Encoding::UTF_8, foo: "bar")
+    end
+  end
+
   private
 
   def buffer

--- a/test/html5/test_nokogumbo.rb
+++ b/test/html5/test_nokogumbo.rb
@@ -268,6 +268,7 @@ class TestHtml5Nokogumbo < Nokogiri::TestCase
     end
 
     assert(Nokogiri::HTML5(html, max_tree_depth: depth))
+    assert(Nokogiri::HTML5(html, max_tree_depth: -1))
   end
 
   def test_max_depth_fragment
@@ -278,6 +279,7 @@ class TestHtml5Nokogumbo < Nokogiri::TestCase
     end
 
     assert(Nokogiri::HTML5.fragment(html, max_tree_depth: depth))
+    assert(Nokogiri::HTML5.fragment(html, max_tree_depth: -1))
   end
 
   def test_document_encoding


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Refactor `Gumbo.parse` and `Gumbo.fragment` to use keyword arguments for parse options (instead of positional arguments).

These methods are internal and not part of the public API, so this isn't considered a breaking change. We're changing them to be more extensible going forward.

See comments at #3178 for context

This PR also

- introduces checking for the Gumbo options passed in
- takes care to delete deprecated kwarg `max_parse_errors`
- cleans up options passed around in tests


**Have you included adequate test coverage?**

It's a refactor, existing test coverage should be sufficient.


**Does this change affect the behavior of either the C or the Java implementations?**

No behavior changes, but the HTML5 parser is only available in CRuby.
