### PR TITLE
libgumbo test: Don't print expected errors

### DIFF
--- a/gumbo-parser/test/tokenizer.cc
+++ b/gumbo-parser/test/tokenizer.cc
@@ -75,7 +75,7 @@ class GumboTokenizerTest : public GumboTest {
     parser_._output->document_error = false;
     gumbo_lex(&parser_, &token_);
     EXPECT_EQ(errors_are_expected, parser_._output->document_error);
-    errors_are_expected_ = errors_are_expected;
+    errors_are_expected_ |= errors_are_expected;
   }
 
   void NextChar(int c, bool errors_are_expected = false) {


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Testing gumbo prints error messages even when they are expected (at least in
some cases). This stops that from happening.

No functional changes outside of tests.


<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

N/A. This is a change to the testing infrastructure.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

No.
