### PR TITLE
dev: remove compatibility code for ancient rubies

### DIFF
--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -37,30 +37,6 @@ VALUE cNokogiriHtml5Document;
 static ID internal_subset;
 static ID parent;
 
-/* Backwards compatibility to Ruby 2.1.0 */
-#if RUBY_API_VERSION_CODE < 20200
-#define ONIG_ESCAPE_UCHAR_COLLISION 1
-#include <ruby/encoding.h>
-
-static VALUE
-rb_utf8_str_new(const char *str, long length)
-{
-  return rb_enc_str_new(str, length, rb_utf8_encoding());
-}
-
-static VALUE
-rb_utf8_str_new_cstr(const char *str)
-{
-  return rb_enc_str_new_cstr(str, rb_utf8_encoding());
-}
-
-static VALUE
-rb_utf8_str_new_static(const char *str, long length)
-{
-  return rb_enc_str_new(str, length, rb_utf8_encoding());
-}
-#endif
-
 #include <nokogiri.h>
 #include <libxml/tree.h>
 #include <libxml/HTMLtree.h>


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Remove unneeded code for compatibility with Ruby < 2.1
