### PR TITLE
Compile with type/sign conversion warnings

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -682,12 +682,9 @@ append_cflags("-Winline")
 # good to have no matter what Ruby was compiled with
 append_cflags("-Wmissing-noreturn")
 
-# check integer loss of precision
-if darwin?
-  append_cflags("-Wshorten-64-to-32")
-else
-  append_cflags("-Wconversion -Wno-sign-conversion")
-end
+# check integer loss of precision. this flag won't generally work until Ruby 3.4.
+# see https://bugs.ruby-lang.org/issues/20507
+append_cflags("-Wconversion")
 
 # handle clang variations, see #1101
 if darwin?

--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -70,7 +70,7 @@ perform_parse(const GumboOptions *options, VALUE input)
   GumboOutput *output = gumbo_parse_with_options(
                           options,
                           RSTRING_PTR(input),
-                          RSTRING_LEN(input)
+                          (size_t)RSTRING_LEN(input)
                         );
 
   const char *status_string = gumbo_status_to_string(output->status);
@@ -236,7 +236,7 @@ static void
 add_errors(const GumboOutput *output, VALUE rdoc, VALUE input, VALUE url)
 {
   const char *input_str = RSTRING_PTR(input);
-  size_t input_len = RSTRING_LEN(input);
+  size_t input_len = (size_t)RSTRING_LEN(input);
 
   // Add parse errors to rdoc.
   if (output->errors.length) {
@@ -248,11 +248,11 @@ add_errors(const GumboOutput *output, VALUE rdoc, VALUE input, VALUE url)
       GumboSourcePosition position = gumbo_error_position(err);
       char *msg;
       size_t size = gumbo_caret_diagnostic_to_string(err, input_str, input_len, &msg);
-      VALUE err_str = rb_utf8_str_new(msg, size);
+      VALUE err_str = rb_utf8_str_new(msg, (int)size);
       free(msg);
       VALUE syntax_error = rb_class_new_instance(1, &err_str, cNokogiriXmlSyntaxError);
       const char *error_code = gumbo_error_code(err);
-      VALUE str1 = error_code ? rb_utf8_str_new_static(error_code, strlen(error_code)) : Qnil;
+      VALUE str1 = error_code ? rb_utf8_str_new_static(error_code, (int)strlen(error_code)) : Qnil;
       rb_iv_set(syntax_error, "@domain", INT2NUM(1)); // XML_FROM_PARSER
       rb_iv_set(syntax_error, "@code", INT2NUM(1));   // XML_ERR_INTERNAL_ERROR
       rb_iv_set(syntax_error, "@level", INT2NUM(2));  // XML_ERR_ERROR
@@ -393,7 +393,7 @@ lookup_namespace(VALUE node, bool require_known_ns)
   Check_Type(ns, T_STRING);
 
   const char *href_ptr = RSTRING_PTR(ns);
-  size_t href_len = RSTRING_LEN(ns);
+  size_t href_len = (size_t)RSTRING_LEN(ns);
 #define NAMESPACE_P(uri) (href_len == sizeof uri - 1 && !memcmp(href_ptr, uri, href_len))
   if (NAMESPACE_P("http://www.w3.org/1999/xhtml")) {
     return GUMBO_NAMESPACE_HTML;
@@ -451,7 +451,7 @@ noko_gumbo_s_fragment(int argc, VALUE *argv, VALUE _self)
   } else if (TYPE(ctx) == T_STRING) {
     ctx_tag = StringValueCStr(ctx);
     ctx_ns = GUMBO_NAMESPACE_HTML;
-    size_t len = RSTRING_LEN(ctx);
+    size_t len = (size_t)RSTRING_LEN(ctx);
     const char *colon = memchr(ctx_tag, ':', len);
     if (colon) {
       switch (colon - ctx_tag) {

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -109,7 +109,7 @@ memsize_node(const xmlNodePtr node)
   xmlAttrPtr property;
   size_t memsize = 0;
 
-  memsize += xmlStrlen(node->name);
+  memsize += (size_t)xmlStrlen(node->name);
 
   if (node->type == XML_ELEMENT_NODE) {
     for (property = node->properties; property; property = property->next) {
@@ -117,7 +117,7 @@ memsize_node(const xmlNodePtr node)
     }
   }
   if (node->type == XML_TEXT_NODE) {
-    memsize += xmlStrlen(node->content);
+    memsize += (size_t)xmlStrlen(node->content);
   }
   for (child = node->children; child; child = child->next) {
     memsize += sizeof(xmlNode) + memsize_node(child);

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1805,12 +1805,12 @@ output_escaped_string(VALUE out, xmlChar const *start, bool attr)
       ++next;
       continue;
     }
-    output_partial_string(out, (char const *)start, next - start);
+    output_partial_string(out, (char const *)start, (size_t)(next - start));
     output_string(out, replacement);
     next += replaced_bytes;
     start = next;
   }
-  output_partial_string(out, (char const *)start, next - start);
+  output_partial_string(out, (char const *)start, (size_t)(next - start));
 }
 
 static bool
@@ -2024,11 +2024,11 @@ rb_xml_node_line_set(VALUE rb_node, VALUE rb_line_number)
   // libxml2 optionally uses xmlNode.psvi to store longer line numbers, but only for text nodes.
   // search for "psvi" in SAX2.c and tree.c to learn more.
   if (line_number < 65535) {
-    c_node->line = (short) line_number;
+    c_node->line = (short unsigned)line_number;
   } else {
     c_node->line = 65535;
     if (c_node->type == XML_TEXT_NODE) {
-      c_node->psvi = (void *)(ptrdiff_t) line_number;
+      c_node->psvi = (void *)(ptrdiff_t)line_number;
     }
   }
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

While working with @stevecheckoway on #3205, we caught an edge case in how the `max_depth` parameter was converted from signed to unsigned int. It turned out that it would have been caught much earlier with the `-Wconversion` flag, but that flag is useless in Ruby C extensions because of the issue described at https://bugs.ruby-lang.org/issues/20507

That issue was fixed in Ruby 3.4-dev by https://github.com/ruby/ruby/pull/10843 and so I'm using it here and fixing the compilation warnings it flags.


**Have you included adequate test coverage?**

N/A


**Does this change affect the behavior of either the C or the Java implementations?**

N/A