### PR TITLE
Show nonstandard element tags in error messages

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -1094,6 +1094,16 @@ else
             env["AR"] = "#{host}-ar"
           end
           env["RANLIB"] = "#{host}-ranlib"
+          if windows?
+            # NOTE: that in any particular windows gem package, we only ever compile against either
+            # msvcrt (ruby <= 3.0) or ucrt (ruby > 3.0), so even though this gets evaluated only once
+            # per gem (and not per-version-of-ruby), it's OK.
+            env["CFLAGS"] = if RbConfig::CONFIG["RUBY_SO_NAME"].include?("msvcrt")
+              concat_flags(env["CFLAGS"], "-D_RUBY_MSVCRT")
+            else
+              concat_flags(env["CFLAGS"], "-D_RUBY_UCRT")
+            end
+          end
         end
 
         execute("compile", make_cmd, { env: env })

--- a/gumbo-parser/src/error.c
+++ b/gumbo-parser/src/error.c
@@ -46,7 +46,8 @@ static int PRINTF(2) print_message (
     args
   );
   va_end(args);
-#if _MSC_VER && _MSC_VER < 1900
+
+#if (defined(_MSC_VER) && (_MSC_VER < 1900)) || defined(_RUBY_MSVCRT)
   if (bytes_written == -1) {
     // vsnprintf returns -1 on older MSVC++ if there's not enough capacity,
     // instead of returning the number of bytes that would've been written had
@@ -57,19 +58,19 @@ static int PRINTF(2) print_message (
 
     va_start(args, format);
     bytes_written = vsnprintf (
-      output->data + output->length,
+      NULL,
       0,
       format,
       args
     );
     va_end(args);
   }
-#else
+#endif
+
   // -1 in standard C99 indicates an encoding error. Return 0 and do nothing.
   if (bytes_written == -1) {
     return 0;
   }
-#endif
 
   if (bytes_written >= remaining_capacity) {
     // At least double the size of the buffer.

--- a/gumbo-parser/src/error.h
+++ b/gumbo-parser/src/error.h
@@ -95,12 +95,16 @@ typedef struct GumboInternalParserError {
   // The HTML tag of the input token. TAG_UNKNOWN if this was not a tag token.
   GumboTag input_tag;
 
+  // The HTML tag of the input token if it was nonstandard tag token. NULL otherwise.
+  char *input_name;
+
   // The insertion mode that the parser was in at the time.
   GumboInsertionMode parser_state;
 
   // The tag stack at the point of the error. Note that this is an GumboVector
   // of GumboTag's *stored by value* - cast the void* to an GumboTag directly to
-  // get at the tag.
+  // get at the tag. For nonstandard tags, this is a pointer to an owned char *
+  // containing the tag name.
   GumboVector /* GumboTag */ tag_stack;
 } GumboParserError;
 

--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -749,10 +749,20 @@ static void parser_add_parse_error (
   GumboParserError* extra_data = &error->v.parser;
   extra_data->input_type = token->type;
   extra_data->input_tag = GUMBO_TAG_UNKNOWN;
-  if (token->type == GUMBO_TOKEN_START_TAG) {
+  extra_data->input_name = NULL;
+  if (token->type == GUMBO_TOKEN_START_TAG)
+  {
     extra_data->input_tag = token->v.start_tag.tag;
-  } else if (token->type == GUMBO_TOKEN_END_TAG) {
+    if (extra_data->input_tag == GUMBO_TAG_UNKNOWN && token->v.start_tag.name) {
+      extra_data->input_name = gumbo_strdup(token->v.start_tag.name);
+    }
+  }
+  else if (token->type == GUMBO_TOKEN_END_TAG)
+  {
     extra_data->input_tag = token->v.end_tag.tag;
+    if (extra_data->input_tag == GUMBO_TAG_UNKNOWN && token->v.end_tag.name) {
+      extra_data->input_name = gumbo_strdup(token->v.end_tag.name);
+    }
   }
   const GumboParserState* state = parser->_parser_state;
   extra_data->parser_state = state->_insertion_mode;
@@ -763,10 +773,13 @@ static void parser_add_parse_error (
       node->type == GUMBO_NODE_ELEMENT
       || node->type == GUMBO_NODE_TEMPLATE
     );
-    gumbo_vector_add (
-      (void*) node->v.element.tag,
-      &extra_data->tag_stack
-    );
+    void *tag;
+    if (node->v.element.tag == GUMBO_TAG_UNKNOWN && node->v.element.name) {
+      tag = gumbo_strdup(node->v.element.name);
+    } else {
+      tag = (void *)(uintptr_t)node->v.element.tag;
+    }
+    gumbo_vector_add(tag, &extra_data->tag_stack);
   }
 }
 

--- a/test/html5/test_errors.rb
+++ b/test/html5/test_errors.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require "helper"
+
+class TestHtml5Serialize < Nokogiri::TestCase
+  def test_nonstandard_elements_in_errors
+    doc = Nokogiri::HTML5.fragment("<table><foo></foo></table>", max_errors: 100)
+    assert_equal(2, doc.errors.length)
+    assert_match(/Start tag 'foo'/, doc.errors.first.to_s.lines.first)
+  end
+
+  def test_nonstandard_elements_in_tag_stack
+    doc = Nokogiri::HTML5.fragment("<foo><table><br></table></foo>", max_errors: 100)
+    assert_equal(1, doc.errors.length)
+    assert_match(/Currently open tags: html, foo, table/, doc.errors.first.to_s.lines.first)
+  end
+end if Nokogiri.uses_gumbo?


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Error messages do not currently show nonstandard element names.  This remedies this situation.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

Yes.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

It changes the behavior of the gumbo parser.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
