### PR TITLE
deprecate: Nokogiri::CSS.parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] `Nokogiri::XML::CData.new` no longer accepts `nil` as the content argument, making `CData` behave like other character data classes (like `Comment` and `Text`). This change was necessitated by behavioral changes in the upcoming libxml 2.13.0 release. If you wish to create an empty CDATA node, pass an empty string. [#3156] @flavorjones
 
 
+### Deprecated
+
+* The undocumented and unused method `Nokogiri::CSS.parse` is now deprecated and will generate a warning. The AST returned by this method is private and subject to change and removal in future versions of Nokogiri. This method will be removed in a future version of Nokogiri.
+
+
 ## v1.16.5
 
 ### Security

--- a/lib/nokogiri/css.rb
+++ b/lib/nokogiri/css.rb
@@ -8,6 +8,7 @@ module Nokogiri
       # TODO: Deprecate this method ahead of 2.0 and delete it in 2.0.
       # It is not used by Nokogiri and shouldn't be part of the public API.
       def parse(selector) # :nodoc:
+        warn("Nokogiri::CSS.parse is deprecated and will be removed in a future version of Nokogiri. Use Nokogiri::CSS::Parser#parse instead.", uplevel: 1, category: :deprecated)
         Parser.new.parse(selector)
       end
 


### PR DESCRIPTION

**What problem is this PR intended to solve?**

The undocumented and unused method `Nokogiri::CSS.parse` is now deprecated and will generate a warning. This method will be removed in a future version of Nokogiri.

The AST returned by this method is private and subject to change and removal in future versions of Nokogiri.


**Have you included adequate test coverage?**

There is no test coverage for this method because Nokogiri doesn't use it.


**Does this change affect the behavior of either the C or the Java implementations?**

This method is unused.