### PR TITLE
extract CSS selector cache into CSS::SelectorCache

### DIFF
--- a/lib/nokogiri/css/selector_cache.rb
+++ b/lib/nokogiri/css/selector_cache.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "thread"
+
+module Nokogiri
+  module CSS
+    module SelectorCache # :nodoc:
+      @cache = {}
+      @mutex = Mutex.new
+
+      class << self
+        # Retrieve the cached XPath expressions for the key
+        def [](key)
+          @mutex.synchronize { @cache[key] }
+        end
+
+        # Insert the XPath expressions `value` at the cache key
+        def []=(key, value)
+          @mutex.synchronize { @cache[key] = value }
+        end
+
+        # Clear the cache
+        def clear_cache(create_new_object = false)
+          @mutex.synchronize do
+            if create_new_object
+              @cache = {}
+            else
+              @cache.clear
+            end
+          end
+        end
+
+        # Construct a unique key cache key
+        def key(selector:, visitor:)
+          [selector, visitor.config]
+        end
+      end
+    end
+  end
+end

--- a/lib/nokogiri/decorators/slop.rb
+++ b/lib/nokogiri/decorators/slop.rb
@@ -23,11 +23,9 @@ module Nokogiri
             list = xpath("#{XPATH_PREFIX}#{name}[#{conds}]")
           end
         else
-          CSS::Parser.without_cache do
-            list = xpath(
-              *CSS.xpath_for("#{name}#{args.first}", prefix: XPATH_PREFIX),
-            )
-          end
+          list = xpath(
+            *CSS.xpath_for("#{name}#{args.first}", prefix: XPATH_PREFIX, cache: false),
+          )
         end
 
         super if list.empty?

--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -233,6 +233,7 @@ Gem::Specification.new do |spec|
     "lib/nokogiri/css/parser.rb",
     "lib/nokogiri/css/parser.y",
     "lib/nokogiri/css/parser_extras.rb",
+    "lib/nokogiri/css/selector_cache.rb",
     "lib/nokogiri/css/syntax_error.rb",
     "lib/nokogiri/css/tokenizer.rb",
     "lib/nokogiri/css/tokenizer.rex",

--- a/test/css/test_css.rb
+++ b/test/css/test_css.rb
@@ -9,16 +9,14 @@ describe Nokogiri::CSS do
     end
 
     it "accepts a CSS::XPathVisitor" do
-      Nokogiri::CSS::Parser.without_cache do
-        mock_visitor = Minitest::Mock.new
-        mock_visitor.expect(:accept, "injected-value", [Nokogiri::CSS::Node])
-        mock_visitor.expect(:prefix, "//")
+      mock_visitor = Minitest::Mock.new
+      mock_visitor.expect(:accept, "injected-value", [Nokogiri::CSS::Node])
+      mock_visitor.expect(:prefix, "//")
 
-        result = Nokogiri::CSS.xpath_for("foo", visitor: mock_visitor)
+      result = Nokogiri::CSS.xpath_for("foo", visitor: mock_visitor, cache: false)
 
-        mock_visitor.verify
-        assert_equal(["//injected-value"], result)
-      end
+      mock_visitor.verify
+      assert_equal(["//injected-value"], result)
     end
 
     it "accepts an options hash" do

--- a/test/css/test_parser_cache.rb
+++ b/test/css/test_parser_cache.rb
@@ -8,8 +8,8 @@ describe Nokogiri::CSS::Parser do
       super
       @css = "a1 > b2 > c3"
 
-      Nokogiri::CSS::Parser.clear_cache
-      Nokogiri::CSS::Parser.class_eval do
+      Nokogiri::CSS::SelectorCache.clear_cache
+      Nokogiri::CSS::SelectorCache.class_eval do
         class << @cache
           alias_method :old_bracket, :[]
 
@@ -24,48 +24,35 @@ describe Nokogiri::CSS::Parser do
           end
         end
       end
-
-      assert_predicate(Nokogiri::CSS::Parser, :cache_on?)
     end
 
     def teardown
-      Nokogiri::CSS::Parser.clear_cache(true)
-      Nokogiri::CSS::Parser.set_cache(true)
+      Nokogiri::CSS::SelectorCache.clear_cache(true)
       super
     end
 
     [false, true].each do |cache_setting|
       define_method "test_css_cache_#{cache_setting ? "true" : "false"}" do
-        Nokogiri::CSS::Parser.set_cache(cache_setting)
-
-        Nokogiri::CSS.xpath_for(@css)
-        Nokogiri::CSS.xpath_for(@css)
-        Nokogiri::CSS::Parser.new.xpath_for(@css, Nokogiri::CSS::XPathVisitor.new(prefix: "//"))
-        Nokogiri::CSS::Parser.new.xpath_for(@css, Nokogiri::CSS::XPathVisitor.new(prefix: "//"))
+        Nokogiri::CSS.xpath_for(@css, cache: cache_setting)
+        Nokogiri::CSS.xpath_for(@css, cache: cache_setting)
 
         if cache_setting
-          assert_equal(1, Nokogiri::CSS::Parser.class_eval { @cache.count })
-          assert_equal(4, Nokogiri::CSS::Parser.class_eval { @cache.access_count })
+          assert_equal(1, Nokogiri::CSS::SelectorCache.class_eval { @cache.count })
+          assert_equal(2, Nokogiri::CSS::SelectorCache.class_eval { @cache.access_count })
         else
-          assert_equal(0, Nokogiri::CSS::Parser.class_eval { @cache.count })
-          assert_equal(0, Nokogiri::CSS::Parser.class_eval { @cache.access_count })
+          assert_equal(0, Nokogiri::CSS::SelectorCache.class_eval { @cache.count })
+          assert_equal(0, Nokogiri::CSS::SelectorCache.class_eval { @cache.access_count })
         end
       end
     end
   end
 
   class TestCssCache < Nokogiri::TestCase
-    def teardown
-      Nokogiri::CSS::Parser.set_cache(true)
-      super
-    end
-
     def test_enabled_cache_is_used
-      Nokogiri::CSS::Parser.clear_cache
-      Nokogiri::CSS::Parser.set_cache(true)
+      Nokogiri::CSS::SelectorCache.clear_cache
 
       css = ".foo .bar .baz"
-      cache = Nokogiri::CSS::Parser.instance_variable_get(:@cache)
+      cache = Nokogiri::CSS::SelectorCache.instance_variable_get(:@cache)
 
       assert_empty(cache)
       Nokogiri::CSS.xpath_for(css)
@@ -77,56 +64,20 @@ describe Nokogiri::CSS::Parser do
     end
 
     def test_disabled_cache_is_not_used
-      Nokogiri::CSS::Parser.clear_cache
-      Nokogiri::CSS::Parser.set_cache(false)
+      Nokogiri::CSS::SelectorCache.clear_cache
 
       css = ".foo .bar .baz"
-      cache = Nokogiri::CSS::Parser.instance_variable_get(:@cache)
+      cache = Nokogiri::CSS::SelectorCache.instance_variable_get(:@cache)
 
       assert_empty(cache)
-      Nokogiri::CSS.xpath_for(css)
+      Nokogiri::CSS.xpath_for(css, cache: false)
       assert_empty(cache)
-    end
-
-    def test_without_cache_avoids_cache
-      Nokogiri::CSS::Parser.clear_cache
-      Nokogiri::CSS::Parser.set_cache(true)
-
-      css = ".foo .bar .baz"
-      cache = Nokogiri::CSS::Parser.instance_variable_get(:@cache)
-
-      assert_empty(cache)
-      Nokogiri::CSS::Parser.without_cache do
-        Nokogiri::CSS.xpath_for(css)
-      end
-      assert_empty(cache)
-    end
-
-    def test_without_cache_resets_cache_value
-      Nokogiri::CSS::Parser.set_cache(true)
-
-      Nokogiri::CSS::Parser.without_cache do
-        refute_predicate(Nokogiri::CSS::Parser, :cache_on?)
-      end
-      assert_predicate(Nokogiri::CSS::Parser, :cache_on?)
-    end
-
-    def test_without_cache_resets_cache_value_even_after_exception
-      Nokogiri::CSS::Parser.set_cache(true)
-
-      assert_raises(RuntimeError) do
-        Nokogiri::CSS::Parser.without_cache do
-          raise RuntimeError
-        end
-      end
-      assert_predicate(Nokogiri::CSS::Parser, :cache_on?)
     end
 
     def test_cache_key_on_ns_prefix_and_visitor_config
-      Nokogiri::CSS::Parser.clear_cache
-      Nokogiri::CSS::Parser.set_cache(true)
+      Nokogiri::CSS::SelectorCache.clear_cache
 
-      cache = Nokogiri::CSS::Parser.instance_variable_get(:@cache)
+      cache = Nokogiri::CSS::SelectorCache.instance_variable_get(:@cache)
       assert_empty(cache)
 
       Nokogiri::CSS.xpath_for("foo")
@@ -150,31 +101,6 @@ describe Nokogiri::CSS::Parser do
         ),
       )
       assert_equal(5, cache.length)
-    end
-
-    def test_race_condition
-      # https://github.com/sparklemotion/nokogiri/issues/1935
-      threads = []
-
-      Nokogiri::CSS::Parser.set_cache(true)
-
-      threads << Thread.new do
-        Nokogiri::CSS::Parser.without_cache do
-          sleep(0.02)
-        end
-      end
-
-      threads << Thread.new do
-        sleep(0.01)
-
-        Nokogiri::CSS::Parser.without_cache do
-          sleep(0.02)
-        end
-      end
-
-      threads.each(&:join)
-
-      assert_predicate(Nokogiri::CSS::Parser, :cache_on?)
     end
   end
 end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

This is part of a continuing track of work to separate out the concerns of CSS parser, CSS selector cache, and XPath expression translation into distinct components.

In this PR, I've extracted a CSS::SelectorCache class providing functionality that was previously built directly into CSS::Parser (with an awkward API that I'm responsible for writing in 2008).

- The methods `Parser.set_cache`, `Parser.cache_on?`, and `Parser.without_cache(&blk)` have been removed.
- The cache is now injected by `CSS.xpath_for` (optionally, via a `cache:` keyword argument) instead of being built into the parser.
- Documentation for `CSS.xpath_for` has also been updated and improved.


**Have you included adequate test coverage?**

Mostly an internal refactor, existing test coverage is sufficient except where I removed tests of the removed methods.


**Does this change affect the behavior of either the C or the Java implementations?**

N/A

