### PR TITLE
Support parsing noscript content in script-enabled mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] `Nokogiri::HTML5::Builder` is similar to `HTML4::Builder` but returns an `HTML5::Document`. @flavorjones
 * [CRuby] Attributes in an HTML5 document can be serialized individually, something that has always been supported by the HTML4 serializer. [#3125, #3127] @flavorjones
 * [CRuby] When compiling packaged libraries from source, allow users' `AR` and `LD` environment variables to set the archiver and linker commands, respectively. This augments the existing `CC` environment variable to set the compiler command. [#3165] @ziggythehamster
+* [CRuby] The HTML5 parse methods accept a `:parse_noscript_content_as_text` keyword argument which will emulate the parsing behavior of a browser which has scripting enabled. [#3178, #3231] @stevecheckoway
 
 
 ### Fixed

--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -301,15 +301,19 @@ common_options(VALUE kwargs)
   // If this order is changed, then setting the options below must change as
   // well.
   ID keywords[] = {
+    // Required keywords.
     rb_intern_const("max_attributes"),
     rb_intern_const("max_errors"),
     rb_intern_const("max_tree_depth"),
+
+    // Optional keywords.
+    rb_intern_const("parse_noscript_content_as_text"),
   };
   VALUE values[sizeof keywords / sizeof keywords[0]];
 
   // Extract the values coresponding to the required keywords. Raise an error
   // if required arguments are missing.
-  rb_get_kwargs(kwargs, keywords, 3, 0, values);
+  rb_get_kwargs(kwargs, keywords, 3, 1, values);
 
   GumboOptions options = kGumboDefaultOptions;
   options.max_attributes = NUM2INT(values[0]);
@@ -318,6 +322,8 @@ common_options(VALUE kwargs)
   // handle negative values
   int depth = NUM2INT(values[2]);
   options.max_tree_depth = depth < 0 ? UINT_MAX : (unsigned int)depth;
+
+  options.parse_noscript_content_as_text = RTEST(values[3]);
 
   return options;
 }

--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -323,7 +323,7 @@ common_options(VALUE kwargs)
   int depth = NUM2INT(values[2]);
   options.max_tree_depth = depth < 0 ? UINT_MAX : (unsigned int)depth;
 
-  options.parse_noscript_content_as_text = RTEST(values[3]);
+  options.parse_noscript_content_as_text = values[3] != Qundef && RTEST(values[3]);
 
   return options;
 }

--- a/gumbo-parser/src/nokogiri_gumbo.h
+++ b/gumbo-parser/src/nokogiri_gumbo.h
@@ -780,6 +780,15 @@ typedef struct GumboInternalOptions {
    * Default: `false`.
    */
   bool fragment_context_has_form_ancestor;
+
+  /**
+   * Parse `noscript` elements as if scripting was enabled. This causes the
+   * contents of the `noscript` element to be parsed as raw text, rather
+   * than as HTML elements.
+   * 
+   * Default: `false`.
+   */
+  bool parse_noscript_content_as_text;
 } GumboOptions;
 
 /** Default options struct; use this with gumbo_parse_with_options. */

--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -56,6 +56,7 @@ const GumboOptions kGumboDefaultOptions = {
   .fragment_encoding = NULL,
   .quirks_mode = GUMBO_DOCTYPE_NO_QUIRKS,
   .fragment_context_has_form_ancestor = false,
+  .parse_noscript_content_as_text = false,
 };
 
 #define STRING(s) {.data = s, .length = sizeof(s) - 1}
@@ -2614,6 +2615,7 @@ static void handle_in_head(GumboParser* parser, GumboToken* token) {
   }
   if (
     tag_in(token, kStartTag, &(const TagSet){TAG(NOFRAMES), TAG(STYLE)})
+    || (tag_is(token, kStartTag, GUMBO_TAG_NOSCRIPT) && parser->_options->parse_noscript_content_as_text)
   ) {
     run_generic_parsing_algorithm(parser, token, GUMBO_LEX_RAWTEXT);
     return;
@@ -3319,7 +3321,10 @@ static void handle_in_body(GumboParser* parser, GumboToken* token) {
     run_generic_parsing_algorithm(parser, token, GUMBO_LEX_RAWTEXT);
     return;
   }
-  if (tag_is(token, kStartTag, GUMBO_TAG_NOEMBED)) {
+  if (
+    tag_is(token, kStartTag, GUMBO_TAG_NOEMBED)
+    || (tag_is(token, kStartTag, GUMBO_TAG_NOSCRIPT) && parser->_options->parse_noscript_content_as_text)
+  ) {
     run_generic_parsing_algorithm(parser, token, GUMBO_LEX_RAWTEXT);
     return;
   }
@@ -4633,12 +4638,20 @@ static void fragment_parser_init (
   const char* fragment_encoding = options->fragment_encoding;
   GumboQuirksModeEnum quirks = options->quirks_mode;
   bool ctx_has_form_ancestor = options->fragment_context_has_form_ancestor;
-
   GumboNode* root;
-  // 2.
+
+  // 1. [Create a new Document node, and mark it as being an HTML document.]
+  // 2. [If the node document of the context element is in quirks mode, then
+  //    let the Document be in quirks mode. Otherwise, the node document of
+  //    the context element is in limited-quirks mode, then let the Document
+  //    be in limited-quirks mode. Otherwise, leave the Document in no-quirks
+  //    mode.]
   get_document_node(parser)->v.document.doc_type_quirks_mode = quirks;
 
-  // 3.
+  // 3. [If allowDeclarativeShadowRoots is true, then set the Document's allow
+  //    declarative shadow roots to true.]
+  // 4. [Create a new HTML parser, and associate it with the just created Document node.]
+  // 5. [Set the state of the HTML parser's tokenization stage as follows, switching on the context element:]
   parser->_parser_state->_fragment_ctx =
     create_fragment_ctx_element(fragment_ctx, fragment_namespace, fragment_encoding);
   GumboTag ctx_tag = parser->_parser_state->_fragment_ctx->v.element.tag;
@@ -4665,8 +4678,8 @@ static void fragment_parser_init (
         break;
 
       case GUMBO_TAG_NOSCRIPT:
-        /* scripting is disabled in Gumbo, so leave the tokenizer
-         * in the default data state */
+        if (options->parse_noscript_content_as_text)
+          gumbo_tokenizer_set_state(parser, GUMBO_LEX_RAWTEXT);
         break;
 
       case GUMBO_TAG_PLAINTEXT:

--- a/lib/nokogiri/html5.rb
+++ b/lib/nokogiri/html5.rb
@@ -46,182 +46,210 @@ module Nokogiri
   #
   # == Parsing options
   #
-  # The document and fragment parsing methods support options that are different from Nokogiri's.
+  # The document and fragment parsing methods support options that are
+  # different from Nokogiri's.
   #
   # - <tt>Nokogiri.HTML5(html, url = nil, encoding = nil, options = {})</tt>
-  # - <tt>Nokogiri::HTML5.parse(html, url = nil, encoding = nil, options = {})</tt>
-  # - <tt>Nokogiri::HTML5::Document.parse(html, url = nil, encoding = nil, options = {})</tt>
+  # - <tt>Nokogiri::HTML5.parse(html, url = nil, encoding = nil, options =
+  #   {})</tt>
+  # - <tt>Nokogiri::HTML5::Document.parse(html, url = nil, encoding = nil,
+  #   options = {})</tt>
   # - <tt>Nokogiri::HTML5.fragment(html, encoding = nil, options = {})</tt>
-  # - <tt>Nokogiri::HTML5::DocumentFragment.parse(html, encoding = nil, options = {})</tt>
+  # - <tt>Nokogiri::HTML5::DocumentFragment.parse(html, encoding = nil,
+  #   options = {})</tt>
   #
-  # The three currently supported options are +:max_errors+, +:max_tree_depth+ and
-  # +:max_attributes+, described below.
+  # The four currently supported options are +:max_errors+, +:max_tree_depth+,
+  # +:max_attributes+, and +parse_noscript_content_as_text+ described below.
   #
   # === Error reporting
   #
-  # Nokogiri contains an experimental HTML5 parse error reporting facility. By default, no parse
-  # errors are reported but this can be configured by passing the +:max_errors+ option to
-  # {HTML5.parse} or {HTML5.fragment}.
+  # Nokogiri contains an experimental HTML5 parse error reporting facility. By
+  # default, no parse errors are reported but this can be configured by
+  # passing the +:max_errors+ option to {HTML5.parse} or {HTML5.fragment}.
   #
   # For example, this script:
   #
-  #   doc = Nokogiri::HTML5.parse('<span/>Hi there!</span foo=bar />', max_errors: 10)
-  #   doc.errors.each do |err|
-  #     puts(err)
-  #   end
+  #   doc = Nokogiri::HTML5.parse('<span/>Hi there!</span foo=bar />',
+  #   max_errors: 10) doc.errors.each do |err| puts(err) end
   #
   # Emits:
   #
-  #   1:1: ERROR: Expected a doctype token
-  #   <span/>Hi there!</span foo=bar />
-  #   ^
+  #   1:1: ERROR: Expected a doctype token <span/>Hi there!</span foo=bar /> ^
   #   1:1: ERROR: Start tag of nonvoid HTML element ends with '/>', use '>'.
-  #   <span/>Hi there!</span foo=bar />
-  #   ^
-  #   1:17: ERROR: End tag ends with '/>', use '>'.
-  #   <span/>Hi there!</span foo=bar />
-  #                   ^
-  #   1:17: ERROR: End tag contains attributes.
-  #   <span/>Hi there!</span foo=bar />
-  #                   ^
+  #   <span/>Hi there!</span foo=bar /> ^ 1:17: ERROR: End tag ends with '/>',
+  #   use '>'. <span/>Hi there!</span foo=bar /> ^ 1:17: ERROR: End tag
+  #   contains attributes. <span/>Hi there!</span foo=bar /> ^
   #
-  # Using <tt>max_errors: -1</tt> results in an unlimited number of errors being returned.
+  # Using <tt>max_errors: -1</tt> results in an unlimited number of errors
+  # being returned.
   #
-  # The errors returned by {HTML5::Document#errors} are instances of {Nokogiri::XML::SyntaxError}.
+  # The errors returned by {HTML5::Document#errors} are instances of
+  # {Nokogiri::XML::SyntaxError}.
   #
-  # The {https://html.spec.whatwg.org/multipage/parsing.html#parse-errors HTML standard} defines a
-  # number of standard parse error codes. These error codes only cover the "tokenization" stage of
-  # parsing HTML. The parse errors in the "tree construction" stage do not have standardized error
+  # The {https://html.spec.whatwg.org/multipage/parsing.html#parse-errors HTML
+  # standard} defines a number of standard parse error codes. These error
+  # codes only cover the "tokenization" stage of parsing HTML. The parse
+  # errors in the "tree construction" stage do not have standardized error
   # codes (yet).
   #
-  # As a convenience to Nokogiri users, the defined error codes are available via
-  # {Nokogiri::XML::SyntaxError#str1} method.
+  # As a convenience to Nokogiri users, the defined error codes are available
+  # via {Nokogiri::XML::SyntaxError#str1} method.
   #
-  #   doc = Nokogiri::HTML5.parse('<span/>Hi there!</span foo=bar />', max_errors: 10)
-  #   doc.errors.each do |err|
-  #     puts("#{err.line}:#{err.column}: #{err.str1}")
-  #   end
+  #   doc = Nokogiri::HTML5.parse('<span/>Hi there!</span foo=bar />',
+  #   max_errors: 10) doc.errors.each do |err|
+  #     puts("#{err.line}:#{err.column}: #{err.str1}") end
   #   # => 1:1: generic-parser
   #   #    1:1: non-void-html-element-start-tag-with-trailing-solidus
   #   #    1:17: end-tag-with-trailing-solidus
   #   #    1:17: end-tag-with-attributes
   #
-  # Note that the first error is +generic-parser+ because it's an error from the tree construction
-  # stage and doesn't have a standardized error code.
+  # Note that the first error is +generic-parser+ because it's an error from
+  # the tree construction stage and doesn't have a standardized error code.
   #
-  # For the purposes of semantic versioning, the error messages, error locations, and error codes
-  # are not part of Nokogiri's public API. That is, these are subject to change without Nokogiri's
-  # major version number changing. These may be stabilized in the future.
+  # For the purposes of semantic versioning, the error messages, error
+  # locations, and error codes are not part of Nokogiri's public API. That is,
+  # these are subject to change without Nokogiri's major version number
+  # changing. These may be stabilized in the future.
   #
   # === Maximum tree depth
   #
-  # The maximum depth of the DOM tree parsed by the various parsing methods is configurable by the
-  # +:max_tree_depth+ option. If the depth of the tree would exceed this limit, then an
-  # {::ArgumentError} is thrown.
+  # The maximum depth of the DOM tree parsed by the various parsing methods is
+  # configurable by the +:max_tree_depth+ option. If the depth of the tree
+  # would exceed this limit, then an {::ArgumentError} is thrown.
   #
-  # This limit (which defaults to <tt>Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH = 400</tt>) can be
-  # removed by giving the option <tt>max_tree_depth: -1</tt>.
+  # This limit (which defaults to <tt>Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH
+  # = 400</tt>) can be removed by giving the option <tt>max_tree_depth:
+  # -1</tt>.
   #
-  #   html = '<!DOCTYPE html>' + '<div>' * 1000
-  #   doc = Nokogiri.HTML5(html)
+  #   html = '<!DOCTYPE html>' + '<div>' * 1000 doc = Nokogiri.HTML5(html)
   #   # raises ArgumentError: Document tree depth limit exceeded
   #   doc = Nokogiri.HTML5(html, max_tree_depth: -1)
   #
   # === Attribute limit per element
   #
-  # The maximum number of attributes per DOM element is configurable by the +:max_attributes+
-  # option. If a given element would exceed this limit, then an {::ArgumentError} is thrown.
+  # The maximum number of attributes per DOM element is configurable by the
+  # +:max_attributes+ option. If a given element would exceed this limit, then
+  # an {::ArgumentError} is thrown.
   #
-  # This limit (which defaults to <tt>Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES = 400</tt>) can be
-  # removed by giving the option <tt>max_attributes: -1</tt>.
+  # This limit (which defaults to <tt>Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES
+  # = 400</tt>) can be removed by giving the option <tt>max_attributes:
+  # -1</tt>.
   #
-  #   html = '<!DOCTYPE html><div ' + (1..1000).map { |x| "attr-#{x}" }.join(' ') + '>'
+  # html = '<!DOCTYPE html><div ' + (1..1000).map { |x| "attr-#{x}" }.join('
+  # ') + '>'
   #   # "<!DOCTYPE html><div attr-1 attr-2 attr-3 ... attr-1000>"
   #   doc = Nokogiri.HTML5(html)
   #   # raises ArgumentError: Attributes per element limit exceeded
   #   doc = Nokogiri.HTML5(html, max_attributes: -1)
   #
+  # === Parse +noscript+ elements' content as text
+  #
+  # By default, the content of +noscript+ elements is parsed as HTML elements.
+  # Browsers that support scripting parse the content of +noscript+ elements
+  # as raw text.
+  #
+  # The +parse_noscript_content_as_text+ option causes Nokogiri to parse the
+  # content of +noscript+ elements as a single text node.
+  #
+  #   html = "<!DOCTYPE html><noscript><meta charset='UTF-8'><link rel=stylesheet href=!></noscript>"
+  #   doc = Nokogiri::HTML5.parse(html, parse_noscript_content_as_text: true)
+  #   puts(doc.at("/html/head/noscript").children.length)
+  #   # 1
+  #
+  # In contrast, +parse_noscript_content_as_text: false+ (the default) causes
+  # the +noscript+ element in the previous example to have two children, a
+  # +meta+ element and a +link+ element.
+  #
+  #   doc = Nokogiri::HTML5.parse(html)
+  #   puts(doc.at("/html/head/noscript").children.length)
+  #   #2
+  #
   # == HTML Serialization
   #
-  # After parsing HTML, it may be serialized using any of the {Nokogiri::XML::Node} serialization
-  # methods. In particular, {XML::Node#serialize}, {XML::Node#to_html}, and {XML::Node#to_s} will
-  # serialize a given node and its children. (This is the equivalent of JavaScript's
-  # +Element.outerHTML+.) Similarly, {XML::Node#inner_html} will serialize the children of a given
-  # node. (This is the equivalent of JavaScript's +Element.innerHTML+.)
+  # After parsing HTML, it may be serialized using any of the
+  # {Nokogiri::XML::Node} serialization methods. In particular,
+  # {XML::Node#serialize}, {XML::Node#to_html}, and {XML::Node#to_s} will
+  # serialize a given node and its children. (This is the equivalent of
+  # JavaScript's +Element.outerHTML+.) Similarly, {XML::Node#inner_html} will
+  # serialize the children of a given node. (This is the equivalent of
+  # JavaScript's +Element.innerHTML+.)
   #
-  #   doc = Nokogiri::HTML5("<!DOCTYPE html><span>Hello world!</span>")
-  #   puts doc.serialize
+  #   doc = Nokogiri::HTML5("<!DOCTYPE html><span>Hello world!</span>") puts
+  #   doc.serialize
   #   # => <!DOCTYPE html><html><head></head><body><span>Hello world!</span></body></html>
   #
-  # Due to quirks in how HTML is parsed and serialized, it's possible for a DOM tree to be
-  # serialized and then re-parsed, resulting in a different DOM.  Mostly, this happens with DOMs
-  # produced from invalid HTML. Unfortunately, even valid HTML may not survive serialization and
+  # Due to quirks in how HTML is parsed and serialized, it's possible for a
+  # DOM tree to be serialized and then re-parsed, resulting in a different
+  # DOM.  Mostly, this happens with DOMs produced from invalid HTML.
+  # Unfortunately, even valid HTML may not survive serialization and
   # re-parsing.
   #
-  # In particular, a newline at the start of +pre+, +listing+, and +textarea+ elements is ignored by
-  # the parser.
+  # In particular, a newline at the start of +pre+, +listing+, and +textarea+
+  # elements is ignored by the parser.
   #
   #   doc = Nokogiri::HTML5(<<-EOF)
   #   <!DOCTYPE html>
   #   <pre>
   #   Content</pre>
-  #   EOF
-  #   puts doc.at('/html/body/pre').serialize
+  #   EOF puts doc.at('/html/body/pre').serialize
   #   # => <pre>Content</pre>
   #
-  # In this case, the original HTML is semantically equivalent to the serialized version. If the
-  # +pre+, +listing+, or +textarea+ content starts with two newlines, the first newline will be
-  # stripped on the first parse and the second newline will be stripped on the second, leading to
-  # semantically different DOMs. Passing the parameter <tt>preserve_newline: true</tt> will cause
-  # two or more newlines to be preserved. (A single leading newline will still be removed.)
+  # In this case, the original HTML is semantically equivalent to the
+  # serialized version. If the +pre+, +listing+, or +textarea+ content starts
+  # with two newlines, the first newline will be stripped on the first parse
+  # and the second newline will be stripped on the second, leading to
+  # semantically different DOMs. Passing the parameter <tt>preserve_newline:
+  # true</tt> will cause two or more newlines to be preserved. (A single
+  # leading newline will still be removed.)
   #
   #   doc = Nokogiri::HTML5(<<-EOF)
   #   <!DOCTYPE html>
   #   <listing>
   #
-  #   Content</listing>
-  #   EOF
-  #   puts doc.at('/html/body/listing').serialize(preserve_newline: true)
+  #   Content</listing> EOF puts
+  #   doc.at('/html/body/listing').serialize(preserve_newline: true)
   #   # => <listing>
   #   #
   #   #    Content</listing>
   #
   # == Encodings
   #
-  # Nokogiri always parses HTML5 using {https://en.wikipedia.org/wiki/UTF-8 UTF-8}; however, the
-  # encoding of the input can be explicitly selected via the optional +encoding+ parameter. This is
-  # most useful when the input comes not from a string but from an IO object.
+  # Nokogiri always parses HTML5 using {https://en.wikipedia.org/wiki/UTF-8
+  # UTF-8}; however, the encoding of the input can be explicitly selected via
+  # the optional +encoding+ parameter. This is most useful when the input
+  # comes not from a string but from an IO object.
   #
-  # When serializing a document or node, the encoding of the output string can be specified via the
-  # +:encoding+ options. Characters that cannot be encoded in the selected encoding will be encoded
-  # as {https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references HTML numeric
-  # entities}.
+  # When serializing a document or node, the encoding of the output string can
+  # be specified via the +:encoding+ options. Characters that cannot be
+  # encoded in the selected encoding will be encoded as
+  # {https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
+  # HTML numeric entities}.
   #
-  #   frag = Nokogiri::HTML5.fragment('<span>아는 길도 물어가라</span>')
-  #   html = frag.serialize(encoding: 'US-ASCII')
-  #   puts html
+  #   frag = Nokogiri::HTML5.fragment('<span>아는 길도 물어가라</span>') html
+  #   = frag.serialize(encoding: 'US-ASCII') puts html
   #   # => <span>&#xc544;&#xb294; &#xae38;&#xb3c4; &#xbb3c;&#xc5b4;&#xac00;&#xb77c;</span>
-  #   frag = Nokogiri::HTML5.fragment(html)
-  #   puts frag.serialize
+  #   frag = Nokogiri::HTML5.fragment(html) puts frag.serialize
   #   # => <span>아는 길도 물어가라</span>
   #
-  # (There's a {https://bugs.ruby-lang.org/issues/15033 bug} in all current versions of Ruby that
-  # can cause the entity encoding to fail. Of the mandated supported encodings for HTML, the only
-  # encoding I'm aware of that has this bug is <tt>'ISO-2022-JP'</tt>. We recommend avoiding this
+  # (There's a {https://bugs.ruby-lang.org/issues/15033 bug} in all current
+  # versions of Ruby that can cause the entity encoding to fail. Of the
+  # mandated supported encodings for HTML, the only encoding I'm aware of that
+  # has this bug is <tt>'ISO-2022-JP'</tt>. We recommend avoiding this
   # encoding.)
   #
   # == Notes
   #
-  # * The {Nokogiri::HTML5.fragment} function takes a string and parses it
-  #   as a HTML5 document.  The +<html>+, +<head>+, and +<body>+ elements are
-  #   removed from this document, and any children of these elements that remain
-  #   are returned as a {Nokogiri::HTML5::DocumentFragment}.
+  # * The {Nokogiri::HTML5.fragment} function takes a string and parses it as
+  #   a HTML5 document.  The +<html>+, +<head>+, and +<body>+ elements are
+  #   removed from this document, and any children of these elements that
+  #   remain are returned as a {Nokogiri::HTML5::DocumentFragment}.
   #
   # * The {Nokogiri::HTML5.parse} function takes a string and passes it to the
   #   <code>gumbo_parse_with_options</code> method, using the default options.
   #   The resulting Gumbo parse tree is then walked.
   #
-  # * Instead of uppercase element names, lowercase element names are produced.
+  # * Instead of uppercase element names, lowercase element names are
+  #   produced.
   #
   # * Instead of returning +unknown+ as the element name for unknown tags, the
   #   original tag name is returned verbatim.

--- a/lib/nokogiri/html5.rb
+++ b/lib/nokogiri/html5.rb
@@ -46,142 +46,152 @@ module Nokogiri
   #
   # == Parsing options
   #
-  # The document and fragment parsing methods support options that are
-  # different from Nokogiri's.
+  # The document and fragment parsing methods support options that are different from Nokogiri's.
   #
-  # - <tt>Nokogiri.HTML5(html, url = nil, encoding = nil, options = {})</tt>
-  # - <tt>Nokogiri::HTML5.parse(html, url = nil, encoding = nil, options =
-  #   {})</tt>
-  # - <tt>Nokogiri::HTML5::Document.parse(html, url = nil, encoding = nil,
-  #   options = {})</tt>
-  # - <tt>Nokogiri::HTML5.fragment(html, encoding = nil, options = {})</tt>
-  # - <tt>Nokogiri::HTML5::DocumentFragment.parse(html, encoding = nil,
-  #   options = {})</tt>
+  # - <tt>Nokogiri.HTML5(html, url = nil, encoding = nil, **options)</tt>
+  # - <tt>Nokogiri::HTML5.parse(html, url = nil, encoding = nil, **options)</tt>
+  # - <tt>Nokogiri::HTML5::Document.parse(html, url = nil, encoding = nil, **options)</tt>
+  # - <tt>Nokogiri::HTML5.fragment(html, encoding = nil, **options)</tt>
+  # - <tt>Nokogiri::HTML5::DocumentFragment.parse(html, encoding = nil, **options)</tt>
   #
-  # The four currently supported options are +:max_errors+, +:max_tree_depth+,
-  # +:max_attributes+, and +parse_noscript_content_as_text+ described below.
+  # The four currently supported options are +:max_errors+, +:max_tree_depth+, +:max_attributes+,
+  # and +:parse_noscript_content_as_text+ described below.
   #
   # === Error reporting
   #
-  # Nokogiri contains an experimental HTML5 parse error reporting facility. By
-  # default, no parse errors are reported but this can be configured by
-  # passing the +:max_errors+ option to {HTML5.parse} or {HTML5.fragment}.
+  # Nokogiri contains an experimental HTML5 parse error reporting facility. By default, no parse
+  # errors are reported but this can be configured by passing the +:max_errors+ option to
+  # HTML5.parse or HTML5.fragment.
   #
   # For example, this script:
   #
-  #   doc = Nokogiri::HTML5.parse('<span/>Hi there!</span foo=bar />',
-  #   max_errors: 10) doc.errors.each do |err| puts(err) end
+  #   doc = Nokogiri::HTML5.parse('<span/>Hi there!</span foo=bar />', max_errors: 10)
+  #   doc.errors.each do |err|
+  #     puts(err)
+  #   end
   #
   # Emits:
   #
-  #   1:1: ERROR: Expected a doctype token <span/>Hi there!</span foo=bar /> ^
+  #   1:1: ERROR: Expected a doctype token
+  #   <span/>Hi there!</span foo=bar />
+  #   ^
   #   1:1: ERROR: Start tag of nonvoid HTML element ends with '/>', use '>'.
-  #   <span/>Hi there!</span foo=bar /> ^ 1:17: ERROR: End tag ends with '/>',
-  #   use '>'. <span/>Hi there!</span foo=bar /> ^ 1:17: ERROR: End tag
-  #   contains attributes. <span/>Hi there!</span foo=bar /> ^
+  #   <span/>Hi there!</span foo=bar />
+  #   ^
+  #   1:17: ERROR: End tag ends with '/>', use '>'.
+  #   <span/>Hi there!</span foo=bar />
+  #                   ^
+  #   1:17: ERROR: End tag contains attributes.
+  #   <span/>Hi there!</span foo=bar />
+  #                   ^
   #
-  # Using <tt>max_errors: -1</tt> results in an unlimited number of errors
-  # being returned.
+  # Using <tt>max_errors: -1</tt> results in an unlimited number of errors being returned.
   #
-  # The errors returned by {HTML5::Document#errors} are instances of
-  # {Nokogiri::XML::SyntaxError}.
+  # The errors returned by HTML5::Document#errors are instances of Nokogiri::XML::SyntaxError.
   #
-  # The {https://html.spec.whatwg.org/multipage/parsing.html#parse-errors HTML
-  # standard} defines a number of standard parse error codes. These error
-  # codes only cover the "tokenization" stage of parsing HTML. The parse
-  # errors in the "tree construction" stage do not have standardized error
+  # The {HTML standard}[https://html.spec.whatwg.org/multipage/parsing.html#parse-errors] defines a
+  # number of standard parse error codes. These error codes only cover the "tokenization" stage of
+  # parsing HTML. The parse errors in the "tree construction" stage do not have standardized error
   # codes (yet).
   #
   # As a convenience to Nokogiri users, the defined error codes are available
-  # via {Nokogiri::XML::SyntaxError#str1} method.
+  # via Nokogiri::XML::SyntaxError#str1 method.
   #
+  #   doc = Nokogiri::HTML5.parse('<span/>Hi there!</span foo=bar />', max_errors: 10)
+  #   doc.errors.each do |err|
+  #     puts("#{err.line}:#{err.column}: #{err.str1}")
+  #   end
   #   doc = Nokogiri::HTML5.parse('<span/>Hi there!</span foo=bar />',
-  #   max_errors: 10) doc.errors.each do |err|
-  #     puts("#{err.line}:#{err.column}: #{err.str1}") end
   #   # => 1:1: generic-parser
   #   #    1:1: non-void-html-element-start-tag-with-trailing-solidus
   #   #    1:17: end-tag-with-trailing-solidus
   #   #    1:17: end-tag-with-attributes
   #
-  # Note that the first error is +generic-parser+ because it's an error from
-  # the tree construction stage and doesn't have a standardized error code.
+  # Note that the first error is +generic-parser+ because it's an error from the tree construction
+  # stage and doesn't have a standardized error code.
   #
-  # For the purposes of semantic versioning, the error messages, error
-  # locations, and error codes are not part of Nokogiri's public API. That is,
-  # these are subject to change without Nokogiri's major version number
-  # changing. These may be stabilized in the future.
+  # For the purposes of semantic versioning, the error messages, error locations, and error codes
+  # are not part of Nokogiri's public API. That is, these are subject to change without Nokogiri's
+  # major version number changing. These may be stabilized in the future.
   #
   # === Maximum tree depth
   #
-  # The maximum depth of the DOM tree parsed by the various parsing methods is
-  # configurable by the +:max_tree_depth+ option. If the depth of the tree
-  # would exceed this limit, then an {::ArgumentError} is thrown.
+  # The maximum depth of the DOM tree parsed by the various parsing methods is configurable by the
+  # +:max_tree_depth+ option. If the depth of the tree would exceed this limit, then an
+  # +ArgumentError+ is thrown.
   #
-  # This limit (which defaults to <tt>Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH
-  # = 400</tt>) can be removed by giving the option <tt>max_tree_depth:
-  # -1</tt>.
+  # This limit (which defaults to +Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH+) can be removed by
+  # giving the option <tt>max_tree_depth: -1</tt>.
   #
-  #   html = '<!DOCTYPE html>' + '<div>' * 1000 doc = Nokogiri.HTML5(html)
+  #   html = '<!DOCTYPE html>' + '<div>' * 1000
+  #   doc = Nokogiri.HTML5(html)
   #   # raises ArgumentError: Document tree depth limit exceeded
   #   doc = Nokogiri.HTML5(html, max_tree_depth: -1)
   #
   # === Attribute limit per element
   #
-  # The maximum number of attributes per DOM element is configurable by the
-  # +:max_attributes+ option. If a given element would exceed this limit, then
-  # an {::ArgumentError} is thrown.
+  # The maximum number of attributes per DOM element is configurable by the +:max_attributes+
+  # option. If a given element would exceed this limit, then an +ArgumentError+ is thrown.
   #
-  # This limit (which defaults to <tt>Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES
-  # = 400</tt>) can be removed by giving the option <tt>max_attributes:
-  # -1</tt>.
+  # This limit (which defaults to +Nokogiri::Gumbo::DEFAULT_MAX_ATTRIBUTES+) can be removed by
+  # giving the option <tt>max_attributes: -1</tt>.
   #
-  # html = '<!DOCTYPE html><div ' + (1..1000).map { |x| "attr-#{x}" }.join('
-  # ') + '>'
+  #   html = '<!DOCTYPE html><div ' + (1..1000).map { |x| "attr-#{x}" }.join(' # ') + '>'
   #   # "<!DOCTYPE html><div attr-1 attr-2 attr-3 ... attr-1000>"
   #   doc = Nokogiri.HTML5(html)
   #   # raises ArgumentError: Attributes per element limit exceeded
+  #
   #   doc = Nokogiri.HTML5(html, max_attributes: -1)
+  #   # parses successfully
   #
   # === Parse +noscript+ elements' content as text
   #
-  # By default, the content of +noscript+ elements is parsed as HTML elements.
-  # Browsers that support scripting parse the content of +noscript+ elements
-  # as raw text.
+  # By default, the content of +noscript+ elements is parsed as HTML elements. Browsers that
+  # support scripting parse the content of +noscript+ elements as raw text.
   #
-  # The +parse_noscript_content_as_text+ option causes Nokogiri to parse the
-  # content of +noscript+ elements as a single text node.
+  # The +:parse_noscript_content_as_text+ option causes Nokogiri to parse the content of +noscript+
+  # elements as a single text node.
   #
   #   html = "<!DOCTYPE html><noscript><meta charset='UTF-8'><link rel=stylesheet href=!></noscript>"
   #   doc = Nokogiri::HTML5.parse(html, parse_noscript_content_as_text: true)
-  #   puts(doc.at("/html/head/noscript").children.length)
-  #   # 1
+  #   pp doc.at_xpath("/html/head/noscript")
+  #   # => #(Element:0x878c {
+  #   #        name = "noscript",
+  #   #        children = [ #(Text "<meta charset='UTF-8'><link rel=stylesheet href=!>")]
+  #   #      })
   #
-  # In contrast, +parse_noscript_content_as_text: false+ (the default) causes
-  # the +noscript+ element in the previous example to have two children, a
-  # +meta+ element and a +link+ element.
+  # In contrast, <tt>parse_noscript_content_as_text: false</tt> (the default) causes the +noscript+
+  # element in the previous example to have two children, a +meta+ element and a +link+ element.
   #
   #   doc = Nokogiri::HTML5.parse(html)
-  #   puts(doc.at("/html/head/noscript").children.length)
-  #   #2
+  #   puts doc.at_xpath("/html/head/noscript")
+  #   # => #(Element:0x96b4 {
+  #   #      name = "noscript",
+  #   #      children = [
+  #   #        #(Element:0x97e0 { name = "meta", attribute_nodes = [ #(Attr:0x990c { name = "charset", value = "UTF-8" })] }),
+  #   #        #(Element:0x9b00 {
+  #   #          name = "link",
+  #   #          attribute_nodes = [
+  #   #            #(Attr:0x9c2c { name = "rel", value = "stylesheet" }),
+  #   #            #(Attr:0x9dd0 { name = "href", value = "!" })]
+  #   #          })]
+  #   #      })
   #
   # == HTML Serialization
   #
-  # After parsing HTML, it may be serialized using any of the
-  # {Nokogiri::XML::Node} serialization methods. In particular,
-  # {XML::Node#serialize}, {XML::Node#to_html}, and {XML::Node#to_s} will
-  # serialize a given node and its children. (This is the equivalent of
-  # JavaScript's +Element.outerHTML+.) Similarly, {XML::Node#inner_html} will
-  # serialize the children of a given node. (This is the equivalent of
-  # JavaScript's +Element.innerHTML+.)
+  # After parsing HTML, it may be serialized using any of the Nokogiri::XML::Node serialization
+  # methods. In particular, XML::Node#serialize, XML::Node#to_html, and XML::Node#to_s will
+  # serialize a given node and its children. (This is the equivalent of JavaScript's
+  # +Element.outerHTML+.) Similarly, XML::Node#inner_html will serialize the children of a given
+  # node. (This is the equivalent of JavaScript's +Element.innerHTML+.)
   #
-  #   doc = Nokogiri::HTML5("<!DOCTYPE html><span>Hello world!</span>") puts
-  #   doc.serialize
+  #   doc = Nokogiri::HTML5("<!DOCTYPE html><span>Hello world!</span>")
+  #   puts doc.serialize
   #   # => <!DOCTYPE html><html><head></head><body><span>Hello world!</span></body></html>
   #
-  # Due to quirks in how HTML is parsed and serialized, it's possible for a
-  # DOM tree to be serialized and then re-parsed, resulting in a different
-  # DOM.  Mostly, this happens with DOMs produced from invalid HTML.
-  # Unfortunately, even valid HTML may not survive serialization and
+  # Due to quirks in how HTML is parsed and serialized, it's possible for a DOM tree to be
+  # serialized and then re-parsed, resulting in a different DOM. Mostly, this happens with DOMs
+  # produced from invalid HTML. Unfortunately, even valid HTML may not survive serialization and
   # re-parsing.
   #
   # In particular, a newline at the start of +pre+, +listing+, and +textarea+
@@ -191,79 +201,77 @@ module Nokogiri
   #   <!DOCTYPE html>
   #   <pre>
   #   Content</pre>
-  #   EOF puts doc.at('/html/body/pre').serialize
+  #   EOF
+  #   puts doc.at('/html/body/pre').serialize
   #   # => <pre>Content</pre>
   #
-  # In this case, the original HTML is semantically equivalent to the
-  # serialized version. If the +pre+, +listing+, or +textarea+ content starts
-  # with two newlines, the first newline will be stripped on the first parse
-  # and the second newline will be stripped on the second, leading to
-  # semantically different DOMs. Passing the parameter <tt>preserve_newline:
-  # true</tt> will cause two or more newlines to be preserved. (A single
-  # leading newline will still be removed.)
+  # In this case, the original HTML is semantically equivalent to the serialized version. If the
+  # +pre+, +listing+, or +textarea+ content starts with two newlines, the first newline will be
+  # stripped on the first parse and the second newline will be stripped on the second, leading to
+  # semantically different DOMs. Passing the parameter <tt>preserve_newline: true</tt> will cause
+  # two or more newlines to be preserved. (A single leading newline will still be removed.)
   #
   #   doc = Nokogiri::HTML5(<<-EOF)
   #   <!DOCTYPE html>
   #   <listing>
   #
-  #   Content</listing> EOF puts
-  #   doc.at('/html/body/listing').serialize(preserve_newline: true)
+  #   Content</listing>
+  #   EOF
+  #   puts doc.at('/html/body/listing').serialize(preserve_newline: true)
   #   # => <listing>
   #   #
   #   #    Content</listing>
   #
   # == Encodings
   #
-  # Nokogiri always parses HTML5 using {https://en.wikipedia.org/wiki/UTF-8
-  # UTF-8}; however, the encoding of the input can be explicitly selected via
-  # the optional +encoding+ parameter. This is most useful when the input
-  # comes not from a string but from an IO object.
+  # Nokogiri always parses HTML5 using {UTF-8}[https://en.wikipedia.org/wiki/UTF-8]; however, the
+  # encoding of the input can be explicitly selected via the optional +encoding+ parameter. This is
+  # most useful when the input comes not from a string but from an IO object.
   #
-  # When serializing a document or node, the encoding of the output string can
-  # be specified via the +:encoding+ options. Characters that cannot be
-  # encoded in the selected encoding will be encoded as
-  # {https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
-  # HTML numeric entities}.
+  # When serializing a document or node, the encoding of the output string can be specified via the
+  # +:encoding+ options. Characters that cannot be encoded in the selected encoding will be encoded
+  # as {HTML numeric
+  # entities}[https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references].
   #
-  #   frag = Nokogiri::HTML5.fragment('<span>아는 길도 물어가라</span>') html
-  #   = frag.serialize(encoding: 'US-ASCII') puts html
+  #   frag = Nokogiri::HTML5.fragment('<span>아는 길도 물어가라</span>')
+  #   html = frag.serialize(encoding: 'US-ASCII')
+  #   puts html
   #   # => <span>&#xc544;&#xb294; &#xae38;&#xb3c4; &#xbb3c;&#xc5b4;&#xac00;&#xb77c;</span>
-  #   frag = Nokogiri::HTML5.fragment(html) puts frag.serialize
+  #
+  #   frag = Nokogiri::HTML5.fragment(html)
+  #   puts frag.serialize
   #   # => <span>아는 길도 물어가라</span>
   #
-  # (There's a {https://bugs.ruby-lang.org/issues/15033 bug} in all current
-  # versions of Ruby that can cause the entity encoding to fail. Of the
-  # mandated supported encodings for HTML, the only encoding I'm aware of that
-  # has this bug is <tt>'ISO-2022-JP'</tt>. We recommend avoiding this
+  # (There's a {bug}[https://bugs.ruby-lang.org/issues/15033] in all current versions of Ruby that
+  # can cause the entity encoding to fail. Of the mandated supported encodings for HTML, the only
+  # encoding I'm aware of that has this bug is <tt>'ISO-2022-JP'</tt>. We recommend avoiding this
   # encoding.)
   #
   # == Notes
   #
-  # * The {Nokogiri::HTML5.fragment} function takes a string and parses it as
-  #   a HTML5 document.  The +<html>+, +<head>+, and +<body>+ elements are
-  #   removed from this document, and any children of these elements that
-  #   remain are returned as a {Nokogiri::HTML5::DocumentFragment}.
+  # * The Nokogiri::HTML5.fragment function takes a string and parses it as a HTML5 document. The
+  #   +html+, +head+, and +body+ elements are removed from this document, and any children of these
+  #   elements that remain are returned as a Nokogiri::HTML5::DocumentFragment.
   #
-  # * The {Nokogiri::HTML5.parse} function takes a string and passes it to the
-  #   <code>gumbo_parse_with_options</code> method, using the default options.
-  #   The resulting Gumbo parse tree is then walked.
+  # * The Nokogiri::HTML5.parse function takes a string and passes it to the
+  #   <code>gumbo_parse_with_options</code> method, using the default options.  The resulting Gumbo
+  #   parse tree is then walked.
   #
-  # * Instead of uppercase element names, lowercase element names are
-  #   produced.
+  # * Instead of uppercase element names, lowercase element names are produced.
   #
-  # * Instead of returning +unknown+ as the element name for unknown tags, the
-  #   original tag name is returned verbatim.
+  # * Instead of returning +unknown+ as the element name for unknown tags, the original tag name is
+  #   returned verbatim.
   #
   # Since v1.12.0
   module HTML5
     class << self
-      # Parse an HTML 5 document. Convenience method for {Nokogiri::HTML5::Document.parse}
+      # Parse an HTML 5 document. Convenience method for Nokogiri::HTML5::Document.parse
       def parse(string, url = nil, encoding = nil, **options, &block)
         Document.parse(string, url, encoding, **options, &block)
       end
 
       # Parse a fragment from +string+. Convenience method for
-      # {Nokogiri::HTML5::DocumentFragment.parse}.
+      # Nokogiri::HTML5::DocumentFragment.parse.
       def fragment(string, encoding = nil, **options)
         DocumentFragment.parse(string, encoding, options)
       end
@@ -296,11 +304,11 @@ module Nokogiri
       private
 
       # Charset sniffing is a complex and controversial topic that understandably isn't done _by
-      # default_ by the Ruby Net::HTTP library.  This being said, it is a very real problem for
+      # default_ by the Ruby Net::HTTP library. This being said, it is a very real problem for
       # consumers of HTML as the default for HTML is iso-8859-1, most "good" producers use utf-8, and
       # the Gumbo parser *only* supports utf-8.
       #
-      # Accordingly, Nokogiri::HTML4::Document.parse provides limited encoding detection.  Following
+      # Accordingly, Nokogiri::HTML4::Document.parse provides limited encoding detection. Following
       # this lead, Nokogiri::HTML5 attempts to do likewise, while attempting to more closely follow
       # the HTML5 standard.
       #

--- a/test/html5/test_api.rb
+++ b/test/html5/test_api.rb
@@ -172,7 +172,6 @@ class TestHtml5API < Nokogiri::TestCase
     img = doc.at("/html/body/noscript/img")
     refute_nil(img)
   end
-  
 
   ["pre", "listing", "textarea"].each do |tag|
     define_method("test_serialize_preserve_newline_#{tag}".to_sym) do

--- a/test/html5/test_api.rb
+++ b/test/html5/test_api.rb
@@ -117,7 +117,7 @@ class TestHtml5API < Nokogiri::TestCase
     # Start tag 'img' isn't allowed here
     # End tag 'noscript' isn't allowed here
     # End tag head isn't allowed here
-    assert(noscript.children.empty?)
+    assert_empty(noscript.children)
     img = doc.at("/html/body/img")
     refute_nil(img)
   end
@@ -130,7 +130,7 @@ class TestHtml5API < Nokogiri::TestCase
     noscript = doc.at("/html/head/noscript")
     assert_equal(0, doc.errors.length, doc.errors.join("\n"))
     assert_equal(1, noscript.children.length)
-    assert(noscript.children.first.is_a?(Nokogiri::XML::Text))
+    assert_kind_of(Nokogiri::XML::Text, noscript.children.first)
   end
 
   def test_parse_noscript_as_elements_in_body
@@ -146,22 +146,22 @@ class TestHtml5API < Nokogiri::TestCase
     doc = Nokogiri::HTML5(html, parse_noscript_content_as_text: true, max_errors: 100)
     noscript = doc.at("/html/body/noscript")
     assert_equal(0, doc.errors.length, doc.errors.join("\n"))
-    assert(noscript.children.first.is_a?(Nokogiri::XML::Text))
+    assert_kind_of(Nokogiri::XML::Text, noscript.children.first)
   end
 
   def test_parse_noscript_fragment_as_elements
     html = "<meta charset='UTF-8'><link rel=stylesheet href=!>"
-    frag = Nokogiri::HTML5::DocumentFragment.new(Nokogiri::HTML5::Document.new, html, 'noscript', parse_noscript_content_as_text: false, max_errors: 100)
+    frag = Nokogiri::HTML5::DocumentFragment.new(Nokogiri::HTML5::Document.new, html, "noscript", parse_noscript_content_as_text: false, max_errors: 100)
     assert_equal(0, frag.errors.length, frag.errors.join("\n"))
     assert_equal(2, frag.children.length)
   end
 
   def test_parse_noscript_fragment_as_text
     html = "<meta charset='UTF-8'><link rel=stylesheet href=!>"
-    frag = Nokogiri::HTML5::DocumentFragment.new(Nokogiri::HTML5::Document.new, html, 'noscript', parse_noscript_content_as_text: true, max_errors: 100)
+    frag = Nokogiri::HTML5::DocumentFragment.new(Nokogiri::HTML5::Document.new, html, "noscript", parse_noscript_content_as_text: true, max_errors: 100)
     assert_equal(0, frag.errors.length, frag.errors.join("\n"))
     assert_equal(1, frag.children.length)
-    assert(frag.children.first.is_a?(Nokogiri::XML::Text))
+    assert_kind_of(Nokogiri::XML::Text, frag.children.first)
   end
 
   ["pre", "listing", "textarea"].each do |tag|

--- a/test/html5/test_api.rb
+++ b/test/html5/test_api.rb
@@ -104,6 +104,66 @@ class TestHtml5API < Nokogiri::TestCase
     assert_match("ฉันไม่พูดภาษาไทย", html2)
   end
 
+  def test_parse_noscript_as_elements_in_head
+    # <img> isn't allowed in noscript so the noscript element is popped off
+    # the stack of open elements and the <img> token is reprocessed in `head`
+    # which causes the `head` element to be popped off the stack of open
+    # elements and a `body` element to be inserted. Then the `img` element is
+    # inserted in the body.
+    html = "<!DOCTYPE html><head><noscript><img src=!></noscript></head>"
+    doc = Nokogiri::HTML5(html, parse_noscript_content_as_text: false, max_errors: 100)
+    noscript = doc.at("/html/head/noscript")
+    assert_equal(3, doc.errors.length, doc.errors.join("\n"))
+    # Start tag 'img' isn't allowed here
+    # End tag 'noscript' isn't allowed here
+    # End tag head isn't allowed here
+    assert(noscript.children.empty?)
+    img = doc.at("/html/body/img")
+    refute_nil(img)
+  end
+
+  def test_parse_noscript_as_text_in_head
+    # In contrast to the previous test, when the scripting flag is enabled, the content
+    # of the noscript element is parsed as raw text.
+    html = "<!DOCTYPE html><head><noscript><img src=!></noscript></head>"
+    doc = Nokogiri::HTML5(html, parse_noscript_content_as_text: true, max_errors: 100)
+    noscript = doc.at("/html/head/noscript")
+    assert_equal(0, doc.errors.length, doc.errors.join("\n"))
+    assert_equal(1, noscript.children.length)
+    assert(noscript.children.first.is_a?(Nokogiri::XML::Text))
+  end
+
+  def test_parse_noscript_as_elements_in_body
+    html = "<!DOCTYPE html><body><noscript><img src=!></noscript></body>"
+    doc = Nokogiri::HTML5(html, parse_noscript_content_as_text: false, max_errors: 100)
+    assert_equal(0, doc.errors.length, doc.errors.join("\n"))
+    img = doc.at("/html/body/noscript/img")
+    refute_nil(img)
+  end
+
+  def test_parse_noscript_as_text_in_body
+    html = "<!DOCTYPE html><body><noscript><img src=!></noscript></body>"
+    doc = Nokogiri::HTML5(html, parse_noscript_content_as_text: true, max_errors: 100)
+    noscript = doc.at("/html/body/noscript")
+    assert_equal(0, doc.errors.length, doc.errors.join("\n"))
+    assert(noscript.children.first.is_a?(Nokogiri::XML::Text))
+  end
+
+  def test_parse_noscript_fragment_as_elements
+    html = "<meta charset='UTF-8'><link rel=stylesheet href=!>"
+    frag = Nokogiri::HTML5::DocumentFragment.new(Nokogiri::HTML5::Document.new, html, 'noscript', parse_noscript_content_as_text: false, max_errors: 100)
+    assert_equal(0, frag.errors.length, frag.errors.join("\n"))
+    assert_equal(2, frag.children.length)
+  end
+
+  def test_parse_noscript_fragment_as_text
+    html = "<meta charset='UTF-8'><link rel=stylesheet href=!>"
+    frag = Nokogiri::HTML5::DocumentFragment.new(Nokogiri::HTML5::Document.new, html, 'noscript', parse_noscript_content_as_text: true, max_errors: 100)
+    assert_equal(0, frag.errors.length, frag.errors.join("\n"))
+    assert_equal(1, frag.children.length)
+    assert(frag.children.first.is_a?(Nokogiri::XML::Text))
+  end
+
   ["pre", "listing", "textarea"].each do |tag|
     define_method("test_serialize_preserve_newline_#{tag}".to_sym) do
       doc = Nokogiri::HTML5("<!DOCTYPE html><#{tag}>\n\nContent</#{tag}>")

--- a/test/html5/test_api.rb
+++ b/test/html5/test_api.rb
@@ -128,7 +128,7 @@ class TestHtml5API < Nokogiri::TestCase
     html = "<!DOCTYPE html><head><noscript><img src=!></noscript></head>"
     doc = Nokogiri::HTML5(html, parse_noscript_content_as_text: true, max_errors: 100)
     noscript = doc.at("/html/head/noscript")
-    assert_equal(0, doc.errors.length, doc.errors.join("\n"))
+    assert_empty(doc.errors)
     assert_equal(1, noscript.children.length)
     assert_kind_of(Nokogiri::XML::Text, noscript.children.first)
   end
@@ -136,7 +136,7 @@ class TestHtml5API < Nokogiri::TestCase
   def test_parse_noscript_as_elements_in_body
     html = "<!DOCTYPE html><body><noscript><img src=!></noscript></body>"
     doc = Nokogiri::HTML5(html, parse_noscript_content_as_text: false, max_errors: 100)
-    assert_equal(0, doc.errors.length, doc.errors.join("\n"))
+    assert_empty(doc.errors)
     img = doc.at("/html/body/noscript/img")
     refute_nil(img)
   end
@@ -145,24 +145,34 @@ class TestHtml5API < Nokogiri::TestCase
     html = "<!DOCTYPE html><body><noscript><img src=!></noscript></body>"
     doc = Nokogiri::HTML5(html, parse_noscript_content_as_text: true, max_errors: 100)
     noscript = doc.at("/html/body/noscript")
-    assert_equal(0, doc.errors.length, doc.errors.join("\n"))
+    assert_empty(doc.errors, doc.errors.join("\n"))
+    assert_equal(1, noscript.children.length)
     assert_kind_of(Nokogiri::XML::Text, noscript.children.first)
   end
 
   def test_parse_noscript_fragment_as_elements
     html = "<meta charset='UTF-8'><link rel=stylesheet href=!>"
     frag = Nokogiri::HTML5::DocumentFragment.new(Nokogiri::HTML5::Document.new, html, "noscript", parse_noscript_content_as_text: false, max_errors: 100)
-    assert_equal(0, frag.errors.length, frag.errors.join("\n"))
+    assert_empty(frag.errors)
     assert_equal(2, frag.children.length)
   end
 
   def test_parse_noscript_fragment_as_text
     html = "<meta charset='UTF-8'><link rel=stylesheet href=!>"
     frag = Nokogiri::HTML5::DocumentFragment.new(Nokogiri::HTML5::Document.new, html, "noscript", parse_noscript_content_as_text: true, max_errors: 100)
-    assert_equal(0, frag.errors.length, frag.errors.join("\n"))
+    assert_empty(frag.errors)
     assert_equal(1, frag.children.length)
     assert_kind_of(Nokogiri::XML::Text, frag.children.first)
   end
+
+  def test_parse_noscript_content_default
+    html = "<!DOCTYPE html><body><noscript><img src=!></noscript></body>"
+    doc = Nokogiri::HTML5(html, max_errors: 100)
+    assert_empty(doc.errors)
+    img = doc.at("/html/body/noscript/img")
+    refute_nil(img)
+  end
+  
 
   ["pre", "listing", "textarea"].each do |tag|
     define_method("test_serialize_preserve_newline_#{tag}".to_sym) do


### PR DESCRIPTION
This change adds support for parsing noscript content with the scripting flag enabled. In this case, Gumbo will treat the content of the noscript element as raw text, exactly as the browser would.

<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Closes #3178 

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

Yes.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

It adds support for this parsing option to libgumbo only.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
