### PR TITLE
dep(dev): drop mutex_m from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  # ruby 3.4.0-dev removed some gems from the default set
-  #
-  # TODO: we should be able to remove these as our gem dependencies sort it out and we pull them in
-  # transitively.
-  gem "mutex_m"
-
   # bootstrapping
   gem "bundler", "~> 2.3"
   gem "rake", "13.2.1"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

`mutex_m` is one of the gems that was dropped from the default gems in Ruby 3.4. I think we originally added it to the Gemfile in #3092 because minitest was using it, and that changed in minitest/minitest@5f5c2111

