### PR TITLE
upstream: update tests for upstream libxml2 changes

### DIFF
--- a/test/xml/test_entity_reference.rb
+++ b/test/xml/test_entity_reference.rb
@@ -186,7 +186,13 @@ module Nokogiri
 
         assert_kind_of Nokogiri::XML::EntityReference, doc.xpath("//body").first.children.first
 
-        expected = if Nokogiri.uses_libxml?(">= 2.13")
+        expected = if Nokogiri.uses_libxml?("~> 2.14")
+          [
+            "2:49: WARNING: failed to load \"http://foo.bar.com/\": Attempt to load network entity",
+            # "attempt to load network entity" removed in gnome/libxml2@1b1e8b3c
+            "4:14: ERROR: Entity 'bar' not defined",
+          ]
+        elsif Nokogiri.uses_libxml?("~> 2.13.0")
           [
             "2:49: WARNING: failed to load \"http://foo.bar.com/\": Attempt to load network entity",
             "ERROR: Attempt to load network entity: http://foo.bar.com/",

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -269,17 +269,16 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
           it "XML::Schema parsing does not attempt to access external DTDs" do
             doc = Nokogiri::XML::Schema.new(schema)
             errors = doc.errors.map(&:to_s)
-            assert_equal(
-              1,
-              errors.grep(/ERROR: Attempt to load network entity/).length,
+            refute_empty(
+              errors.grep(/Attempt to load network entity/),
               "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
             )
             assert_empty(
-              errors.grep(/WARNING: failed to load HTTP resource/),
+              errors.grep(/failed to load HTTP resource/),
               "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
             )
             assert_empty(
-              errors.grep(/WARNING: failed to load external entity/),
+              errors.grep(/failed to load external entity/),
               "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
             )
           end
@@ -287,17 +286,16 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
           it "XML::Schema parsing of memory does not attempt to access external DTDs" do
             doc = Nokogiri::XML::Schema.read_memory(schema)
             errors = doc.errors.map(&:to_s)
-            assert_equal(
-              1,
-              errors.grep(/ERROR: Attempt to load network entity/).length,
+            refute_empty(
+              errors.grep(/Attempt to load network entity/),
               "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
             )
             assert_empty(
-              errors.grep(/WARNING: failed to load HTTP resource/),
+              errors.grep(/failed to load HTTP resource/),
               "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
             )
             assert_empty(
-              errors.grep(/WARNING: failed to load external entity/),
+              errors.grep(/failed to load external entity/),
               "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
             )
           end
@@ -307,25 +305,21 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
           it "XML::Schema parsing attempts to access external DTDs" do
             doc = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions.new.nononet)
             errors = doc.errors.map(&:to_s)
-            assert_equal(
-              0,
-              errors.grep(/ERROR: Attempt to load network entity/).length,
+            assert_empty(
+              errors.grep(/Attempt to load network entity/),
               "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
             )
-            # changed from "WARNING" to "FATAL" in libxml2 2.13
-            assert_equal(1, errors.grep(/(WARNING|FATAL): failed to load/).length)
+            assert_equal(1, errors.grep(%r(failed to load.*http://localhost:8000/making-a-request)).length)
           end
 
           it "XML::Schema parsing of memory attempts to access external DTDs" do
             doc = Nokogiri::XML::Schema.read_memory(schema, Nokogiri::XML::ParseOptions.new.nononet)
             errors = doc.errors.map(&:to_s)
-            assert_equal(
-              0,
-              errors.grep(/ERROR: Attempt to load network entity/).length,
+            assert_empty(
+              errors.grep(/ERROR: Attempt to load network entity/),
               "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
             )
-            # changed from "WARNING" to "FATAL" in libxml2 2.13
-            assert_equal(1, errors.grep(/(WARNING|FATAL): failed to load/).length)
+            assert_equal(1, errors.grep(%r(failed to load.*http://localhost:8000/making-a-request)).length)
           end
         end
       end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Update tests to accept new libxml2 error messages (from `master` branch, pre-2.14).

Failing tests: https://github.com/sparklemotion/nokogiri/actions/runs/9544039534/job/26301851765

```
1) Failure:
Nokogiri::XML::TestDOMEntityReference#test_document_dtd_loading_with_nonet [test/xml/test_entity_reference.rb:203]:
--- expected
+++ actual
@@ -1 +1 @@
-["2:49: WARNING: failed to load \"http://foo.bar.com/\": Attempt to load network entity", "ERROR: Attempt to load network entity: http://foo.bar.com/", "4:14: ERROR: Entity 'bar' not defined"]
+["2:49: WARNING: failed to load \"http://foo.bar.com/\": Attempt to load network entity", "4:14: ERROR: Entity 'bar' not defined"]


  2) Failure:
Nokogiri::XML::TestDOMEntityReference#test_document_dtd_loading_with_nonet_with_absolute_path [test/xml/test_entity_reference.rb:203]:
--- expected
+++ actual
@@ -1 +1 @@
-["2:49: WARNING: failed to load \"http://foo.bar.com/\": Attempt to load network entity", "ERROR: Attempt to load network entity: http://foo.bar.com/", "4:14: ERROR: Entity 'bar' not defined"]
+["2:49: WARNING: failed to load \"http://foo.bar.com/\": Attempt to load network entity", "4:14: ERROR: Entity 'bar' not defined"]


  3) Failure:
Nokogiri::XML::Schema::CVE-2020-26247::with default parse options#test_0001_XML::Schema parsing does not attempt to access external DTDs [test/xml/test_schema.rb:272]:
Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT.
Expected: 1
  Actual: 0

  4) Failure:
Nokogiri::XML::Schema::CVE-2020-26247::with default parse options#test_0002_XML::Schema parsing of memory does not attempt to access external DTDs [test/xml/test_schema.rb:290]:
Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT.
Expected: 1
  Actual: 0

4[53](https://github.com/sparklemotion/nokogiri/actions/runs/9544039534/job/26301851765#step:8:54)2 runs, 61344 assertions, 4 failures, 0 errors, 26 skips
```