### PR TITLE
dep: update libxml to 2.13.1 and libxslt to 1.1.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ### Dependencies
 
-* [CRuby] Vendored libxml2 is updated to [v2.13.0](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.0). [#3230] @flavorjones
-* [CRuby] Vendored libxslt is updated to [v1.1.40](https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.40). [#3230] @flavorjones
+* [CRuby] Vendored libxml2 is updated to [v2.13.1](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.1). [#3230] @flavorjones
+* [CRuby] Vendored libxslt is updated to [v1.1.41](https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.41). [#3230] @flavorjones
 * [CRuby] Minimum supported version of libxml2 raised to v2.7.7 (released 2010-03-15) from v2.6.21. [#3232] @flavorjones
 * [JRuby] Minimum supported versino of Java raised to 8 (released 2014-03-18) from 7. [#3134] @flavorjones 
 * [CRuby] Update to rake-compiler-dock v1.5.1 for building precompiled native gems. [#3216] @flavorjones

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 ---
 libxml2:
-  version: "2.13.0"
-  sha256: "d5a2f36bea96e1fb8297c6046fb02016c152d81ed58e65f3d20477de85291bc9"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.0.sha256sum
+  version: "2.13.1"
+  sha256: "25239263dc37f5f55a5393eff27b35f0b7d9ea4b2a7653310598ea8299e3b741"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.1.sha256sum
 
 libxslt:
-  version: "1.1.40"
-  sha256: "194715db023035f65fb566402f2ad2b5eab4c29d541f511305c40b29b1f48d13"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.40.sha256sum
+  version: "1.1.41"
+  sha256: "3ad392af91115b7740f7b50d228cc1c5fc13afc1da7f16cb0213917a37f71bda"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.41.sha256sum
 
 zlib:
   version: "1.3.1"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

 update libxml to 2.13.1 and libxslt to 1.1.41

- https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.1
- https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.41

