### PR TITLE
ci: update some containers and versions of ruby

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -27,15 +27,15 @@ jobs:
           - url: https://github.com/flavorjones/loofah
             name: loofah
             command: "bundle exec rake test"
-            ruby: "3.2"
+            ruby: "3.3"
           - url: https://github.com/rails/rails-html-sanitizer
             name: rails-html-sanitizer
             command: "bundle exec rake test"
-            ruby: "3.2"
+            ruby: "3.3"
           - url: https://github.com/rgrove/sanitize
             name: sanitize
             command: "bundle exec rake test"
-            ruby: "3.2"
+            ruby: "3.3"
           - url: https://github.com/ebeigarts/signer
             name: signer
             command: "bundle exec rake spec"
@@ -47,7 +47,7 @@ jobs:
           - url: https://github.com/rails/rails
             name: xmlmini
             command: "cd activesupport && bundle exec rake test TESTOPTS=-n/XmlMini/"
-            ruby: "3.2"
+            ruby: "3.3"
           - url: https://github.com/pythonicrubyist/creek
             name: creek
             command: "bundle exec rake spec"
@@ -59,11 +59,11 @@ jobs:
           - url: https://github.com/sparklemotion/mechanize
             name: mechanize
             command: "bundle exec rake test"
-            ruby: "3.2"
+            ruby: "3.3"
           - url: https://github.com/stimulusreflex/stimulus_reflex
             name: stimulus_reflex
             command: "bundle exec rake test"
-            ruby: "3.2"
+            ruby: "3.3"
           # - url: https://github.com/instructure/nokogiri-xmlsec-instructure
           #   name: nokogiri-xmlsec-instructure
           #   precommand: "apt install -y libxmlsec1-dev"

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -63,7 +63,7 @@ jobs:
   xmlsoft-head-valgrind:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.1
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.3
     steps:
       - uses: actions/checkout@v4
         with:
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-    runs-on: ubuntu-20.04 # warning that 22.04 binary has dwarf5 debug info that valgrind can't read
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

- use ruby 3.3 for some downstream projects
- use ruby 3.3 for upstream xmlsoft-head-valgrind job


Note: an early version of this PR updated ubuntu 24.04 for upstream ruby-head-valgrind job, and that failed because some of the stack frames had no information.
