### PR TITLE
ci: stop upstream valgrind testing against system libraries

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sys: ["enable", "disable"]
+        sys: ["disable"]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

**What problem is this PR intended to solve?**

The runners are now using libxml 2.9.14 which leaks memory in schema parsing edge cases (and is fixed in modern versions of libxml2).

Testing against old system libraries is not really useful since we can't do anything about it. So I'm removing it.

