### PR TITLE
Fix fragment quirks mode, and make it easier to specify fragment context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * Documentation has been improved for `CSS.xpath_for`. [#3224] @flavorjones
 * [CRuby] When compiling packaged libraries from source, allow users' `AR` and `LD` environment variables to set the archiver and linker commands, respectively. This augments the existing `CC` environment variable to set the compiler command. [#3165] @ziggythehamster
 * [CRuby] The HTML5 parse methods accept a `:parse_noscript_content_as_text` keyword argument which will emulate the parsing behavior of a browser which has scripting enabled. [#3178, #3231] @stevecheckoway
+* [CRuby] `HTML5::DocumentFragment.parse` and `.new` accept a `:context` keyword argument that is the parse context node or element name. Previously this could only be passed in as a positional argument to `.new` and not at all to `.parse`. @flavorjones
 
 
 ### Fixed
@@ -49,6 +50,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 * The undocumented and unused method `Nokogiri::CSS.parse` is now deprecated and will generate a warning. The AST returned by this method is private and subject to change and removal in future versions of Nokogiri. This method will be removed in a future version of Nokogiri.
 * Passing an options hash to `CSS.xpath_for` is now deprecated and will generate a warning. Use keyword arguments instead. This will become an error in a future version of Nokogiri.
+* Passing an options hash to `HTML5::DocumentFragment.parse` is now deprecated and will generate a warning. Use keyword arguments instead. This will become an error in a future version of Nokogiri.
 
 
 ## v1.16.6 / 2024-06-13

--- a/ext/nokogiri/gumbo.c
+++ b/ext/nokogiri/gumbo.c
@@ -538,7 +538,7 @@ error:
   VALUE doc = rb_funcall(doc_fragment, rb_intern_const("document"), 0);
   VALUE dtd = rb_funcall(doc, internal_subset, 0);
   VALUE doc_quirks_mode = rb_iv_get(doc, "@quirks_mode");
-  if (NIL_P(ctx) || NIL_P(doc_quirks_mode)) {
+  if (NIL_P(ctx) || (TYPE(ctx) == T_STRING) || NIL_P(doc_quirks_mode)) {
     quirks_mode = GUMBO_DOCTYPE_NO_QUIRKS;
   } else if (NIL_P(dtd)) {
     quirks_mode = GUMBO_DOCTYPE_QUIRKS;

--- a/lib/nokogiri/css.rb
+++ b/lib/nokogiri/css.rb
@@ -88,7 +88,7 @@ module Nokogiri
         cache: true
       )
         unless options.nil?
-          warn("Passing options as an explicit hash is deprecated. Use keyword arguments instead. This will become an error in a future release.", uplevel: 1, category: :deprecated)
+          warn("Nokogiri::CSS.xpath_for: Passing options as an explicit hash is deprecated. Use keyword arguments instead. This will become an error in a future release.", uplevel: 1, category: :deprecated)
         end
 
         raise(TypeError, "no implicit conversion of #{selector.inspect} to String") unless selector.respond_to?(:to_str)

--- a/lib/nokogiri/html5.rb
+++ b/lib/nokogiri/html5.rb
@@ -249,11 +249,13 @@ module Nokogiri
   #
   # == Notes
   #
-  # * The Nokogiri::HTML5.fragment function takes a string and parses it as a HTML5 document. The
-  #   +html+, +head+, and +body+ elements are removed from this document, and any children of these
-  #   elements that remain are returned as a Nokogiri::HTML5::DocumentFragment.
+  # * The Nokogiri::HTML5.fragment function takes a String or IO and parses it as a HTML5 document
+  #   in a +body+ context. As a result, the +html+, +head+, and +body+ elements are removed from
+  #   this document, and any children of these elements that remain are returned as a
+  #   Nokogiri::HTML5::DocumentFragment; but you can pass in a different context (e.g., "html" to
+  #   get +head+ and +body+ tags in the result).
   #
-  # * The Nokogiri::HTML5.parse function takes a string and passes it to the
+  # * The Nokogiri::HTML5.parse function takes a String or IO and passes it to the
   #   <code>gumbo_parse_with_options</code> method, using the default options.  The resulting Gumbo
   #   parse tree is then walked.
   #
@@ -273,7 +275,7 @@ module Nokogiri
       # Parse a fragment from +string+. Convenience method for
       # Nokogiri::HTML5::DocumentFragment.parse.
       def fragment(string, encoding = nil, **options)
-        DocumentFragment.parse(string, encoding, options)
+        DocumentFragment.parse(string, encoding, **options)
       end
 
       # :nodoc:

--- a/test/html5/test_api.rb
+++ b/test/html5/test_api.rb
@@ -398,6 +398,44 @@ class TestHtml5API < Nokogiri::TestCase
   end
 
   describe Nokogiri::HTML5::DocumentFragment do
+    describe "passing in context node" do
+      it "to DocumentFragment.new" do
+        fragment = Nokogiri::HTML5::DocumentFragment.new(
+          Nokogiri::HTML5::Document.new,
+          "<body><div>foo</div></body>",
+          "html",
+        )
+        assert_match(/<body>/, fragment.to_s)
+        assert_match(/<head>/, fragment.to_s)
+      end
+
+      describe "to DocumentFragment.parse" do
+        it "as an options hash" do
+          assert_output(nil, /Passing options as an explicit hash is deprecated/) do
+            fragment = Nokogiri::HTML5::DocumentFragment.parse(
+              "<body><div>foo</div></body>",
+              nil,
+              { context: "html" },
+            )
+            assert_match(/<body>/, fragment.to_s)
+            assert_match(/<head>/, fragment.to_s)
+          end
+        end
+
+        it "as keyword argument" do
+          fragment = Nokogiri::HTML5::DocumentFragment.parse("<body><div>foo</div></body>", context: "html")
+          assert_match(/<body>/, fragment.to_s)
+          assert_match(/<head>/, fragment.to_s)
+        end
+      end
+
+      it "to HTML5.fragment" do
+        fragment = Nokogiri::HTML5.fragment("<body><div>foo</div></body>", context: "html")
+        assert_match(/<body>/, fragment.to_s)
+        assert_match(/<head>/, fragment.to_s)
+      end
+    end
+
     describe "subclassing" do
       let(:klass) do
         Class.new(Nokogiri::HTML5::DocumentFragment) do

--- a/test/html5/test_quirks_mode.rb
+++ b/test/html5/test_quirks_mode.rb
@@ -66,6 +66,15 @@ describe Nokogiri::HTML5 do
           assert_equal(Nokogiri::HTML5::QuirksMode::NO_QUIRKS, fragment.quirks_mode)
           assert_equal(no_quirks_output, fragment.to_html)
         end
+
+        describe "context node is just a tag name and not a real node" do
+          it "parses the fragment in no-quirks mode" do
+            fragment = Nokogiri::HTML5::DocumentFragment.new(document, input, "body")
+
+            assert_equal(Nokogiri::HTML5::QuirksMode::NO_QUIRKS, fragment.quirks_mode)
+            assert_equal(no_quirks_output, fragment.to_html)
+          end
+        end
       end
 
       describe "document does not have a doctype" do
@@ -77,6 +86,15 @@ describe Nokogiri::HTML5 do
 
           assert_equal(Nokogiri::HTML5::QuirksMode::QUIRKS, fragment.quirks_mode)
           assert_equal(quirks_output, fragment.to_html)
+        end
+
+        describe "context node is just a tag name and not a real node" do
+          it "parses the fragment in no-quirks mode" do
+            fragment = Nokogiri::HTML5::DocumentFragment.new(document, input, "body")
+
+            assert_equal(Nokogiri::HTML5::QuirksMode::NO_QUIRKS, fragment.quirks_mode)
+            assert_equal(no_quirks_output, fragment.to_html)
+          end
         end
       end
     end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Coming from the discussion at #3203, I wanted to improve the fragment parsing API

- as discussed in #2646, parse in no-quirks mode if a context element name is provided (not a context `Node`, just the name)
- allow passing `:context` kwarg to `DocumentFragment.new` and `.parse`
- deprecate the positional options hash to `.parse` per notes at #3200


**Have you included adequate test coverage?**

Included additional coverage for the API changes


**Does this change affect the behavior of either the C or the Java implementations?**

HTML5 is only in CRuby.