### PR TITLE
fix: No rule to make target 'nokogiri.so' on android

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -205,6 +205,10 @@ def openbsd?
   RbConfig::CONFIG["target_os"].include?("openbsd")
 end
 
+def android?
+  RbConfig::CONFIG["target_os"].include?("android")
+end
+
 def aix?
   RbConfig::CONFIG["target_os"].include?("aix")
 end
@@ -586,6 +590,8 @@ def do_clean
     Pathname.glob(pwd.join("tmp", "*", "ports")) do |dir|
       FileUtils.rm_rf(dir, verbose: true)
     end
+
+    exit!(0) if android?
 
     if config_static?
       # ports installation can be safely removed if statically linked.
@@ -1165,7 +1171,7 @@ if config_clean?
     mk.print(<<~EOF)
 
       all: clean-ports
-      clean-ports: $(DLLIB)
+      clean-ports: #{android? ? "$(TARGET_SO)" : "$(DLLIB)"}
       \t-$(Q)$(RUBY) $(srcdir)/extconf.rb --clean --#{static_p ? "enable" : "disable"}-static
     EOF
   end


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

On android builds of ruby, `DLLIB` does not direct to a valid `nokogiri.so` path but `TARGET_SO` does. This PR fixes it for the `clean-ports` step.

Reference #3244

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

Not sure what kind of tests should be added. I have tested this on my [build system](https://github.com/jekyllex/ruby-android/actions/runs/9634684158) and it passes.

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

Does not change the behaviour, but allows the compilation.
