### PR TITLE
fix: use TARGET_SO instead of DLLIB to clean installation

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -1165,7 +1165,7 @@ if config_clean?
     mk.print(<<~EOF)
 
       all: clean-ports
-      clean-ports: $(DLLIB)
+      clean-ports: $(TARGET_SO)
       \t-$(Q)$(RUBY) $(srcdir)/extconf.rb --clean --#{static_p ? "enable" : "disable"}-static
     EOF
   end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

`DLLIB` seems to be broken on Android.

Closes #3244


**Have you included adequate test coverage?**

We don't have test coverage for Android builds, so they remain officially unsupported, but this reportedly helps.


**Does this change affect the behavior of either the C or the Java implementations?**

N/A