### PR TITLE
test: raise exception on assertionless tests

### DIFF
--- a/test/html4/sax/test_parser.rb
+++ b/test/html4/sax/test_parser.rb
@@ -20,7 +20,10 @@ module Nokogiri
         def test_parse_empty_file
           # Make sure empty files don't break stuff
           empty_file_name = File.join(ASSETS_DIR, "bogus.xml")
-          @parser.parse_file(empty_file_name) # assert_nothing_raised
+
+          refute_raises do
+            @parser.parse_file(empty_file_name)
+          end
         end
 
         def test_parse_file
@@ -164,7 +167,10 @@ module Nokogiri
         end
 
         def test_empty_processing_instruction
-          @parser.parse_memory("<strong>this will segfault<?strong>")
+          # https://github.com/sparklemotion/nokogiri/issues/845
+          refute_raises do
+            @parser.parse_memory("<strong>this will segfault<?strong>")
+          end
         end
 
         it "handles invalid types gracefully" do

--- a/test/html4/sax/test_parser_context.rb
+++ b/test/html4/sax/test_parser_context.rb
@@ -25,20 +25,20 @@ module Nokogiri
         end
 
         def test_parse_with_sax_parser
-          # assert_nothing_raised do
-          xml = "<root />"
-          ctx = ParserContext.new(xml)
-          parser = Parser.new(Doc.new)
-          ctx.parse_with(parser)
-          # end
+          refute_raises do
+            xml = "<root />"
+            ctx = ParserContext.new(xml)
+            parser = Parser.new(Doc.new)
+            ctx.parse_with(parser)
+          end
         end
 
         def test_from_file
-          # assert_nothing_raised do
-          ctx = ParserContext.file(HTML_FILE, "UTF-8")
-          parser = Parser.new(Doc.new)
-          ctx.parse_with(parser)
-          # end
+          refute_raises do
+            ctx = ParserContext.file(HTML_FILE, "UTF-8")
+            parser = Parser.new(Doc.new)
+            ctx.parse_with(parser)
+          end
         end
 
         def test_graceful_handling_of_invalid_types

--- a/test/html4/test_document.rb
+++ b/test/html4/test_document.rb
@@ -693,17 +693,6 @@ module Nokogiri
           assert_equal(0, doc.errors.length)
         end
 
-        def test_leaking_dtd_nodes_after_internal_subset_removal
-          # see https://github.com/sparklemotion/nokogiri/issues/1784
-          #
-          # just checking that this doesn't raise a valgrind error. we
-          # don't otherwise have any test coverage for removing DTDs.
-          #
-          100.times do |_i|
-            Nokogiri::HTML4::Document.new.internal_subset.remove
-          end
-        end
-
         it "skips encoding for script tags" do
           html = Nokogiri::HTML4(<<~HTML)
             <html>

--- a/test/html4/test_document_fragment.rb
+++ b/test/html4/test_document_fragment.rb
@@ -88,10 +88,6 @@ module Nokogiri
           assert_instance_of(Nokogiri::HTML4::DocumentFragment, fragment)
         end
 
-        def test_many_fragments
-          100.times { Nokogiri::HTML4::DocumentFragment.new(html) }
-        end
-
         def test_html_fragment
           fragment = Nokogiri::HTML4.fragment("<div>a</div>")
           assert_equal("<div>a</div>", fragment.to_s)

--- a/test/html4/test_element_description.rb
+++ b/test/html4/test_element_description.rb
@@ -70,8 +70,12 @@ module Nokogiri
       end
 
       def test_null_default_sub_element
+        # https://github.com/sparklemotion/nokogiri/issues/917
         doc = Nokogiri::HTML4("foo")
-        doc.root.description.default_sub_element
+
+        refute_raises do
+          doc.root.description.default_sub_element
+        end
       end
 
       def test_optional_attributes

--- a/test/html4/test_node.rb
+++ b/test/html4/test_node.rb
@@ -193,12 +193,14 @@ module Nokogiri
         table = html.xpath("//table")[1]
         trs = table.xpath("tr").drop(1)
 
-        # the jruby implementation of drop uses dup() on the IRubyObject (which
-        # is NOT the same dup() method on the ruby Object) which produces a
-        # shallow clone. a shallow of valid XMLNode triggers several
-        # NullPointerException on inspect() since loads of invariants
-        # are not set. the fix for GH1042 ensures a proper working clone.
-        trs.inspect # assert_nothing_raised
+        refute_raises do
+          # the jruby implementation of drop uses dup() on the IRubyObject (which
+          # is NOT the same dup() method on the ruby Object) which produces a
+          # shallow clone. a shallow of valid XMLNode triggers several
+          # NullPointerException on inspect() since loads of invariants
+          # are not set. the fix for GH1042 ensures a proper working clone.
+          trs.inspect
+        end
       end
 
       def test_fragment_node_to_xhtml # see #2355

--- a/test/test_compaction.rb
+++ b/test/test_compaction.rb
@@ -12,17 +12,19 @@ describe "compaction" do
     it "compacts safely" do # https://github.com/sparklemotion/nokogiri/pull/2579
       skip if skip_compaction_tests
 
-      big_doc = "<root>" + ("a".."zz").map { |x| "<#{x}>#{x}</#{x}>" }.join + "</root>"
-      doc = Nokogiri.XML(big_doc)
+      refute_valgrind_errors do
+        big_doc = "<root>" + ("a".."zz").map { |x| "<#{x}>#{x}</#{x}>" }.join + "</root>"
+        doc = Nokogiri.XML(big_doc)
 
-      # ensure a bunch of node objects have been wrapped
-      doc.root.children.each(&:inspect)
+        # ensure a bunch of node objects have been wrapped
+        doc.root.children.each(&:inspect)
 
-      # compact the heap and try to get the node wrappers to move
-      gc_verify_compaction_references
+        # compact the heap and try to get the node wrappers to move
+        gc_verify_compaction_references
 
-      # access the node wrappers and make sure they didn't move
-      doc.root.children.each(&:inspect)
+        # access the node wrappers and make sure they didn't move
+        doc.root.children.each(&:inspect)
+      end
     end
   end
 
@@ -38,11 +40,13 @@ describe "compaction" do
         </root>
       EOF
 
-      doc.at_xpath("//root:first", "root" => "http://example.com/root").namespace_scopes.inspect
+      refute_valgrind_errors do
+        doc.at_xpath("//root:first", "root" => "http://example.com/root").namespace_scopes.inspect
 
-      gc_verify_compaction_references
+        gc_verify_compaction_references
 
-      doc.at_xpath("//root:first", "root" => "http://example.com/root").namespace_scopes.inspect
+        doc.at_xpath("//root:first", "root" => "http://example.com/root").namespace_scopes.inspect
+      end
     end
 
     it "remove_namespaces!" do
@@ -58,13 +62,15 @@ describe "compaction" do
         </root>
       XML
 
-      namespaces = doc.root.namespaces
-      namespaces.each(&:inspect)
-      doc.remove_namespaces!
+      refute_valgrind_errors do
+        namespaces = doc.root.namespaces
+        namespaces.each(&:inspect)
+        doc.remove_namespaces!
 
-      gc_verify_compaction_references
+        gc_verify_compaction_references
 
-      namespaces.each(&:inspect)
+        namespaces.each(&:inspect)
+      end
     end
   end
 end

--- a/test/test_memory_usage.rb
+++ b/test/test_memory_usage.rb
@@ -49,14 +49,16 @@ class TestMemoryUsage < Nokogiri::TestCase
       # https://github.com/sparklemotion/nokogiri/issues/2923
       skip("memsize_of not defined") unless ObjectSpace.respond_to?(:memsize_of)
 
-      doc = Nokogiri::XML(<<~XML)
-        <?xml version="1.0"?>
-        <!DOCTYPE staff PUBLIC "staff.dtd" [
-          <!ATTLIST payment type CDATA "check">
-        ]>
-        <staff></staff>
-      XML
-      ObjectSpace.memsize_of(doc) # assert_does_not_crash
+      refute_valgrind_errors do
+        doc = Nokogiri::XML(<<~XML)
+          <?xml version="1.0"?>
+          <!DOCTYPE staff PUBLIC "staff.dtd" [
+            <!ATTLIST payment type CDATA "check">
+          ]>
+          <staff></staff>
+        XML
+        ObjectSpace.memsize_of(doc)
+      end
     end
   end
 

--- a/test/xml/sax/test_parser.rb
+++ b/test/xml/sax/test_parser.rb
@@ -363,11 +363,14 @@ module Nokogiri
         end
 
         it :test_parse_document do
-          skip_unless_libxml2("JRuby SAXParser only parses well-formed XML documents")
           parser.parse_memory(<<~EOF)
-            <p>Paragraph 1</p>
-            <p>Paragraph 2</p>
+            <div>
+              <p>Paragraph 1</p>
+              <p>Paragraph 2</p>
+            </div>
           EOF
+
+          assert_equal(["div", "p", "p"], parser.document.start_elements.map(&:first))
         end
 
         it :test_parser_attributes do

--- a/test/xml/test_builder.rb
+++ b/test/xml/test_builder.rb
@@ -14,14 +14,6 @@ module Nokogiri
         assert_equal("world", doc.root["abcDef"])
       end
 
-      def test_builder_multiple_nodes
-        Nokogiri::XML::Builder.new do |xml|
-          0.upto(10) do
-            xml.text("test")
-          end
-        end
-      end
-
       def test_builder_resilient_to_exceptions
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.root do

--- a/test/xml/test_comment.rb
+++ b/test/xml/test_comment.rb
@@ -31,12 +31,6 @@ module Nokogiri
           Nokogiri::XML::Comment.new("NOT A NOKOGIRI CLASS", "hello world")
         end
       end
-
-      def test_many_comments
-        100.times do
-          Nokogiri::XML::Comment.new(@xml, "hello world")
-        end
-      end
     end
   end
 end

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -985,9 +985,11 @@ module Nokogiri
         end
 
         def test_can_be_closed
-          f = File.open(XML_FILE)
-          Nokogiri::XML(f)
-          f.close
+          refute_raises do
+            f = File.open(XML_FILE)
+            Nokogiri::XML(f)
+            f.close
+          end
         end
 
         describe "JRuby-only methods" do

--- a/test/xml/test_entity_reference.rb
+++ b/test/xml/test_entity_reference.rb
@@ -15,10 +15,6 @@ module Nokogiri
         assert_instance_of(EntityReference, ref)
       end
 
-      def test_many_references
-        100.times { EntityReference.new(@xml, "foo") }
-      end
-
       def test_newline_node
         # issue 719
         xml = <<~EOF

--- a/test/xml/test_namespace.rb
+++ b/test/xml/test_namespace.rb
@@ -72,9 +72,12 @@ module Nokogiri
       end
 
       def test_remove_entity_namespace
-        s = %q{<?xml version='1.0'?><!DOCTYPE schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" [<!ENTITY % p ''>]>}
-        Nokogiri::XML(s).remove_namespaces!
-        # TODO: we should probably assert something here. See commit 14d2f59.
+        skip_unless_libxml2("valgrind tests should only run with libxml2")
+
+        refute_valgrind_errors do
+          s = %q{<?xml version='1.0'?><!DOCTYPE schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" [<!ENTITY % p ''>]>}
+          Nokogiri::XML(s).remove_namespaces!
+        end
       end
 
       def test_maintain_element_namespaces

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -149,8 +149,13 @@ module Nokogiri
         def test_parse_error_on_fragment_with_empty_document
           doc = Document.new
           fragment = DocumentFragment.new(doc, "<foo><bar/></foo>")
-          node = fragment % "bar"
+          node = fragment.at_css("bar")
+
+          assert_empty(doc.errors)
+
           node.parse("<baz><</baz>")
+
+          refute_empty(doc.errors)
         end
 
         def test_parse_with_unparented_text_context_node

--- a/test/xml/test_node_attributes.rb
+++ b/test/xml/test_node_attributes.rb
@@ -75,12 +75,10 @@ module Nokogiri
 
         assert_empty(node.namespace_definitions.map(&:prefix))
 
-        # assert_nothing_raised do
         child_node = Nokogiri::XML::Node.new("foo", doc)
         child_node["xml:lang"] = "en-GB"
 
         node << child_node
-        # end
 
         assert_empty(child_node.namespace_definitions.map(&:prefix))
       end
@@ -100,18 +98,20 @@ module Nokogiri
       end
 
       def test_set_attribute_frees_nodes
-        # testing a segv
         skip_unless_libxml2("JRuby doesn't do GC.")
-        document = Nokogiri::XML.parse("<foo></foo>")
 
-        node = document.root
-        node["visible"] = "foo"
-        attribute = node.attribute("visible")
-        text = Nokogiri::XML::Text.new("bar", document)
-        attribute.add_child(text)
+        refute_valgrind_errors do
+          document = Nokogiri::XML.parse("<foo></foo>")
 
-        stress_memory_while do
-          node["visible"] = "attr"
+          node = document.root
+          node["visible"] = "foo"
+          attribute = node.attribute("visible")
+          text = Nokogiri::XML::Text.new("bar", document)
+          attribute.add_child(text)
+
+          stress_memory_while do
+            node["visible"] = "attr"
+          end
         end
       end
     end

--- a/test/xml/test_node_reparenting.rb
+++ b/test/xml/test_node_reparenting.rb
@@ -778,14 +778,18 @@ module Nokogiri
 
         describe "reparenting and preserving a reference to the original ns" do
           it "should not cause illegal memory access" do
-            # this test will only cause a failure in valgrind. it
-            # drives out the reason why we can't call xmlFreeNs in
-            # relink_namespace and instead have to root the nsdef.
-            doc = Nokogiri::XML('<root xmlns="http://flavorjon.es/"><envelope /></root>')
-            elem = doc.create_element("package", { "xmlns" => "http://flavorjon.es/" })
-            ns = elem.namespace_definitions
-            doc.at_css("envelope").add_child(elem)
-            ns.inspect
+            skip_unless_libxml2("valgrind tests should only run with libxml2")
+
+            refute_valgrind_errors do
+              # this test will only cause a failure in valgrind. it
+              # drives out the reason why we can't call xmlFreeNs in
+              # relink_namespace and instead have to root the nsdef.
+              doc = Nokogiri::XML('<root xmlns="http://flavorjon.es/"><envelope /></root>')
+              elem = doc.create_element("package", { "xmlns" => "http://flavorjon.es/" })
+              ns = elem.namespace_definitions
+              doc.at_css("envelope").add_child(elem)
+              ns.inspect
+            end
           end
         end
 

--- a/test/xml/test_processing_instruction.rb
+++ b/test/xml/test_processing_instruction.rb
@@ -23,9 +23,10 @@ module Nokogiri
         assert_instance_of(ProcessingInstruction, ref)
       end
 
-      def test_many_new
-        100.times { ProcessingInstruction.new(@xml, "foo", "bar") }
-        @xml.root << ProcessingInstruction.new(@xml, "foo", "bar")
+      def test_rooting_pi
+        refute_raises do
+          @xml.root << ProcessingInstruction.new(@xml, "foo", "bar")
+        end
       end
     end
   end

--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -143,12 +143,14 @@ module Nokogiri
       end
 
       def test_io_that_reads_too_much
-        io = if Nokogiri.jruby?
-          ReallyBadIO4Java.new
-        else
-          ReallyBadIO.new
+        refute_raises do
+          io = if Nokogiri.jruby?
+            ReallyBadIO4Java.new
+          else
+            ReallyBadIO.new
+          end
+          Nokogiri::XML::Reader(io)
         end
-        Nokogiri::XML::Reader(io)
       end
 
       def test_in_memory

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -200,11 +200,15 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
     end
 
     it "xsd_with_dtd" do
+      # https://github.com/sparklemotion/nokogiri/pull/791
       Dir.chdir(File.join(ASSETS_DIR, "saml")) do
-        # works
-        Nokogiri::XML::Schema(File.read("xmldsig_schema.xsd"))
-        # was not working
-        Nokogiri::XML::Schema(File.read("saml20protocol_schema.xsd"))
+        refute_raises do
+          Nokogiri::XML::Schema(File.read("xmldsig_schema.xsd"))
+        end
+
+        refute_raises do
+          Nokogiri::XML::Schema(File.read("saml20protocol_schema.xsd"))
+        end
       end
     end
 
@@ -220,7 +224,10 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
         <xs:import/>
         </xs:schema>
       EOF
-      Nokogiri::XML::Schema(xsd) # assert_nothing_raised
+
+      refute_raises do
+        Nokogiri::XML::Schema(xsd)
+      end
     end
 
     it "issue_1985_schema_parse_modifying_underlying_document" do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Raise exception if a test makes no assertions.

See https://railsatscale.com/2024-01-25-catching-assertionless-tests/

And this PR cleans up all of the assertionless tests that were found.

- some were not useful (doing a thing in a loop might have been useful
  early in nokogiri development, but not anymore) and were deleted
- some needed explicit `refute_raises`
- some needed explicit `refute_valgrind_errors`
- some just needed rewriting with assertions
