### PR TITLE
feat: aggregate libxml2 errors into a single exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] The HTML5 parse methods accept a `:parse_noscript_content_as_text` keyword argument which will emulate the parsing behavior of a browser which has scripting enabled. [#3178, #3231] @stevecheckoway
 * [CRuby] `HTML5::DocumentFragment.parse` and `.new` accept a `:context` keyword argument that is the parse context node or element name. Previously this could only be passed in as a positional argument to `.new` and not at all to `.parse`. @flavorjones
 * [CRuby] The update to libxml v2.13 improves "in context" fragment parsing recovery. We removed our hacky workaround for recovery that led to silently-degraded functionality when parsing fragments with parse errors. Specifically, malformed XML fragments that used implicit namespace prefixes will now "link up" to the namespaces in the parent document or node, where previously they did not. [#2092] @flavorjones
+* [CRuby] When multiple errors could be detected by the parser and there's no obvious document to save them in (for example, when parsing a document with the recovery parse option turned off), the libxml2 errors are aggregated into a single `Nokogiri::XML::SyntaxError`. Previously, only the last error recorded by libxml2 was raised, which might be misleading if it's merely a warning and not the fatal error preventing the operation. [#2562] @flavorjones
 
 
 ### Fixed

--- a/ext/nokogiri/html4_document.c
+++ b/ext/nokogiri/html4_document.c
@@ -46,7 +46,7 @@ rb_html_document_s_read_io(VALUE klass, VALUE rb_io, VALUE rb_url, VALUE rb_enco
   const char *c_encoding = NIL_P(rb_encoding) ? NULL : StringValueCStr(rb_encoding);
   int options = NUM2INT(rb_options);
 
-  xmlSetStructuredErrorFunc((void *)rb_error_list, Nokogiri_error_array_pusher);
+  xmlSetStructuredErrorFunc((void *)rb_error_list, noko__error_array_pusher);
 
   c_doc = htmlReadIO(noko_io_read, noko_io_close, (void *)rb_io, c_url, c_encoding, options);
 
@@ -106,7 +106,7 @@ rb_html_document_s_read_memory(VALUE klass, VALUE rb_html, VALUE rb_url, VALUE r
   int html_len = (int)RSTRING_LEN(rb_html);
   int options = NUM2INT(rb_options);
 
-  xmlSetStructuredErrorFunc((void *)rb_error_list, Nokogiri_error_array_pusher);
+  xmlSetStructuredErrorFunc((void *)rb_error_list, noko__error_array_pusher);
 
   c_doc = htmlReadMemory(c_buffer, html_len, c_url, c_encoding, options);
 

--- a/ext/nokogiri/html4_sax_push_parser.c
+++ b/ext/nokogiri/html4_sax_push_parser.c
@@ -24,16 +24,16 @@ native_write(VALUE self, VALUE _chunk, VALUE _last_chunk)
     size = (int)RSTRING_LEN(_chunk);
   }
 
-  Nokogiri_structured_error_func_save_and_set(&handler_state, NULL, NULL);
+  noko__structured_error_func_save_and_set(&handler_state, NULL, NULL);
 
   status = htmlParseChunk(ctx, chunk, size, Qtrue == _last_chunk ? 1 : 0);
 
-  Nokogiri_structured_error_func_restore(&handler_state);
+  noko__structured_error_func_restore(&handler_state);
 
   if ((status != 0) && !(xmlCtxtGetOptions(ctx) & XML_PARSE_RECOVER)) {
     // TODO: there appear to be no tests for this block
     xmlErrorConstPtr e = xmlCtxtGetLastError(ctx);
-    Nokogiri_error_raise(NULL, e);
+    noko__error_raise(NULL, e);
   }
 
   return self;

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -232,13 +232,13 @@ xmlParserCtxtPtr noko_xml_sax_parser_context_unwrap(VALUE rb_context);
 #  define NOKO_WARN_DEPRECATION(message...) rb_warning(message)
 #endif
 
-void Nokogiri_structured_error_func_save(libxmlStructuredErrorHandlerState *handler_state);
-void Nokogiri_structured_error_func_save_and_set(libxmlStructuredErrorHandlerState *handler_state, void *user_data,
+void noko__structured_error_func_save(libxmlStructuredErrorHandlerState *handler_state);
+void noko__structured_error_func_save_and_set(libxmlStructuredErrorHandlerState *handler_state, void *user_data,
     xmlStructuredErrorFunc handler);
-void Nokogiri_structured_error_func_restore(libxmlStructuredErrorHandlerState *handler_state);
-VALUE Nokogiri_wrap_xml_syntax_error(xmlErrorConstPtr error);
-void Nokogiri_error_array_pusher(void *ctx, xmlErrorConstPtr error);
-NORETURN_DECL void Nokogiri_error_raise(void *ctx, xmlErrorConstPtr error);
+void noko__structured_error_func_restore(libxmlStructuredErrorHandlerState *handler_state);
+VALUE noko_xml_syntax_error__wrap(xmlErrorConstPtr error);
+void noko__error_array_pusher(void *ctx, xmlErrorConstPtr error);
+NORETURN_DECL void noko__error_raise(void *ctx, xmlErrorConstPtr error);
 void Nokogiri_marshal_xpath_funcall_and_return_values(xmlXPathParserContextPtr ctx, int nargs, VALUE handler,
     const char *function_name) ;
 

--- a/ext/nokogiri/xml_dtd.c
+++ b/ext/nokogiri/xml_dtd.c
@@ -144,7 +144,7 @@ validate(VALUE self, VALUE document)
 
   ctxt = xmlNewValidCtxt();
 
-  xmlSetStructuredErrorFunc((void *)error_list, Nokogiri_error_array_pusher);
+  xmlSetStructuredErrorFunc((void *)error_list, noko__error_array_pusher);
 
   xmlValidateDtd(ctxt, doc, dtd);
 

--- a/ext/nokogiri/xml_sax_push_parser.c
+++ b/ext/nokogiri/xml_sax_push_parser.c
@@ -60,7 +60,7 @@ native_write(VALUE self, VALUE _chunk, VALUE _last_chunk)
   if (xmlParseChunk(ctx, chunk, size, Qtrue == _last_chunk ? 1 : 0)) {
     if (!(xmlCtxtGetOptions(ctx) & XML_PARSE_RECOVER)) {
       xmlErrorConstPtr e = xmlCtxtGetLastError(ctx);
-      Nokogiri_error_raise(NULL, e);
+      noko__error_raise(NULL, e);
     }
   }
 

--- a/ext/nokogiri/xml_syntax_error.c
+++ b/ext/nokogiri/xml_syntax_error.c
@@ -3,7 +3,7 @@
 VALUE cNokogiriXmlSyntaxError;
 
 void
-Nokogiri_structured_error_func_save(libxmlStructuredErrorHandlerState *handler_state)
+noko__structured_error_func_save(libxmlStructuredErrorHandlerState *handler_state)
 {
   /* this method is tightly coupled to the implementation of xmlSetStructuredErrorFunc */
   handler_state->user_data = xmlStructuredErrorContext;
@@ -11,36 +11,38 @@ Nokogiri_structured_error_func_save(libxmlStructuredErrorHandlerState *handler_s
 }
 
 void
-Nokogiri_structured_error_func_save_and_set(libxmlStructuredErrorHandlerState *handler_state,
-    void *user_data,
-    xmlStructuredErrorFunc handler)
+noko__structured_error_func_save_and_set(
+  libxmlStructuredErrorHandlerState *handler_state,
+  void *user_data,
+  xmlStructuredErrorFunc handler
+)
 {
-  Nokogiri_structured_error_func_save(handler_state);
+  noko__structured_error_func_save(handler_state);
   xmlSetStructuredErrorFunc(user_data, handler);
 }
 
 void
-Nokogiri_structured_error_func_restore(libxmlStructuredErrorHandlerState *handler_state)
+noko__structured_error_func_restore(libxmlStructuredErrorHandlerState *handler_state)
 {
   xmlSetStructuredErrorFunc(handler_state->user_data, handler_state->handler);
 }
 
 void
-Nokogiri_error_array_pusher(void *ctx, xmlErrorConstPtr error)
+noko__error_array_pusher(void *ctx, xmlErrorConstPtr error)
 {
   VALUE list = (VALUE)ctx;
   Check_Type(list, T_ARRAY);
-  rb_ary_push(list,  Nokogiri_wrap_xml_syntax_error(error));
+  rb_ary_push(list,  noko_xml_syntax_error__wrap(error));
 }
 
 void
-Nokogiri_error_raise(void *ctx, xmlErrorConstPtr error)
+noko__error_raise(void *ctx, xmlErrorConstPtr error)
 {
-  rb_exc_raise(Nokogiri_wrap_xml_syntax_error(error));
+  rb_exc_raise(noko_xml_syntax_error__wrap(error));
 }
 
 VALUE
-Nokogiri_wrap_xml_syntax_error(xmlErrorConstPtr error)
+noko_xml_syntax_error__wrap(xmlErrorConstPtr error)
 {
   VALUE msg, e, klass;
 

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -397,7 +397,7 @@ rb_xml_xpath_context_evaluate(int argc, VALUE *argv, VALUE rb_context)
     );
   }
 
-  xmlSetStructuredErrorFunc((void *)errors, Nokogiri_error_array_pusher);
+  xmlSetStructuredErrorFunc((void *)errors, noko__error_array_pusher);
   xmlSetGenericErrorFunc((void *)errors, generic_exception_pusher);
 
   xpath = xmlXPathEvalExpression(query, c_context);

--- a/lib/nokogiri/xml/syntax_error.rb
+++ b/lib/nokogiri/xml/syntax_error.rb
@@ -6,6 +6,19 @@ module Nokogiri
     # This class provides information about XML SyntaxErrors.  These
     # exceptions are typically stored on Nokogiri::XML::Document#errors.
     class SyntaxError < ::Nokogiri::SyntaxError
+      class << self
+        def aggregate(errors)
+          return nil if errors.empty?
+          return errors.first if errors.length == 1
+
+          messages = ["Multiple errors encountered:"]
+          errors.each do |error|
+            messages << error.to_s
+          end
+          new(messages.join("\n"))
+        end
+      end
+
       attr_reader :domain
       attr_reader :code
       attr_reader :level

--- a/suppressions/ruby.supp
+++ b/suppressions/ruby.supp
@@ -98,49 +98,22 @@
   fun:evaluate
 }
 {
-  https://github.com/sparklemotion/nokogiri/actions/runs/5354163940/jobs/9710862134
-  # 240 (120 direct, 120 indirect) bytes in 1 blocks are definitely lost in loss record 28,980 of 37,883
-  # *xmlNewNodeEatName (tree.c:2299)
-  # *xmlNewDocNodeEatName (tree.c:2374)
-  # *xmlSAX2StartElementNs (SAX2.c:2255)
-  # *xmlParseStartTag2 (parser.c:9658)
-  # *xmlParseElementStart (parser.c:10043)
-  # *xmlParseContentInternal (parser.c:9908)
-  # *xmlParseElement (parser.c:9983)
-  # *xmlParseDocument (parser.c:10821)
-  # *xmlDoRead (parser.c:15167)
-  # *read_memory (xml_document.c:331)
-  Memcheck:Leak
-  fun:malloc
-  fun:objspace_xmalloc0
-  ...
-  fun:xmlNewNodeEatName
-  fun:xmlNewDocNodeEatName
-  fun:xmlSAX2StartElementNs
-  fun:xmlParseStartTag*
-  fun:xmlParseElementStart
-  fun:xmlParseContentInternal
-  fun:xmlParseElement
-  fun:xmlParseDocument
-  fun:xmlDoRead
-  fun:read_memory
-}
-{
   https://github.com/sparklemotion/nokogiri/actions/runs/4845701723/jobs/8634781681
-  # 240 (120 direct, 120 indirect) bytes in 1 blocks are definitely lost in loss record 28,576 of 36,831
-  #   malloc (vg_replace_malloc.c:381)
-  #   objspace_xmalloc0 (gc.c:12298)
-  #   xmlNewNodeEatName (tree.c:2257)
-  #   xmlNewDocNodeEatName (tree.c:2329)
-  #   xmlSAX2StartElementNs (SAX2.c:2085)
-  #   xmlParseStartTag2 (parser.c:9459)
-  #   xmlParseElementStart (parser.c:9848)
-  #   xmlParseContentInternal (parser.c:9697)
-  #   xmlParseElement (parser.c:9786)
-  #   xmlParseDocument (parser.c:10572)
-  #   xmlCtxtParseDocument (parser.c:13508)
-  #   xmlReadMemory (parser.c:13646)
-  #  *read_memory (xml_document.c:382)
+  # 240 (120 direct, 120 indirect) bytes in 1 blocks are definitely lost in loss record 408 of 452
+  #   malloc (at /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
+  #   objspace_xmalloc0 (gc.c:12617)
+  #  *xmlNewElem (tree.c:2084)
+  #  *xmlNewDocNodeEatName (tree.c:2188)
+  #  *xmlSAX2StartElementNs (SAX2.c:2129)
+  #  *xmlParseStartTag2.constprop.0 (parser.c:9455)
+  #  *xmlParseElementStart (parser.c:9851)
+  #  *xmlParseContentInternal (parser.c:9693)
+  #  *xmlParseElement (parser.c:9789)
+  #  *xmlParseDocument (parser.c:10573)
+  #  *xmlCtxtParseDocument (parser.c:13687)
+  #  *xmlReadMemory (parser.c:13822)
+  #  *noko_xml_document_s_read_memory (xml_document.c:427)
+  #   vm_call_cfunc_with_frame_ (vm_insnhelper.c:3490)
   Memcheck:Leak
   fun:malloc
   fun:objspace_xmalloc0
@@ -148,9 +121,8 @@
   fun:xmlNewDocNodeEatName
   fun:xmlSAX2StartElementNs
   ...
-  fun:xmlParseDocument
-  ...
-  fun:read_memory
+  fun:xmlReadMemory
+  fun:noko_xml_document_s_read_memory
 }
 {
   TODO

--- a/test/xml/test_syntax_error.rb
+++ b/test/xml/test_syntax_error.rb
@@ -2,33 +2,61 @@
 
 require "helper"
 
-module Nokogiri
-  module XML
-    class TestSyntaxError < Nokogiri::TestCase
-      it "#new accepts a message" do
+describe Nokogiri::XML::SyntaxError do
+  it ".new accepts a message" do
+    error = Nokogiri::XML::SyntaxError.new("hello")
+    assert_equal "hello", error.message
+  end
+
+  describe ".aggregate" do
+    describe "when there are no errors" do
+      it "returns nil" do
+        assert_nil(Nokogiri::XML::SyntaxError.aggregate([]))
+      end
+    end
+
+    describe "when there is exactly one error" do
+      it "returns the error" do
         error = Nokogiri::XML::SyntaxError.new("hello")
-        assert_equal "hello", error.message
+        assert_equal(error, Nokogiri::XML::SyntaxError.aggregate([error]))
       end
+    end
 
-      it "describes the syntax error encountered" do
-        if Nokogiri.uses_libxml?
-          bad_doc = Nokogiri::XML("test")
-          error = bad_doc.errors.first
-
-          assert_equal "1:1: FATAL: Start tag expected, '<' not found", error.message
-          assert_equal 1, error.line
-          assert_equal 1, error.column
-          assert_equal 3, error.level
-        else
-          bad_doc = Nokogiri::XML("<root>test</bar>")
-          error = bad_doc.errors.first
-
-          assert_equal "The element type \"root\" must be terminated by the matching end-tag \"</root>\".", error.message
-          assert_nil error.line
-          assert_nil error.column
-          assert_nil error.level
-        end
+    describe "when there are multiple errors" do
+      it "returns a new error with the messages of all errors" do
+        errors = [
+          Nokogiri::XML::SyntaxError.new("hello"),
+          Nokogiri::XML::SyntaxError.new("there"),
+          Nokogiri::XML::SyntaxError.new("world"),
+        ]
+        aggregate = Nokogiri::XML::SyntaxError.aggregate(errors)
+        assert_equal(<<~MSG.chomp, aggregate.to_s)
+          Multiple errors encountered:
+          hello
+          there
+          world
+        MSG
       end
+    end
+  end
+
+  it "describes the syntax error encountered" do
+    if Nokogiri.uses_libxml?
+      bad_doc = Nokogiri::XML("test")
+      error = bad_doc.errors.first
+
+      assert_equal "1:1: FATAL: Start tag expected, '<' not found", error.message
+      assert_equal 1, error.line
+      assert_equal 1, error.column
+      assert_equal 3, error.level
+    else
+      bad_doc = Nokogiri::XML("<root>test</bar>")
+      error = bad_doc.errors.first
+
+      assert_equal "The element type \"root\" must be terminated by the matching end-tag \"</root>\".", error.message
+      assert_nil error.line
+      assert_nil error.column
+      assert_nil error.level
     end
   end
 end


### PR DESCRIPTION

**What problem is this PR intended to solve?**

In places (like document parsing) where it's possible for libxml2 to emit multiple warnings and errors, aggregate these libxml2 errors into a single exception so users can see all the problems.

Previously, we were grabbing the most recent "error" which might just be a warning and not the fatal error preventing parsing from completing. This was misleading and hid the source of the real problem.

Now, if there are multiple errors, they're aggregated into a single Nokogiri::XML::SyntaxError with a message like:

    Multiple errors encountered:
    WARNING: text of warning message
    ERROR: text of error message
    WARNING: text of second warning message

Note that I've also renamed some internal C functions to try to incrementally get consistent with naming.

Closes #2562


**Have you included adequate test coverage?**

Yes.


**Does this change affect the behavior of either the C or the Java implementations?**

It's a cosmetic improvement on the behavior of the CRuby XML and HTML4 parser.

I have not made this improvement to the JRuby implementation, but it should be easy enough to add if someone wishes to do the work.