### PR TITLE
fix(jruby): Schema#validate should not accumulate errors in @errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] Update node GC lifecycle to avoid a potential memory leak with fragments in libxml 2.13.0 caused by changes in `xmlAddChild`. [#3156] @flavorjones
 * [CRuby] libgumbo correctly prints nonstandard element names in error messages. [#3219] @stevecheckoway
 * [JRuby] Fixed some bugs in how `Node#attributes` handles attributes with namespaces. [#2677, #2679] @flavorjones
+* [JRuby] Fix `Schema#validate` to only return the most recent Document's errors. Previously, if multiple documents were validated, this method returned the accumulated errors of all previous documents. [#1282] @flavorjones
+* [JRuby] Fix `Schema#validate` to not clobber the `@errors` instance variable. [#1282] @ flavorjones
 
 
 ### Changed

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -222,7 +222,7 @@ public class XmlSchema extends RubyObject
   IRubyObject
   validate_document_or_file(ThreadContext context, XmlDocument xmlDocument)
   {
-    RubyArray<?> errors = (RubyArray) this.getInstanceVariable("@errors");
+    RubyArray errors = (RubyArray)context.runtime.newEmptyArray();
     ErrorHandler errorHandler = new SchemaErrorHandler(context.runtime, errors);
     setErrorHandler(errorHandler);
 

--- a/ext/nokogiri/xml_relax_ng.c
+++ b/ext/nokogiri/xml_relax_ng.c
@@ -24,7 +24,7 @@ static const rb_data_type_t xml_relax_ng_type = {
  * Validate a Nokogiri::XML::Document against this RelaxNG schema.
  */
 static VALUE
-validate_document(VALUE self, VALUE document)
+noko_xml_relax_ng__validate_document(VALUE self, VALUE document)
 {
   xmlDocPtr doc;
   xmlRelaxNGPtr schema;
@@ -162,5 +162,5 @@ noko_init_xml_relax_ng(void)
   rb_define_singleton_method(cNokogiriXmlRelaxNG, "read_memory", read_memory, -1);
   rb_define_singleton_method(cNokogiriXmlRelaxNG, "from_document", from_document, -1);
 
-  rb_define_private_method(cNokogiriXmlRelaxNG, "validate_document", validate_document, 1);
+  rb_define_private_method(cNokogiriXmlRelaxNG, "validate_document", noko_xml_relax_ng__validate_document, 1);
 }

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -17,12 +17,6 @@ static const rb_data_type_t xml_schema_type = {
   .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
-/*
- * call-seq:
- *  validate_document(document)
- *
- * Validate a Nokogiri::XML::Document against this Schema.
- */
 static VALUE
 validate_document(VALUE self, VALUE document)
 {


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Fixes #1282

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

Brings the JRuby impl in line with the CRuby impl.