### PR TITLE
fix(jruby): empty document should fail validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] libgumbo correctly prints nonstandard element names in error messages. [#3219] @stevecheckoway
 * [JRuby] Fixed some bugs in how `Node#attributes` handles attributes with namespaces. [#2677, #2679] @flavorjones
 * [JRuby] Fix `Schema#validate` to only return the most recent Document's errors. Previously, if multiple documents were validated, this method returned the accumulated errors of all previous documents. [#1282] @flavorjones
-* [JRuby] Fix `Schema#validate` to not clobber the `@errors` instance variable. [#1282] @ flavorjones
+* [JRuby] Fix `Schema#validate` to not clobber the `@errors` instance variable. [#1282] @flavorjones
+* [JRuby] Empty documents fail schema validation as they should. [#783] @flavorjones
 
 
 ### Changed

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -248,6 +248,10 @@ public class XmlSchema extends RubyObject
   protected void
   validate(Document document) throws SAXException, IOException
   {
+    if (document.getDocumentElement() == null) {
+      throw new SAXException("Document is empty");
+    }
+
     DOMSource docSource = new DOMSource(document);
     validator.validate(docSource);
   }

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -180,11 +180,9 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
 
       it "validate_empty_document" do
         doc = Nokogiri::XML("")
-        assert(errors = xsd.validate(doc))
 
-        pending_if("https://github.com/sparklemotion/nokogiri/issues/783", Nokogiri.jruby?) do
-          assert_equal(1, errors.length)
-        end
+        assert(errors = xsd.validate(doc))
+        assert_equal(1, errors.length)
       end
 
       it "valid?" do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Brings the behavior in line with CRuby's impl.

Closes #783.

**Have you included adequate test coverage?**

Yes. Test from #2641.

**Does this change affect the behavior of either the C or the Java implementations?**

Bring Java in line with CRuby.