### PR TITLE
fix: Schema#validate returns errors on empty and malformed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 * `Node#clone`, `NodeSet#clone`, and `*::Document#clone` all properly copy the metaclass of the original as expected. Previously, `#clone` had been aliased to `#dup` for these classes (since v1.3.0 in 2009). [#316, #3117] @flavorjones
 * CSS queries for pseudo-selectors that cannot be translated into XPath expressions now raise a more descriptive `Nokogiri::CSS::SyntaxError` when they are parsed. Previously, an invalid XPath expression was evaluated and a hard-to-understand XPath error was raised by the query engine. [#3193] @flavorjones
+* `Schema#validate` returns errors on empty and malformed files. Previously, it would return errors on empty/malformed Documents, but not when reading from files. [#642] @flavorjones
 * [CRuby] libgumbo (the HTML5 parser) treats reaching max-depth as EOF. This addresses a class of issues when the parser is interrupted in this way. [#3121] @stevecheckoway
 * [CRuby] Update node GC lifecycle to avoid a potential memory leak with fragments in libxml 2.13.0 caused by changes in `xmlAddChild`. [#3156] @flavorjones
 * [CRuby] libgumbo correctly prints nonstandard element names in error messages. [#3219] @stevecheckoway

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -202,14 +202,22 @@ public class XmlSchema extends RubyObject
 
     XmlDomParserContext ctx = new XmlDomParserContext(runtime, RubyFixnum.newFixnum(runtime, 1L));
     ctx.setInputSourceFile(context, file);
-    XmlDocument xmlDocument = ctx.parse(context, getNokogiriClass(runtime, "Nokogiri::XML::Document"), context.nil);
-    return validate_document_or_file(context, xmlDocument);
+    try {
+      XmlDocument xmlDocument = ctx.parse(context, getNokogiriClass(runtime, "Nokogiri::XML::Document"), context.nil);
+      return validate_document_or_file(context, xmlDocument);
+    } catch (Exception ex) {
+      RubyArray errors = (RubyArray)context.runtime.newEmptyArray();
+      XmlSyntaxError xmlSyntaxError = XmlSyntaxError.createXMLSyntaxError(context.runtime);
+      xmlSyntaxError.setException(ex);
+      errors.append(xmlSyntaxError);
+      return errors;
+    }
   }
 
   IRubyObject
   validate_document_or_file(ThreadContext context, XmlDocument xmlDocument)
   {
-    RubyArray errors = (RubyArray)context.runtime.newEmptyArray();
+    RubyArray errors = context.runtime.newEmptyArray();
     ErrorHandler errorHandler = new SchemaErrorHandler(context.runtime, errors);
     setErrorHandler(errorHandler);
 

--- a/ext/nokogiri/xml_schema.c
+++ b/ext/nokogiri/xml_schema.c
@@ -43,9 +43,15 @@ noko_xml_schema__validate_document(VALUE self, VALUE document)
     (void *)errors
   );
 
-  xmlSchemaValidateDoc(valid_ctxt, doc);
+  int status = xmlSchemaValidateDoc(valid_ctxt, doc);
 
   xmlSchemaFreeValidCtxt(valid_ctxt);
+
+  if (status != 0) {
+    if (RARRAY_LEN(errors) == 0) {
+      rb_ary_push(errors, rb_str_new2("Could not validate document"));
+    }
+  }
 
   return errors;
 }
@@ -76,9 +82,15 @@ noko_xml_schema__validate_file(VALUE self, VALUE rb_filename)
     (void *)errors
   );
 
-  xmlSchemaValidateFile(valid_ctxt, filename, 0);
+  int status = xmlSchemaValidateFile(valid_ctxt, filename, 0);
 
   xmlSchemaFreeValidCtxt(valid_ctxt);
+
+  if (status != 0) {
+    if (RARRAY_LEN(errors) == 0) {
+      rb_ary_push(errors, rb_str_new2("Could not validate file."));
+    }
+  }
 
   return errors;
 }


### PR DESCRIPTION

**What problem is this PR intended to solve?**

`Schema#validate` now returns errors on empty and malformed files. Previously, it would return errors on empty/malformed Documents, but not when reading from files.

Closes #642


**Have you included adequate test coverage?**

Yes!


**Does this change affect the behavior of either the C or the Java implementations?**

This fixes different bugs on CRuby and JRuby, but both impls agree with each other now.
