### PR TITLE
tidy tests and coverage

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -264,7 +264,7 @@ module Nokogiri
           if new_parent.nil?
             raise "Failed to parse '#{node_or_tags}' in the context of a '#{context_node.name}' element"
           end
-        when XML::Node
+        when Node
           new_parent = node_or_tags.dup
         else
           raise ArgumentError, "Requires a String or Node argument, and cannot accept a #{node_or_tags.class}"

--- a/test/css/test_css.rb
+++ b/test/css/test_css.rb
@@ -60,7 +60,7 @@ describe Nokogiri::CSS do
 
       it "raises a SyntaxError exception if the query is empty" do
         e = assert_raises(Nokogiri::CSS::SyntaxError) { Nokogiri::CSS.xpath_for("") }
-        assert_includes("empty CSS selector", e.message)
+        assert_equal("empty CSS selector", e.message)
       end
 
       it "raises an TypeError exception if the query is not a string" do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,7 +12,7 @@
 # - NOKOGIRI_MEMORY_SUITE: read more in test/test_memory_usage.rb
 #
 
-unless ENV["RUBY_MEMCHECK_RUNNING"]
+unless ENV["RUBY_MEMCHECK_RUNNING"] || ENV["NCPU"]
   require "simplecov"
   SimpleCov.start do
     add_filter "/test/"
@@ -49,6 +49,7 @@ warn
 
 require "minitest/autorun"
 require "minitest/benchmark"
+
 if ENV["NCPU"] && !Nokogiri.jruby?
   require "minitest/parallel_fork"
   warn "Running parallel tests with NCPU=#{ENV["NCPU"].inspect}"

--- a/test/xml/test_attr.rb
+++ b/test/xml/test_attr.rb
@@ -5,16 +5,9 @@ require "helper"
 module Nokogiri
   module XML
     class TestAttr < Nokogiri::TestCase
-      def test_new
-        100.times do
-          doc = Nokogiri::XML::Document.new
-          assert(doc)
-          assert(Nokogiri::XML::Attr.new(doc, "foo"))
-        end
-      end
-
       def test_new_raises_argerror_on_nondocument
         document = Nokogiri::XML("<root><foo/></root>")
+
         assert_raises(ArgumentError) do
           Nokogiri::XML::Attr.new(document.at_css("foo"), "bar")
         end
@@ -25,6 +18,7 @@ module Nokogiri
         address = xml.xpath("//address")[3]
         street = address.attributes["street"]
         street.content = "Y&ent1;"
+
         assert_equal("Y&ent1;", street.value)
       end
 
@@ -37,35 +31,42 @@ module Nokogiri
         address = xml.xpath("//address")[3]
         street = address.attributes["street"]
         street.value = "Y&ent1;"
+
         assert_equal("Y&ent1;", street.value)
-        assert_includes(%{ street="Y&amp;ent1;"}, street.to_xml)
+        assert_equal(%{street="Y&amp;ent1;"}, street.to_xml.strip)
       end
 
       def test_set_value_with_entity_string_in_html_file
         html = Nokogiri::HTML("<html><body><div foo='asdf'>")
         foo = html.at_css("div").attributes["foo"]
         foo.value = "Y&ent1;"
+
         assert_equal("Y&ent1;", foo.value)
-        assert_includes(%{ foo="Y&amp;ent1;"}, foo.to_html)
+        assert_equal(%{foo="Y&amp;ent1;"}, foo.to_html.strip)
       end
 
       def test_set_value_with_blank_string_in_html_file
         html = Nokogiri::HTML("<html><body><div foo='asdf'>")
         foo = html.at_css("div").attributes["foo"]
         foo.value = ""
+
         assert_equal("", foo.value)
-        assert_includes(%{ foo=""}, foo.to_html)
+        assert_equal(%{foo=""}, foo.to_html.strip)
       end
 
       def test_set_value_with_nil_in_html_file
         html = Nokogiri::HTML("<html><body><div foo='asdf'>")
         foo = html.at_css("div").attributes["foo"]
         foo.value = nil
-        assert_equal("", foo.value) # this may be surprising to people, see xmlGetPropNodeValueInternal
+
+        # this may be surprising to people, see xmlGetPropNodeValueInternal
+        assert_equal("", foo.value)
         if Nokogiri.uses_libxml?
-          assert_includes(%{ foo}, foo.to_html) # libxml2 still emits a boolean attribute at serialize-time
+          # libxml2 still emits a boolean attribute at serialize-time
+          assert_equal(%{foo}, foo.to_html.strip)
         else
-          assert_includes(%{ foo=""}, foo.to_html) # jruby does not
+          # jruby does not
+          assert_equal(%{foo=""}, foo.to_html.strip)
         end
       end
 
@@ -73,25 +74,32 @@ module Nokogiri
         html = Nokogiri::HTML("<html><body><div disabled='disabled'>")
         disabled = html.at_css("div").attributes["disabled"]
         disabled.value = ""
+
         assert_equal("", disabled.value)
-        assert_includes(%{ disabled}, disabled.to_html) # we still emit a boolean attribute at serialize-time!
+        # we still emit a boolean attribute at serialize-time!
+        assert_equal(%{disabled}, disabled.to_html.strip)
       end
 
       def test_set_value_of_boolean_attr_with_nil_in_html_file
         html = Nokogiri::HTML("<html><body><div disabled='disabled'>")
         disabled = html.at_css("div").attributes["disabled"]
         disabled.value = nil
-        assert_equal("", disabled.value) # this may be surprising to people, see xmlGetPropNodeValueInternal
-        assert_includes(%{ disabled}, disabled.to_html) # but we emit a boolean attribute at serialize-time
+
+        # this may be surprising to people, see xmlGetPropNodeValueInternal
+        assert_equal("", disabled.value)
+        # but we emit a boolean attribute at serialize-time
+        assert_equal(%{disabled}, disabled.to_html.strip)
       end
 
       def test_unlink # aliased as :remove
         xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE)
         address = xml.xpath("/staff/employee/address").first
+
         assert_equal("Yes", address["domestic"])
 
         attr = address.attribute_nodes.first
         return_val = attr.unlink
+
         assert_nil(address["domestic"])
         assert_equal(attr, return_val)
       end
@@ -102,9 +110,9 @@ module Nokogiri
             <div f:myattr='foo'></div>
           </root>
         EOXML
-
         node = doc.at_css("div")
         attr = node.attributes["myattr"]
+
         assert_equal("http://flavorjon.es/", attr.namespace.href)
       end
 
@@ -114,10 +122,10 @@ module Nokogiri
             <div f:myattr='foo'></div>
           </root>
         EOXML
-
         node = doc.at_css("div")
         attr = node.attributes["myattr"]
         attr.add_namespace("fizzle", "http://fizzle.com/")
+
         assert_equal("http://fizzle.com/", attr.namespace.href)
       end
     end

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -1438,12 +1438,22 @@ module Nokogiri
             end
           end
 
+          it "raises an error if the input is not parseable" do
+            thing = doc.at_css("thing")
+
+            e = assert_raises(RuntimeError) do
+              thing.wrap("<<")
+            end
+            assert_includes(e.message, "Failed to parse '<<' in the context of a 'root' element")
+          end
+
           it "raises an ArgumentError on other types" do
             thing = doc.at_css("thing")
 
-            assert_raises(ArgumentError) do
+            e = assert_raises(ArgumentError) do
               thing.wrap(1)
             end
+            assert_includes(e.message, "Requires a String or Node argument, and cannot accept a Integer")
           end
         end
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Tidying.

- prefer `assert_equal` to `assert_includes` where we're checking a string literal or it's an exact match
- add test coverage for an exceptional branch in `Node#wrap`
- don't collect SimpleCov info if we're using parallel_fork to run the tests
