### PR TITLE
ci: windows upstream needs liblzma

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -34,7 +34,7 @@ jobs:
           ruby-version: "3.3"
           apt-get: "autogen libtool shtool"
           brew: "automake autogen libtool shtool"
-          mingw: "autotools"
+          mingw: "autotools xz"
           bundler-cache: true
           bundler: latest
       - name: Setup libxml2


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Upstream workflow started failing on xmlsoft windows build because it no longer can find liblzma. (I'm not sure why this is, the runner image manifests don't seem to have a relevant change in the last week ...)
