### PR TITLE
fix(jruby): Reader#outer_xml and #inner_xml encode entities properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [JRuby] Empty documents fail schema validation as they should. [#783] @flavorjones
 * [JRuby] SAX parsing now respects the `#replace_entities` attribute, which defaults to `false`. Previously this flag defaulted to `true` and was completely ignored. [#614] @flavorjones
 * [JRuby] The SAX callback `Document#start_element_namespace` received a blank string for the URI when a namespace was not present. It now receives `nil` (as does the CRuby impl). [#3265] @flavorjones
+* [JRuby] `Reader#outer_xml` and `#inner_xml` encode entities properly. [#1523] @flavorjones
 
 
 ### Changed

--- a/ext/java/nokogiri/internals/ReaderNode.java
+++ b/ext/java/nokogiri/internals/ReaderNode.java
@@ -557,7 +557,7 @@ public abstract class ReaderNode
     public String
     getString()
     {
-      return value;
+      return encodeJavaString(value).toString();
     }
   }
 

--- a/test/xml/test_reader.rb
+++ b/test/xml/test_reader.rb
@@ -452,16 +452,27 @@ module Nokogiri
       end
 
       def test_inner_xml
-        str = "<x><y>hello</y></x>"
+        str = "<x><y>hello &amp; goodbye</y></x>"
         reader = Nokogiri::XML::Reader.from_memory(str)
 
         reader.read
 
-        assert_equal("<y>hello</y>", reader.inner_xml)
+        assert_equal("<y>hello &amp; goodbye</y>", reader.inner_xml)
       end
 
       def test_outer_xml
-        str = ["<x><y>hello</y></x>", "<y>hello</y>", "hello", "<y/>", "<x/>"]
+        str = [
+          "<x><y>hello &amp; goodbye</y></x>",
+          "<y>hello &amp; goodbye</y>",
+          "hello &amp; goodbye",
+          "<y/>",
+          "<x/>",
+        ]
+        if Nokogiri.jruby?
+          # jruby will split the string up into three nodes, shrug.
+          str.delete_at(2)
+          str.insert(2, "hello ", "&amp;", " goodbye")
+        end
         reader = Nokogiri::XML::Reader.from_memory(str.first)
 
         xml = []


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Closes #1523


**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

This makes the Java impl behave like the C impl.
