### PR TITLE
test: add test coverage describing how pushparser handles empty docs

### DIFF
--- a/lib/nokogiri/xml/sax/push_parser.rb
+++ b/lib/nokogiri/xml/sax/push_parser.rb
@@ -52,6 +52,9 @@ module Nokogiri
         ###
         # Finish the parsing.  This method is only necessary for
         # Nokogiri::XML::SAX::Document#end_document to be called.
+        #
+        # ⚠ Note that empty documents are treated as an error when using the libxml2-based
+        # implementation (CRuby), but are fine when using the Xerces-based implementation (JRuby).
         def finish
           write("", true)
         end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

The behavior is different between Java and C impls in a way that I don't care enough to fix. Let's document the difference and move on with our lives.

Closes #1758

**Have you included adequate test coverage?**

Yes.


**Does this change affect the behavior of either the C or the Java implementations?**

N/A