### PR TITLE
tests: handle upstream libxml2 returning null for UTF-8 enc handler

### DIFF
--- a/lib/nokogiri/encoding_handler.rb
+++ b/lib/nokogiri/encoding_handler.rb
@@ -6,9 +6,9 @@ module Nokogiri
     # Popular encoding aliases not known by all iconv implementations that Nokogiri should support.
     USEFUL_ALIASES = {
       # alias_name => true_name
-      "NOKOGIRI-SENTINEL" => "UTF-8", # indicating the Nokogiri has installed aliases
+      "ISO-2022-JP" => "ISO-2022-JP", # only for JRuby tests, this is a no-op in CRuby
+      "NOKOGIRI-SENTINEL" => "ISO-2022-JP", # indicating the Nokogiri has installed aliases
       "Windows-31J" => "CP932", # Windows-31J is the IANA registered name of CP932.
-      "UTF-8" => "UTF-8", # for JRuby tests, this is a no-op in CRuby
     }
 
     class << self

--- a/test/test_encoding_handler.rb
+++ b/test/test_encoding_handler.rb
@@ -11,23 +11,23 @@ describe Nokogiri::EncodingHandler do
 
   it :test_get do
     refute_nil(Nokogiri::EncodingHandler["NOKOGIRI-SENTINEL"])
-    refute_nil(Nokogiri::EncodingHandler["UTF-8"])
+    refute_nil(Nokogiri::EncodingHandler["ISO-2022-JP"])
     assert_nil(Nokogiri::EncodingHandler["alsdkjfhaldskjfh"])
   end
 
   it :test_name do
-    eh = Nokogiri::EncodingHandler["UTF-8"]
-    assert_equal("UTF-8", eh.name)
+    eh = Nokogiri::EncodingHandler["ISO-2022-JP"]
+    assert_equal("ISO-2022-JP", eh.name)
   end
 
   it :test_alias do
-    Nokogiri::EncodingHandler.alias("UTF-8", "UTF-18")
-    assert_equal("UTF-8", Nokogiri::EncodingHandler["UTF-18"].name)
+    Nokogiri::EncodingHandler.alias("ISO-2022-JP", "UTF-18")
+    assert_equal("ISO-2022-JP", Nokogiri::EncodingHandler["UTF-18"].name)
   end
 
   it :test_cleanup_aliases do
     assert_nil(Nokogiri::EncodingHandler["UTF-9"])
-    Nokogiri::EncodingHandler.alias("UTF-8", "UTF-9")
+    Nokogiri::EncodingHandler.alias("ISO-2022-JP", "UTF-9")
     refute_nil(Nokogiri::EncodingHandler["UTF-9"])
 
     Nokogiri::EncodingHandler.clear_aliases!
@@ -36,7 +36,7 @@ describe Nokogiri::EncodingHandler do
 
   it :test_delete do
     assert_nil(Nokogiri::EncodingHandler["UTF-9"])
-    Nokogiri::EncodingHandler.alias("UTF-8", "UTF-9")
+    Nokogiri::EncodingHandler.alias("ISO-2022-JP", "UTF-9")
     refute_nil(Nokogiri::EncodingHandler["UTF-9"])
 
     Nokogiri::EncodingHandler.delete("UTF-9")


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Example failure: https://github.com/sparklemotion/nokogiri/actions/runs/9774049613/job/26981486984

Let's just work around it in the tests. The behavior we're testing isn't specific to UTF-8, so let's just swap in ISO-2022-JP.

gnome/libxml2@6d8427dc

Tagging @nwellnhof just for awareness.


**Have you included adequate test coverage?**

Yes


**Does this change affect the behavior of either the C or the Java implementations?**

N/A
