### PR TITLE
ext: don't split the compiler flags when appending env vars

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -670,9 +670,9 @@ if arg_config("--prevent-strip")
 end
 
 # adopt environment config
-append_cflags(ENV["CFLAGS"].split) unless ENV["CFLAGS"].nil?
-append_cppflags(ENV["CPPFLAGS"].split) unless ENV["CPPFLAGS"].nil?
-append_ldflags(ENV["LDFLAGS"].split) unless ENV["LDFLAGS"].nil?
+append_cflags(ENV["CFLAGS"]) unless ENV["CFLAGS"].nil?
+append_cppflags(ENV["CPPFLAGS"]) unless ENV["CPPFLAGS"].nil?
+append_ldflags(ENV["LDFLAGS"]) unless ENV["LDFLAGS"].nil?
 $LIBS = concat_flags($LIBS, ENV["LIBS"])
 
 # libgumbo uses C90/C99 features, see #2302


### PR DESCRIPTION

**What problem is this PR intended to solve?**

See https://github.com/ruby/ruby/pull/11085 for discussion


**Have you included adequate test coverage?**

Existing test suite should be sufficient to tell us if this breaks things.

**Does this change affect the behavior of either the C or the Java implementations?**

N/A