### PR TITLE
dep: update vendored libxml2 → 2.13.2, libxslt → 1.1.42

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,13 +1,13 @@
 ---
 libxml2:
-  version: "2.13.1"
-  sha256: "25239263dc37f5f55a5393eff27b35f0b7d9ea4b2a7653310598ea8299e3b741"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.1.sha256sum
+  version: "2.13.2"
+  sha256: "e7c8f5e0b5542159e0ddc409c22c9164304b581eaa9930653a76fb845b169263"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.2.sha256sum
 
 libxslt:
-  version: "1.1.41"
-  sha256: "3ad392af91115b7740f7b50d228cc1c5fc13afc1da7f16cb0213917a37f71bda"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.41.sha256sum
+  version: "1.1.42"
+  sha256: "85ca62cac0d41fc77d3f6033da9df6fd73d20ea2fc18b0a3609ffb4110e1baeb"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.42.sha256sum
 
 zlib:
   version: "1.3.1"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Update vendored libxml2 and libxslt:

- https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.2
- https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.42

