### PR TITLE
fuzz: limit input size

### DIFF
--- a/gumbo-parser/fuzzer/parse_fuzzer.cc
+++ b/gumbo-parser/fuzzer/parse_fuzzer.cc
@@ -37,7 +37,8 @@ int SanityCheckPointers(const char* input, size_t input_length, const GumboNode*
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  if (size < 10)
+  /* arbitrary upper size limit to avoid "out-of-memory in parse_fuzzer" reports */
+  if (size < 10 | size > 100000)
   {
       return 0;
   }


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Place an upper limit on the input size to the fuzzer, to avoid naive out-of-memory failure reports, which we've been getting regularly.

See:

- [63481 - nokogiri:parse_fuzzer: Out-of-memory in parse_fuzzer - oss-fuzz](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63481)

Earlier I had given up on fixing this because I was trying to configure higher memory limits; this is a more straightforward solution (and one suggested by https://google.github.io/oss-fuzz/getting-started/new-project-guide/#input-size).
