### PR TITLE
dep: update libxml2 to v2.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ### Dependencies
 
-* [CRuby] Vendored libxml2 is updated to [v2.13.2](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.2). [#3230] @flavorjones
+* [CRuby] Vendored libxml2 is updated to [v2.13.3](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.3). [#3230] @flavorjones
 * [CRuby] Vendored libxslt is updated to [v1.1.42](https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.42). [#3230] @flavorjones
 * [CRuby] Minimum supported version of libxml2 raised to v2.7.7 (released 2010-03-15) from v2.6.21. [#3232] @flavorjones
 * [JRuby] Minimum supported versino of Java raised to 8 (released 2014-03-18) from 7. [#3134] @flavorjones 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.13.2"
-  sha256: "e7c8f5e0b5542159e0ddc409c22c9164304b581eaa9930653a76fb845b169263"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.2.sha256sum
+  version: "2.13.3"
+  sha256: "0805d7c180cf09caad71666c7a458a74f041561a532902454da5047d83948138"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.3.sha256sum
 
 libxslt:
   version: "1.1.42"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Update packaged libxml2, see https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.3
