### PR TITLE
dep: update libxml2 to v2.12.9 (branch v1.16.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## v1.16.next / unreleased
+
+## Dependencies
+
+* [CRuby] Vendored libxml2 is updated to [v2.12.9](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.9), which the upstream release notes state is a security release to address CVE-2024-40896. Nokogiri's maintainers believe this vulnerability does not affect users of Nokogiri, but we advise upgrading at your earliest convenience anyway.
+
+
 ## v1.16.6 / 2024-06-13
 
 ## Dependencies

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.12.8"
-  sha256: "43ad877b018bc63deb2468d71f95219c2fac196876ef36d1bee51d226173ec93"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.8.sha256sum
+  version: "2.12.9"
+  sha256: "59912db536ab56a3996489ea0299768c7bcffe57169f0235e7f962a91f483590"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.9.sha256sum
 
 libxslt:
   version: "1.1.39"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

See https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.9

Addresses CVE-2024-40896 which Nokogiri maintainers believe does not affect Nokogiri users.

