### PR TITLE
fix: IO handling in HTML4::DocumentFragment.parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ We've resolved many long-standing bugs in the various schema classes, validation
 * CSS queries for pseudo-selectors that cannot be translated into XPath expressions now raise a more descriptive `Nokogiri::CSS::SyntaxError` when they are parsed. Previously, an invalid XPath expression was evaluated and a hard-to-understand XPath error was raised by the query engine. [#3193] @flavorjones
 * `Schema#validate` returns errors on empty and malformed files. Previously, it would return errors on empty/malformed Documents, but not when reading from files. [#642] @flavorjones
 * `XML::Builder` is now consistent with how it sets block scope. Previously, missing methods with blocks on dynamically-created nodes were always handled by invoking `instance_eval(&block)` on the Builder, even when the Builder was yielding self for all other missing methods with blocks. [#1041] @flavorjones
+* `HTML4::DocumentFragment.parse` accepts `IO` input. Previously, it required a string and would raise a `TypeError` when passed an `IO`. [#2069] @sharvy
 * [CRuby] libgumbo (the HTML5 parser) treats reaching max-depth as EOF. This addresses a class of issues when the parser is interrupted in this way. [#3121] @stevecheckoway
 * [CRuby] Update node GC lifecycle to avoid a potential memory leak with fragments in libxml 2.13.0 caused by changes in `xmlAddChild`. [#3156] @flavorjones
 * [CRuby] libgumbo correctly prints nonstandard element names in error messages. [#3219] @stevecheckoway
@@ -85,7 +86,6 @@ We've resolved many long-standing bugs in the various schema classes, validation
 * [JRuby] SAX parsing now respects the `#replace_entities` attribute, which defaults to `false`. Previously this flag defaulted to `true` and was completely ignored. [#614] @flavorjones
 * [JRuby] The SAX callback `Document#start_element_namespace` received a blank string for the URI when a namespace was not present. It now receives `nil` (as does the CRuby impl). [#3265] @flavorjones
 * [JRuby] `Reader#outer_xml` and `#inner_xml` encode entities properly. [#1523] @flavorjones
-* `HTML4::DocumentFragment.parse` can now handle IO objects. Previously, it would raise a `TypeError`. [#2069] @sharvy
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ We've resolved many long-standing bugs in the various schema classes, validation
 * [JRuby] SAX parsing now respects the `#replace_entities` attribute, which defaults to `false`. Previously this flag defaulted to `true` and was completely ignored. [#614] @flavorjones
 * [JRuby] The SAX callback `Document#start_element_namespace` received a blank string for the URI when a namespace was not present. It now receives `nil` (as does the CRuby impl). [#3265] @flavorjones
 * [JRuby] `Reader#outer_xml` and `#inner_xml` encode entities properly. [#1523] @flavorjones
+* `HTML4::DocumentFragment.parse` can now handle IO objects. Previously, it would raise a `TypeError`. [#2069] @sharvy
 
 
 ### Changed

--- a/lib/nokogiri/html4/document_fragment.rb
+++ b/lib/nokogiri/html4/document_fragment.rb
@@ -3,31 +3,49 @@
 module Nokogiri
   module HTML4
     class DocumentFragment < Nokogiri::XML::DocumentFragment
-      ####
-      # Parse HTML fragment. +tags+ may be a String, or any object that
-      # responds to _read_ and _close_ such as an IO, or StringIO.
       #
-      # +encoding+ is the encoding that should be used when processing the document.
-      # If not specified, it will be automatically detected.
+      # :call-seq:
+      #   parse(tags) => DocumentFragment
+      #   parse(tags, encoding) => DocumentFragment
+      #   parse(tags, encoding, options) => DocumentFragment
+      #   parse(tags, encoding) { |options| ... } => DocumentFragment
       #
-      # +options+ is a number that sets options in the parser, such as
-      # Nokogiri::XML::ParseOptions::DEFAULT_HTML. See the constants in
-      # Nokogiri::XML::ParseOptions.
+      # Parse an HTML4 fragment.
       #
-      # This method returns a new DocumentFragment. If a block is given, it will be
-      # passed to the new DocumentFragment as an argument.
+      # [Parameters]
+      # - +tags+ (optional String, or any object that responds to +#read+ such as an IO, or
+      #   StringIO)
+      # - +encoding+ (optional String) the name of the encoding that should be used when processing
+      #   the document.  (default +nil+ for auto-detection)
+      # - +options+ (optional) configuration object that sets options during parsing, such as
+      #   Nokogiri::XML::ParseOptions::RECOVER. See Nokogiri::XML::ParseOptions for more
+      #   information.
       #
-      # Examples:
+      # [Yields] If present, the block will be passed a Nokogiri::XML::ParseOptions object to modify
+      #   before the fragment is parsed. See Nokogiri::XML::ParseOptions for more information.
+      #
+      # [Returns] DocumentFragment
+      #
+      # *Example:* Parsing a string
+      #
       #   fragment = DocumentFragment.parse("<div>Hello World</div>")
       #
-      #   file = File.open("fragment.html")
-      #   fragment = DocumentFragment.parse(file)
+      # *Example:* Parsing an IO
       #
-      #   fragment = DocumentFragment.parse("<div>こんにちは世界</div>", "UTF-8")
-      #
-      #   DocumentFragment.parse("<div>Hello World") do |fragment|
-      #     puts fragment.at_css("div").content
+      #   fragment = File.open("fragment.html") do |file|
+      #     DocumentFragment.parse(file)
       #   end
+      #
+      # *Example:* Specifying encoding
+      #
+      #   fragment = DocumentFragment.parse(input, "EUC-JP")
+      #
+      # *Example:* Setting parse options dynamically
+      #
+      #   DocumentFragment.parse("<div>Hello World") do |options|
+      #     options.huge.pedantic
+      #   end
+      #
       def self.parse(tags, encoding = nil, options = XML::ParseOptions::DEFAULT_HTML, &block)
         doc = HTML4::Document.new
 
@@ -67,6 +85,8 @@ module Nokogiri
         new(doc, tags, nil, options, &block)
       end
 
+      # It's recommended to use either DocumentFragment.parse or XML::Node#parse rather than call this
+      # method directly.
       def initialize(document, tags = nil, ctx = nil, options = XML::ParseOptions::DEFAULT_HTML) # rubocop:disable Lint/MissingSuper
         return self unless tags
 

--- a/test/html4/test_document_fragment.rb
+++ b/test/html4/test_document_fragment.rb
@@ -270,6 +270,15 @@ module Nokogiri
           assert_instance_of(Nokogiri::HTML4::DocumentFragment, duplicate)
         end
 
+        def test_parse_with_io
+          fragment = Nokogiri::HTML4::DocumentFragment.parse(StringIO.new("<div>hello</div>"), "UTF-8")
+          assert_instance_of(HTML4::DocumentFragment, fragment)
+          assert_equal("<div>hello</div>", fragment.to_s)
+
+          fragment = Nokogiri::HTML4::DocumentFragment.parse(StringIO.new("<div>hello</div>"))
+          assert_equal("<div>hello</div>", fragment.to_s)
+        end
+
         describe "encoding" do
           describe "#fragment" do
             it "parses an encoded string" do


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**
Previously an exception (TypeError: no implicit conversion of File into String) would be raised.

Fixes: #2069 
<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**
Yes.
<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**
No.
<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
