### PR TITLE
dep: bump libxml2 min required version to v2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 * [CRuby] Vendored libxml2 is updated to [v2.13.3](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.3). [#3230] @flavorjones
 * [CRuby] Vendored libxslt is updated to [v1.1.42](https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.42). [#3230] @flavorjones
-* [CRuby] Minimum supported version of libxml2 raised to v2.7.7 (released 2010-03-15) from v2.6.21. [#3232] @flavorjones
+* [CRuby] Minimum supported version of libxml2 raised to v2.9.2 (released 2014-10-16) from v2.6.21. [#3232, #3287] @flavorjones
 * [JRuby] Minimum supported versino of Java raised to 8 (released 2014-03-18) from 7. [#3134] @flavorjones 
 * [CRuby] Update to rake-compiler-dock v1.5.1 for building precompiled native gems. [#3216] @flavorjones
 

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -12,8 +12,8 @@ require "pathname"
 
 # helpful constants
 PACKAGE_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
-REQUIRED_LIBXML_VERSION = "2.7.7"
-RECOMMENDED_LIBXML_VERSION = "2.9.3"
+REQUIRED_LIBXML_VERSION = "2.9.2"
+RECOMMENDED_LIBXML_VERSION = "2.12.0"
 
 REQUIRED_MINI_PORTILE_VERSION = "~> 2.8.2" # keep this version in sync with the one in the gemspec
 REQUIRED_PKG_CONFIG_VERSION = "~> 1.1"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

I'm deciding to drop support for earlier versions because:

- 2.7.7 nanohttp.c doesn't compile on modern systems
- 2.8.0 doesn't have PARSE_BIG_LINES, GNOME/libxml2@968a03a2 introduced it in 2.9.0
- 2.9.0 and 2.9.1 have the xpath optimization bug that ruined our CSS queries in :first-child broken with libxml 2.9.0 #829, GNOME/libxml2@b4bcba23 fixed it in 2.9.2

Also, bump the min recommended version to v2.12.0 because Nick has fixed a lot of long-standing issues upstream. ♥ ♥ ♥

Followup to #3232
Closes #3287


**Have you included adequate test coverage?**

Existing coverage is sufficient.


**Does this change affect the behavior of either the C or the Java implementations?**

No.
