### PR TITLE
dep: update vendored libxml2 to 2.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ### Dependencies
 
-* [CRuby] Vendored libxml2 is updated to [v2.13.3](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.3). [#3230] @flavorjones
-* [CRuby] Vendored libxslt is updated to [v1.1.42](https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.42). [#3230] @flavorjones
+* [CRuby] Vendored libxml2 is updated to [v2.13.4](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.4). @flavorjones
+* [CRuby] Vendored libxslt is updated to [v1.1.42](https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.42). @flavorjones
 * [CRuby] Minimum supported version of libxml2 raised to v2.9.2 (released 2014-10-16) from v2.6.21. [#3232, #3287] @flavorjones
 * [JRuby] Minimum supported versino of Java raised to 8 (released 2014-03-18) from 7. [#3134] @flavorjones 
 * [CRuby] Update to rake-compiler-dock v1.5.1 for building precompiled native gems. [#3216] @flavorjones

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.13.3"
-  sha256: "0805d7c180cf09caad71666c7a458a74f041561a532902454da5047d83948138"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.3.sha256sum
+  version: "2.13.4"
+  sha256: "65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.4.sha256sum
 
 libxslt:
   version: "1.1.42"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Update vendored libxml2 to v2.13.4

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.4
