### PR TITLE
Make available the XPath path of the node where a SyntaxError occurred during Schema validation

### DIFF
--- a/ext/nokogiri/xml_syntax_error.c
+++ b/ext/nokogiri/xml_syntax_error.c
@@ -44,6 +44,7 @@ noko__error_raise(void *ctx, xmlErrorConstPtr error)
 VALUE
 noko_xml_syntax_error__wrap(xmlErrorConstPtr error)
 {
+  xmlChar *c_path ;
   VALUE msg, e, klass;
 
   klass = cNokogiriXmlSyntaxError;
@@ -61,16 +62,21 @@ noko_xml_syntax_error__wrap(xmlErrorConstPtr error)
       );
 
   if (error) {
+    c_path = xmlGetNodePath(error->node);
+
     rb_iv_set(e, "@domain", INT2NUM(error->domain));
     rb_iv_set(e, "@code", INT2NUM(error->code));
     rb_iv_set(e, "@level", INT2NUM((short)error->level));
     rb_iv_set(e, "@file", RBSTR_OR_QNIL(error->file));
     rb_iv_set(e, "@line", INT2NUM(error->line));
+    rb_iv_set(e, "@path", RBSTR_OR_QNIL(c_path));
     rb_iv_set(e, "@str1", RBSTR_OR_QNIL(error->str1));
     rb_iv_set(e, "@str2", RBSTR_OR_QNIL(error->str2));
     rb_iv_set(e, "@str3", RBSTR_OR_QNIL(error->str3));
     rb_iv_set(e, "@int1", INT2NUM(error->int1));
     rb_iv_set(e, "@column", INT2NUM(error->int2));
+
+    xmlFree(c_path);
   }
 
   return e;

--- a/lib/nokogiri/xml/syntax_error.rb
+++ b/lib/nokogiri/xml/syntax_error.rb
@@ -19,23 +19,18 @@ module Nokogiri
         end
       end
 
-      # What part of libxml2 raised this error (enum xmlErrorDomain)
       attr_reader :domain
-      # libxml2 error code (enum xmlParserErrors)
       attr_reader :code
-      # libxml2 error level (enum xmlErrorLevel)
       attr_reader :level
       attr_reader :file
       attr_reader :line
-      # libxml2 path of the node in the tree that caused the error
+      # ⚠ path functionality is not available when running JRuby.
+      #
+      # path of the node that caused the error when validating a `Nokogiri::XML::Document`
       attr_reader :path
-      # libxml2 extra string information
       attr_reader :str1
-      # libxml2 extra string information
       attr_reader :str2
-      # libxml2 extra string information
       attr_reader :str3
-      # libxml2 extra extra number information
       attr_reader :int1
       attr_reader :column
 

--- a/lib/nokogiri/xml/syntax_error.rb
+++ b/lib/nokogiri/xml/syntax_error.rb
@@ -24,9 +24,14 @@ module Nokogiri
       attr_reader :level
       attr_reader :file
       attr_reader :line
-      # ⚠ path functionality is not available when running JRuby.
+
+      # The XPath path of the node that caused the error when validating a `Nokogiri::XML::Document`.
       #
-      # path of the node that caused the error when validating a `Nokogiri::XML::Document`
+      # This attribute will only be non-nil when the error is emitted by `Schema#validate` on
+      # Document objects. It will return `nil` for DOM parsing errors and for errors emitted during
+      # Schema validation of files.
+      #
+      # ⚠ `#path` is not supported on JRuby, where it will always return `nil`.
       attr_reader :path
       attr_reader :str1
       attr_reader :str2

--- a/lib/nokogiri/xml/syntax_error.rb
+++ b/lib/nokogiri/xml/syntax_error.rb
@@ -19,14 +19,23 @@ module Nokogiri
         end
       end
 
+      # What part of libxml2 raised this error (enum xmlErrorDomain)
       attr_reader :domain
+      # libxml2 error code (enum xmlParserErrors)
       attr_reader :code
+      # libxml2 error level (enum xmlErrorLevel)
       attr_reader :level
       attr_reader :file
       attr_reader :line
+      # libxml2 path of the node in the tree that caused the error
+      attr_reader :path
+      # libxml2 extra string information
       attr_reader :str1
+      # libxml2 extra string information
       attr_reader :str2
+      # libxml2 extra string information
       attr_reader :str3
+      # libxml2 extra extra number information
       attr_reader :int1
       attr_reader :column
 

--- a/test/html4/test_document.rb
+++ b/test/html4/test_document.rb
@@ -24,7 +24,6 @@ module Nokogiri
           refute_empty(errors, "has errors")
           errors.each do |error|
             assert_equal(error.to_s.chomp, error.to_s)
-            assert_nil(error.path)
           end
         end
 

--- a/test/html4/test_document.rb
+++ b/test/html4/test_document.rb
@@ -24,6 +24,7 @@ module Nokogiri
           refute_empty(errors, "has errors")
           errors.each do |error|
             assert_equal(error.to_s.chomp, error.to_s)
+            assert_nil(error.path)
           end
         end
 
@@ -813,6 +814,7 @@ module Nokogiri
                   Nokogiri::HTML4.parse(input, nil, nil, parse_options)
                 end
                 assert_match(/Parser without recover option encountered error or warning/, exception.to_s)
+                assert_nil(exception.path)
               end
             end
 
@@ -835,6 +837,7 @@ module Nokogiri
                   Nokogiri::HTML4.parse(input, nil, "UTF-8", parse_options)
                 end
                 assert_match(/Parser without recover option encountered error or warning/, exception.to_s)
+                assert_nil(exception.path)
               end
             end
 

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -1087,9 +1087,10 @@ module Nokogiri
               let(:parse_options) { xml_strict }
 
               it "raises exception on parse error" do
-                assert_raises Nokogiri::SyntaxError do
+                error = assert_raises Nokogiri::SyntaxError do
                   Nokogiri::XML.parse(input, nil, nil, parse_options)
                 end
+                assert_nil(error.path)
               end
             end
 

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -159,10 +159,17 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
 
         assert(errors = xsd.validate(doc))
         assert_equal(2, errors.length)
-        assert_equal(
-          ["/purchaseOrder/billTo/state", "/purchaseOrder/shipTo/state"],
-          errors.map(&:path).sort,
-        )
+        if Nokogiri.uses_libxml?
+          assert_equal(
+            ["/purchaseOrder/billTo/state", "/purchaseOrder/shipTo/state"],
+            errors.map(&:path).sort,
+          )
+        else
+          assert_equal(
+            [nil, nil],
+            errors.map(&:path).sort,
+          )
+        end
       end
 
       it "validate_invalid_file" do

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -176,7 +176,7 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
         assert(errors = xsd.validate(tempfile.path))
         assert_equal(2, errors.length)
         assert_equal(
-          ["/purchaseOrder/billTo/state", "/purchaseOrder/shipTo/state"],
+          [nil, nil],
           errors.map(&:path).sort,
         )
       end

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -175,6 +175,10 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
 
         assert(errors = xsd.validate(tempfile.path))
         assert_equal(2, errors.length)
+        assert_equal(
+          ["/purchaseOrder/billTo/state", "/purchaseOrder/shipTo/state"],
+          errors.map(&:path).sort,
+        )
       end
 
       it "validate_non_document" do

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -159,6 +159,10 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
 
         assert(errors = xsd.validate(doc))
         assert_equal(2, errors.length)
+        assert_equal(
+          ["/purchaseOrder/billTo/state", "/purchaseOrder/shipTo/state"],
+          errors.map(&:path).sort,
+        )
       end
 
       it "validate_invalid_file" do

--- a/test/xml/test_syntax_error.rb
+++ b/test/xml/test_syntax_error.rb
@@ -58,5 +58,6 @@ describe Nokogiri::XML::SyntaxError do
       assert_nil error.column
       assert_nil error.level
     end
+    assert_nil error.path
   end
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

When validating an XML document with a schema it is difficult to impossible to know where the error happened in the document. With the path on the error, we can identify where in the document the error occurred.

**Have you included adequate test coverage?**

I believe so. I updated the test in the schema to check to see if path errors were being returned correctly.

**Does this change affect the behavior of either the C or the Java implementations?**

This change the C implementation gently. Setting the path during error creation.
I looked if xerces-j could do it, but I couldn't find anything on the SAXException that would help.