### PR TITLE
XML::DocumentFragment.parse supports kwargs

### DIFF
--- a/lib/nokogiri/xml.rb
+++ b/lib/nokogiri/xml.rb
@@ -39,8 +39,8 @@ module Nokogiri
 
       ####
       # Parse a fragment from +string+ in to a NodeSet.
-      def fragment(string, options = ParseOptions::DEFAULT_XML, &block)
-        XML::DocumentFragment.parse(string, options, &block)
+      def fragment(...)
+        XML::DocumentFragment.parse(...)
       end
     end
   end

--- a/lib/nokogiri/xml/document_fragment.rb
+++ b/lib/nokogiri/xml/document_fragment.rb
@@ -11,7 +11,7 @@ module Nokogiri
 
       ####
       # Create a Nokogiri::XML::DocumentFragment from +tags+
-      def self.parse(tags, options = ParseOptions::DEFAULT_XML, &block)
+      def self.parse(tags, options_ = ParseOptions::DEFAULT_XML, options: options_, &block)
         new(XML::Document.new, tags, nil, options, &block)
       end
 

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -386,6 +386,16 @@ module Nokogiri
               end
             end
 
+            it "accepts kwargs" do
+              frag = Nokogiri::XML.fragment(input, options: xml_default)
+              assert_equal("<a>foo</a>", frag.to_html)
+              refute_empty(frag.errors)
+
+              assert_raises(Nokogiri::SyntaxError) do
+                Nokogiri::XML.fragment(input, options: xml_strict)
+              end
+            end
+
             it "takes a config block" do
               default_config = nil
               Nokogiri::XML.fragment(input) do |config|

--- a/test/xml/test_document_fragment.rb
+++ b/test/xml/test_document_fragment.rb
@@ -416,6 +416,16 @@ module Nokogiri
               end
             end
 
+            it "accepts kwargs" do
+              frag = Nokogiri::XML::DocumentFragment.parse(input, options: xml_default)
+              assert_equal("<a>foo</a>", frag.to_html)
+              refute_empty(frag.errors)
+
+              assert_raises(Nokogiri::SyntaxError) do
+                Nokogiri::XML::DocumentFragment.parse(input, options: xml_strict)
+              end
+            end
+
             it "takes a config block" do
               default_config = nil
               Nokogiri::XML::DocumentFragment.parse(input) do |config|


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Related to https://github.com/sparklemotion/nokogiri/issues/3323, introducing keyword argument support in
`XML::Document.parse`.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

Some minor test coverage introduced.

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

n/a

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
