### PR TITLE
Nokogiri::XML() and Nokogiri::XML.parse() support argument forwarding

### DIFF
--- a/lib/nokogiri/xml.rb
+++ b/lib/nokogiri/xml.rb
@@ -4,8 +4,8 @@ module Nokogiri
   class << self
     ###
     # Parse XML.  Convenience method for Nokogiri::XML::Document.parse
-    def XML(thing, url = nil, encoding = nil, options = XML::ParseOptions::DEFAULT_XML, &block)
-      Nokogiri::XML::Document.parse(thing, url, encoding, options, &block)
+    def XML(...)
+      Nokogiri::XML::Document.parse(...)
     end
   end
 

--- a/lib/nokogiri/xml.rb
+++ b/lib/nokogiri/xml.rb
@@ -2,8 +2,7 @@
 
 module Nokogiri
   class << self
-    ###
-    # Parse XML.  Convenience method for Nokogiri::XML::Document.parse
+    # Convenience method for Nokogiri::XML::Document.parse
     def XML(...)
       Nokogiri::XML::Document.parse(...)
     end
@@ -23,10 +22,9 @@ module Nokogiri
         Reader.new(...)
       end
 
-      ###
-      # Parse XML.  Convenience method for Nokogiri::XML::Document.parse
-      def parse(thing, url = nil, encoding = nil, options = ParseOptions::DEFAULT_XML, &block)
-        Document.parse(thing, url, encoding, options, &block)
+      # Convenience method for Nokogiri::XML::Document.parse
+      def parse(...)
+        Document.parse(...)
       end
 
       ####

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -1101,6 +1101,13 @@ module Nokogiri
                 end
                 assert_nil(error.path)
               end
+
+              it "raises exception on parse error with kwargs" do
+                error = assert_raises Nokogiri::SyntaxError do
+                  Nokogiri::XML.parse(input, options: parse_options)
+                end
+                assert_nil(error.path)
+              end
             end
 
             describe "default options" do
@@ -1120,6 +1127,12 @@ module Nokogiri
               it "raises exception on parse error" do
                 assert_raises Nokogiri::SyntaxError do
                   Nokogiri::XML.parse(input, nil, nil, parse_options)
+                end
+              end
+
+              it "raises exception on parse error with kwargs" do
+                assert_raises Nokogiri::SyntaxError do
+                  Nokogiri::XML.parse(input, options: parse_options)
                 end
               end
             end

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -682,6 +682,10 @@ module Nokogiri
           end
 
           assert_raises(Nokogiri::XML::SyntaxError) do
+            Nokogiri::XML("<foo><bar></foo>", options: 0)
+          end
+
+          assert_raises(Nokogiri::XML::SyntaxError) do
             Nokogiri::XML("<foo><bar></foo>", &:strict)
           end
 

--- a/test/xml/test_document_encoding.rb
+++ b/test/xml/test_document_encoding.rb
@@ -29,6 +29,11 @@ module Nokogiri
             encoding = "Shift_JIS"
             assert_equal(encoding, Nokogiri::XML(nil, nil, encoding).encoding)
           end
+
+          it "applies the specified kwargs encoding even if on empty documents" do
+            encoding = "Shift_JIS"
+            assert_equal(encoding, Nokogiri::XML(nil, encoding: encoding).encoding)
+          end
         end
 
         describe "#encoding=" do

--- a/test/xml/test_node_encoding.rb
+++ b/test/xml/test_node_encoding.rb
@@ -39,6 +39,22 @@ module Nokogiri
         assert_equal(expected, frag.to_xml.sub(/^<.xml[^>]*>\n/m, "").strip)
       end
 
+      def test_encoding_GH_1113_with_kwargs
+        utf8 = "<frag>shahid ὡ 𐄣 𢂁</frag>"
+        hex = "<frag>shahid &#x1f61; &#x10123; &#x22081;</frag>"
+        decimal = "<frag>shahid &#8033; &#65827; &#139393;</frag>"
+        expected = Nokogiri.jruby? ? hex : decimal
+
+        frag = Nokogiri::XML(utf8, encoding: "UTF-8", options: Nokogiri::XML::ParseOptions::STRICT)
+        assert_equal(utf8, frag.to_xml.sub(/^<.xml[^>]*>\n/m, "").strip)
+
+        frag = Nokogiri::XML(expected, encoding: "UTF-8", options: Nokogiri::XML::ParseOptions::STRICT)
+        assert_equal(utf8, frag.to_xml.sub(/^<.xml[^>]*>\n/m, "").strip)
+
+        frag = Nokogiri::XML(expected, encoding: "US-ASCII", options: Nokogiri::XML::ParseOptions::STRICT)
+        assert_equal(expected, frag.to_xml.sub(/^<.xml[^>]*>\n/m, "").strip)
+      end
+
       VEHICLE_XML = <<-eoxml
         <root>
           <car xmlns:part="http://general-motors.com/">


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Related to https://github.com/sparklemotion/nokogiri/issues/3323, introducing keyword argument support in Nokogiri::XML::Document.parse.

**Have you included adequate test coverage?**

Some minor test coverage mimicking the existing permutations of options.

**Does this change affect the behavior of either the C or the Java implementations?**

No
