### PR TITLE
Updates HTML5::DocumentFragment.new, #parse with keyword arguments;

### DIFF
--- a/lib/nokogiri/html5/document_fragment.rb
+++ b/lib/nokogiri/html5/document_fragment.rb
@@ -50,7 +50,7 @@ module Nokogiri
         # [Returns]
         # - [Nokogiri::XML::NodeSet] A node set containing the root nodes of the parsed fragment.
         #
-        def parse(tags, encoding = nil, positional_options_hash = nil, **options)
+        def parse(tags, encoding_ = nil, positional_options_hash = nil, encoding: encoding_, **options)
           unless positional_options_hash.nil?
             warn("Nokogiri::HTML5::DocumentFragment.parse: Passing options as an explicit hash is deprecated. Use keyword arguments instead. This will become an error in a future release.", uplevel: 1, category: :deprecated)
             options.merge!(positional_options_hash)
@@ -62,7 +62,7 @@ module Nokogiri
           document.encoding = "UTF-8"
           tags = HTML5.read_and_encode(tags, encoding)
 
-          new(document, tags, context, options)
+          new(document, tags, context, **options)
         end
       end
 
@@ -77,11 +77,17 @@ module Nokogiri
       attr_reader :quirks_mode
 
       # Create a document fragment.
-      def initialize(doc, tags = nil, context = nil, options = {}) # rubocop:disable Lint/MissingSuper
+      def initialize(doc, tags_ = nil, context_ = nil, positional_options_hash = nil, tags: tags_, context: context_, **options) # rubocop:disable Lint/MissingSuper
+        unless positional_options_hash.nil?
+          warn("Nokogiri::HTML5::DocumentFragment.new: Passing options as an explicit hash is deprecated. Use keyword arguments instead. This will become an error in a future release.", uplevel: 1, category: :deprecated)
+          options.merge!(positional_options_hash)
+        end
+
         @document = doc
         @errors = []
         return self unless tags
 
+        # TODO: Accept encoding as an argument to this method
         tags = Nokogiri::HTML5.read_and_encode(tags, nil)
 
         context = options.delete(:context) if options.key?(:context)


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**
Keywooooooorrrrrrrrd Arguments!

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->

This PR is not complete. DocumentFragment.new is in C, and needs to be updated to call HTML5::DocumentFragment#initialize without the positional options hash.


