### PR TITLE
Update HTML4::DocumentFragment#initialize & #parse to take kwargs

### DIFF
--- a/lib/nokogiri/html4/document_fragment.rb
+++ b/lib/nokogiri/html4/document_fragment.rb
@@ -87,7 +87,7 @@ module Nokogiri
 
       # It's recommended to use either DocumentFragment.parse or XML::Node#parse rather than call this
       # method directly.
-      def initialize(document, tags = nil, ctx = nil, options = XML::ParseOptions::DEFAULT_HTML) # rubocop:disable Lint/MissingSuper
+      def initialize(document, tags_ = nil, ctx_ = nil, options_ = XML::ParseOptions::DEFAULT_HTML, tags: tags_, ctx: ctx_, options: options_) # rubocop:disable Lint/MissingSuper
         return self unless tags
 
         options = Nokogiri::XML::ParseOptions.new(options) if Integer === options

--- a/lib/nokogiri/html4/document_fragment.rb
+++ b/lib/nokogiri/html4/document_fragment.rb
@@ -4,12 +4,6 @@ module Nokogiri
   module HTML4
     class DocumentFragment < Nokogiri::XML::DocumentFragment
       #
-      # :call-seq:
-      #   parse(tags) => DocumentFragment
-      #   parse(tags, encoding) => DocumentFragment
-      #   parse(tags, encoding, options) => DocumentFragment
-      #   parse(tags, encoding) { |options| ... } => DocumentFragment
-      #
       # Parse an HTML4 fragment.
       #
       # [Parameters]
@@ -38,7 +32,7 @@ module Nokogiri
       #
       # *Example:* Specifying encoding
       #
-      #   fragment = DocumentFragment.parse(input, "EUC-JP")
+      #   fragment = DocumentFragment.parse(input, encoding: "EUC-JP")
       #
       # *Example:* Setting parse options dynamically
       #
@@ -46,7 +40,7 @@ module Nokogiri
       #     options.huge.pedantic
       #   end
       #
-      def self.parse(tags, encoding = nil, options = XML::ParseOptions::DEFAULT_HTML, &block)
+      def self.parse(tags, encoding_ = nil, options_ = XML::ParseOptions::DEFAULT_HTML, encoding: encoding_, options: options_, &block)
         doc = HTML4::Document.new
 
         if tags.respond_to?(:read)

--- a/test/html4/test_document_fragment.rb
+++ b/test/html4/test_document_fragment.rb
@@ -326,6 +326,14 @@ module Nokogiri
               assert_equal("hello world", fragment.content)
             end
 
+            it "returns a string matching an encoding passed with kwargs" do
+              input = "<div>hello world</div>"
+
+              fragment = Nokogiri::HTML4::DocumentFragment.parse(input, encoding: "ISO-8859-1")
+              assert_equal("ISO-8859-1", fragment.document.encoding)
+              assert_equal("hello world", fragment.content)
+            end
+
             it "respects encoding for empty strings" do
               fragment = Nokogiri::HTML::DocumentFragment.parse("", "UTF-8")
               assert_equal "UTF-8", fragment.to_html.encoding.to_s
@@ -407,6 +415,13 @@ module Nokogiri
 
             it "accepts options" do
               frag = Nokogiri::HTML4::DocumentFragment.parse(input, nil, html4_huge)
+
+              assert_equal("<div>foo</div>", frag.to_html)
+              assert_equal(html4_huge, frag.parse_options)
+            end
+
+            it "accepts options as kwargs" do
+              frag = Nokogiri::HTML4::DocumentFragment.parse(input, options: html4_huge)
 
               assert_equal("<div>foo</div>", frag.to_html)
               assert_equal(html4_huge, frag.parse_options)


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**
https://github.com/sparklemotion/nokogiri/issues/3323
<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**
Yes and No. Test coverage is included for `#parse`. But the the `DocumentFragment.new` class method calls a C method, which is not getting touched here. Thus I can't add in tests using `.new`.
@flavorjones : you'll need to update the C code to accept keyword args. Then, you can update [this call](https://github.com/sparklemotion/nokogiri/blob/main/lib/nokogiri/html4/document_fragment.rb#L85). Also you'll want to add some tests. I added two in `test_document_fragment` before I realized they wouldn't work. One for "without a context node" and one for "with a context node".
<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**
I.... don't think so?
<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
