### PR TITLE
Nokogiri::XML::SAX::PushParser.new() supports keyword arguments

### DIFF
--- a/lib/nokogiri/xml/sax/push_parser.rb
+++ b/lib/nokogiri/xml/sax/push_parser.rb
@@ -32,7 +32,11 @@ module Nokogiri
         ###
         # Create a new PushParser with +doc+ as the SAX Document, providing
         # an optional +file_name+ and +encoding+
-        def initialize(doc = XML::SAX::Document.new, file_name = nil, encoding = "UTF-8")
+        def initialize(
+          doc = XML::SAX::Document.new,
+          file_name_ = nil, encoding_ = "UTF-8",
+          file_name: file_name_, encoding: encoding_
+        )
           @document = doc
           @encoding = encoding
           @sax_parser = XML::SAX::Parser.new(doc)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Related to https://github.com/sparklemotion/nokogiri/issues/3323, introducing keyword argument support in Nokogiri::XML::SAX::PushParser.new(). 

Note: I presumed that `doc` should remain a positional argument given the method comment.

**Have you included adequate test coverage?**

No; there were no existing tests for the optional positional arguments.

**Does this change affect the behavior of either the C or the Java implementations?**

No