### PR TITLE
extconf: respect AR and RANLIB in recipes on darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,36 @@ jobs:
       - run: bundle exec rake compile -- --${{matrix.sys}}-system-libraries
       - run: bundle exec rake test
 
+  darwin-nix:
+    needs: ["basic"]
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: ["enable", "disable"]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-24.11
+      - run: nix-shell --packages ruby bundler --run 'bundle install'
+      - if: matrix.sys == 'disable'
+        run: nix-shell --packages ruby bundler --run 'bundle exec rake compile -- --disable-system-libraries --disable-xml2-legacy'
+      - if: matrix.sys == 'disable'
+        run: nix-shell --packages ruby bundler --run 'bundle exec rake test'
+      # libxml2 headers are in a subdirectory for some reason so we need to add it to NIX_CFLAGS_COMPILE manually.
+      # there are a bunch of examples of other packages doing this in nixpkgs so this seems to be expected.
+      - if: matrix.sys == 'enable'
+        run: |
+          nix-shell \
+            --expr 'with import <nixpkgs> {}; mkShell { buildInputs = [ ruby bundler libxml2 libxslt ]; env.NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2"; }' \
+            --run 'bundle exec rake compile -- --enable-system-libraries --disable-xml2-legacy'
+      - if: matrix.sys == 'enable'
+        run: |
+          nix-shell --packages ruby bundler libxml2 libxslt --run 'bundle exec rake test'
+
   windows:
     needs: ["basic"]
     strategy:

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -209,8 +209,12 @@ def aix?
   RbConfig::CONFIG["target_os"].include?("aix")
 end
 
-def nix?
+def unix?
   !(windows? || solaris? || darwin?)
+end
+
+def nix?
+  ENV.key?("NIX_CC")
 end
 
 def truffle?
@@ -705,7 +709,7 @@ end
 
 # Add SDK-specific include path for macOS and brew versions before v2.2.12 (2020-04-08) [#1851, #1801]
 macos_mojave_sdk_include_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libxml2"
-if config_system_libraries? && darwin? && Dir.exist?(macos_mojave_sdk_include_path)
+if config_system_libraries? && darwin? && Dir.exist?(macos_mojave_sdk_include_path) && !nix?
   append_cppflags("-I#{macos_mojave_sdk_include_path}")
 end
 
@@ -828,7 +832,7 @@ else
       end
     end
 
-    unless nix?
+    unless unix?
       libiconv_recipe = process_recipe(
         "libiconv",
         dependencies["libiconv"]["version"],

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -928,7 +928,8 @@ else
     end
 
     if darwin? && !cross_build_p
-      recipe.configure_options += ["RANLIB=/usr/bin/ranlib", "AR=/usr/bin/ar"]
+      recipe.configure_options << "RANLIB=/usr/bin/ranlib" unless ENV.key?("RANLIB")
+      recipe.configure_options << "AR=/usr/bin/ar" unless ENV.key?("AR")
     end
 
     if windows?
@@ -969,7 +970,8 @@ else
     cflags = concat_flags(ENV["CFLAGS"], "-O2", "-U_FORTIFY_SOURCE", "-g")
 
     if darwin? && !cross_build_p
-      recipe.configure_options += ["RANLIB=/usr/bin/ranlib", "AR=/usr/bin/ar"]
+      recipe.configure_options << "RANLIB=/usr/bin/ranlib" unless ENV.key?("RANLIB")
+      recipe.configure_options << "AR=/usr/bin/ar" unless ENV.key?("AR")
     end
 
     if windows?


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

When using Nix on Darwin, we ideally should be latching onto the Nix-provided AR and RANLIB. Without this, when blocking Xcode via `sandbox-exec`, I see errors like this while attempting to install the gem, since we end up using the default `ar` and `runlib`
```
xcode-select: note: No developer tools were found, requesting install.
If developer tools are located at a non-default location on disk, use `sudo xcode-select --switch path/to/Xcode.app` to specify the Xcode that you wish to use for command line developer tools, and cancel the installation dialog.
See `man xcode-select` for more details.
```

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

No but this seems relatively harmless?

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

No

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
