### PR TITLE
ci: use github.com instead of gitlab.gnome.org

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -42,7 +42,7 @@ jobs:
           NOCONFIGURE: t
         shell: bash
         run: |
-          git clone --depth=1 https://gitlab.gnome.org/GNOME/libxml2
+          git clone --depth=1 https://github.com/gnome/libxml2
           cd libxml2
           git log -n1
           ./autogen.sh
@@ -51,7 +51,7 @@ jobs:
           NOCONFIGURE: t
         shell: bash
         run: |
-          git clone --depth=1 https://gitlab.gnome.org/GNOME/libxslt
+          git clone --depth=1 https://github.com/gnome/libxslt
           cd libxslt
           git log -n1
           ./autogen.sh
@@ -72,7 +72,7 @@ jobs:
         env:
           NOCONFIGURE: t
         run: |
-          git clone --depth=1 https://gitlab.gnome.org/GNOME/libxml2
+          git clone --depth=1 https://github.com/gnome/libxml2
           cd libxml2
           git log -n1
           ./autogen.sh
@@ -80,7 +80,7 @@ jobs:
         env:
           NOCONFIGURE: t
         run: |
-          git clone --depth=1 https://gitlab.gnome.org/GNOME/libxslt
+          git clone --depth=1 https://github.com/gnome/libxslt
           cd libxslt
           git log -n1
           ./autogen.sh


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Use github instead of gitlab.gnome.org, because the gnome infrastructure has been unstable:

- https://discourse.gnome.org/t/login-problems-gitlab/25132/3
- https://gitlab.gnome.org/Infrastructure/Infrastructure/-/issues/1794
- https://gitlab.gnome.org/Infrastructure/Infrastructure/-/issues/1792

and it's not obvious that the gnome infrastructure team is working on it -- there are no meaningful updates as of this writing, and the status page still shows green despite a complete inability to `git clone` or load most web pages

![image](https://github.com/user-attachments/assets/2027ae72-2b1e-4bdb-8d42-5ac6716b4b98)

🤷
