### PR TITLE
ci: fix macos upstream pkgconf

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           ruby-version: "3.3"
           apt-get: "autogen libtool shtool"
-          brew: "automake autogen libtool shtool"
+          brew: "_upgrade_ automake autogen libtool shtool" # _upgrade_ needed because of the pkg-config → pkgconf migration https://github.com/Homebrew/homebrew-core/commit/0c357945611d988fe65e46aeb092cbb6ca7492bd
           mingw: "autotools xz"
           bundler-cache: true
           bundler: latest


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Seeing CI failures on the upstream macos libxml2 job, e.g. https://github.com/sparklemotion/nokogiri/actions/runs/12005643457/job/33492814380

```
  brew install automake autogen libtool shtool
  ==> Downloading https://ghcr.io/v2/homebrew/core/automake/manifests/1.17
... ✁ ...
  ==> Installing autogen dependency: pkgconf
  ==> Downloading https://ghcr.io/v2/homebrew/core/pkgconf/manifests/2.3.0_1
  Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/2d395f41484daa2c37c818f7abd9d0fc8dd82ff2892c542d9eb136b442ebae19--pkgconf-2.3.0_1.bottle_manifest.json
  ==> Pouring pkgconf--2.3.0_1.arm64_sonoma.bottle.tar.gz
  Error: The `brew link` step did not complete successfully
  The formula built, but is not symlinked into /opt/homebrew
  Could not symlink bin/pkg-config
  Target /opt/homebrew/bin/pkg-config
  is a symlink belonging to pkg-config@0.29.2. You can unlink it:
    brew unlink pkg-config@0.29.2
  
  To force the link and overwrite all conflicting files:
    brew link --overwrite pkgconf
  
  To list all files that would be deleted:
    brew link --overwrite pkgconf --dry-run
  
  Possible conflicting files are:
  /opt/homebrew/bin/pkg-config -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/bin/pkg-config
  /opt/homebrew/share/aclocal/pkg.m4 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/aclocal/pkg.m4
  /opt/homebrew/share/man/man1/pkg-config.1 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/man/man1/pkg-config.1
```

Seems like this is probably due to the transition committed here: https://github.com/Homebrew/homebrew-core/commit/0c357945611d988fe65e46aeb092cbb6ca7492bd

Let's try upgrading to see if we can get around this.
