### PR TITLE
[DOC] Doc for XML::ParseOptions

### DIFF
--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -1,9 +1,10 @@
 # coding: utf-8
 # frozen_string_literal: true
 
+# :markup: markdown
+
 module Nokogiri
   module XML
-    # :markup: markdown
     #
     # \Class to house options for parsing \XML or \HTML4 (but not \HTML5).
     #
@@ -245,8 +246,7 @@ module Nokogiri
     #     doc = Nokogiri::XML::Document.parse(xml, nil, nil, po)
     #
     class ParseOptions
-      # :markup: markdown
-      #
+
       # Strict parsing; do not recover from errors in input.
       STRICT      = 0
 
@@ -400,7 +400,8 @@ module Nokogiri
         RUBY
       end
 
-      # :markup: markdown
+      # :call-seq:
+      #   strict
       #
       # Turns off option `recover`:
       #
@@ -415,8 +416,9 @@ module Nokogiri
         self
       end
 
-      # :markup: markdown
-      #
+      # :call-seq:
+      #   strict?
+      # 
       # Returns whether option `strict` is on:
       #
       # ```
@@ -431,8 +433,6 @@ module Nokogiri
         @options & RECOVER == STRICT
       end
 
-      # :markup: markdown
-      #
       # :call-seq:
       #    self == object
       #
@@ -451,8 +451,6 @@ module Nokogiri
 
       alias_method :to_i, :options
 
-      # :markup: markdown
-      #
       # :call-seq:
       #    inspect
       #

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -86,45 +86,7 @@ module Nokogiri
     #
     # The bitmask constants are:
     #
-    # | Constant | Default | Meaning |
-    # |------|:-------:|---------|
-    # | BIG_LINES | **On** | Store big lines numbers in text PSVI field. |
-    # | COMPACT | **Off** | Compact small text nodes; no modification of the tree allowed afterwards (will possibly crash if you try to modify the tree). |
-    # | DTDATTR | See Note 1. | Default DTD attributes. |
-    # | DTDLOAD | See Note 1. | Load the external subset. |
-    # | DTDVALID | **Off** | Validate with the DTD. |
-    # | HUGE | **Off** | Relax any hardcoded limit from the parser. |
-    # | NOBASEFIX | **Off** | Do not fixup XINCLUDE xml:base uris. |
-    # | NOBLANKS | **Off** | Remove blank nodes. |
-    # | NOCDATA | See Note 1. | Merge CDATA as text nodes. |
-    # | NODICT | **Off** | Do not reuse the context dictionary. |
-    # | NOENT | **Off** | Substitute entities. |
-    # | NOERROR | **On** | Suppress error reports. |
-    # | NONET | See Note 2. | Forbid network access. |
-    # | NOWARNING | **On** | Suppress warning reports. |
-    # | NOXINCNODE | **Off** | Do not generate XINCLUDE START/END nodes. |
-    # | NSCLEAN | **Off** | Remove redundant namespaces declarations. |
-    # | OLD10 | Off| Parse using XML-1.0 before update 5. |
-    # | PEDANTIC | **Off** | Pedantic error reporting. |
-    # | RECOVER | See Note 2. | Recover from errors in input; no strict parsing. |
-    # | SAX1 | **Off** | Use the SAX1 interface internally. |
-    # | STRICT | **Off** | Use strict parsing; do not recover from errors in input. See Note 3. |
-    # | XINCLUDE | **Off** | Implement XInclude substitution. |
     #
-    # <br>
-    #
-    # Notes:
-    #
-    # 1. **On** only for XSLT::Stylesheet; **off** otherwise.
-    # 2. **On** by default for XML::Document, XML::DocumentFragment, HTML4::Document,
-    #    HTML4::DocumentFragment, XSLT::Stylesheet, and XML::Schema; **off** otherwise.
-    # 3. The numeric value of constant `STRICT` is zero.
-    #    Therefore using it alone sets all options to **off**;
-    #    ORing it with other non-zero constants is useless:
-    #
-    #    ```
-    #
-    #    ```
     #
     # There are also several "shorthand" constants that can set multiple options:
     #
@@ -190,7 +152,7 @@ module Nokogiri
     #     options.strict?  # => false
     #     ```
     #
-    # Each setter and unsetter method returns +self+,
+    # Each setter and unsetter method returns `self`,
     # so the methods may be chained:
     #
     # ```
@@ -218,103 +180,112 @@ module Nokogiri
     class ParseOptions
       # :markup: markdown
       #
-      # Strict parsing; all options (including `recover`) **off**.
+      # Strict parsing; do not recover from errors in input.
       STRICT      = 0
 
-      # Recover from errors. On by default for XML::Document, XML::DocumentFragment,
-      # HTML4::Document, HTML4::DocumentFragment, XSLT::Stylesheet, and XML::Schema.
+      # Recover from errors in input; no strict parsing.
       RECOVER     = 1 << 0
 
-      # Substitute entities. Off by default.
+      # Substitute entities.
       #
       # ⚠ This option enables entity substitution, contrary to what the name implies.
       #
       # ⚠ <b>It is UNSAFE to set this option</b> when parsing untrusted documents.
       NOENT       = 1 << 1
 
-      # Load external subsets. On by default for XSLT::Stylesheet.
+      # Load external subsets.
       #
       # ⚠ <b>It is UNSAFE to set this option</b> when parsing untrusted documents.
       DTDLOAD     = 1 << 2
 
-      # Default DTD attributes. On by default for XSLT::Stylesheet.
+      # Default DTD attributes.
       DTDATTR     = 1 << 3
 
-      # Validate with the DTD. Off by default.
+      # Validate with the DTD.
       DTDVALID    = 1 << 4
 
-      # Suppress error reports. On by default for HTML4::Document and HTML4::DocumentFragment
+      # Suppress error reports.
       NOERROR     = 1 << 5
 
-      # Suppress warning reports. On by default for HTML4::Document and HTML4::DocumentFragment
+      # Suppress warning reports.
       NOWARNING   = 1 << 6
 
-      # Enable pedantic error reporting. Off by default.
+      # Enable pedantic error reporting.
       PEDANTIC    = 1 << 7
 
-      # Remove blank nodes. Off by default.
+      # Remove blank nodes.
       NOBLANKS    = 1 << 8
 
-      # Use the SAX1 interface internally. Off by default.
+      # Use the SAX1 interface internally.
       SAX1        = 1 << 9
 
-      # Implement XInclude substitution. Off by default.
+      # Implement XInclude substitution.
       XINCLUDE    = 1 << 10
 
-      # Forbid network access. On by default for XML::Document, XML::DocumentFragment,
-      # HTML4::Document, HTML4::DocumentFragment, XSLT::Stylesheet, and XML::Schema.
+      # Forbid network access.
       #
       # ⚠ <b>It is UNSAFE to unset this option</b> when parsing untrusted documents.
       NONET       = 1 << 11
 
-      # Do not reuse the context dictionary. Off by default.
+      # Do not reuse the context dictionary.
       NODICT      = 1 << 12
 
-      # Remove redundant namespaces declarations. Off by default.
+      # Remove redundant namespaces declarations.
       NSCLEAN     = 1 << 13
 
-      # Merge CDATA as text nodes. On by default for XSLT::Stylesheet.
+      # Merge CDATA as text nodes.
       NOCDATA     = 1 << 14
 
-      # Do not generate XInclude START/END nodes. Off by default.
+      # Do not generate XInclude START/END nodes.
       NOXINCNODE  = 1 << 15
 
-      # Compact small text nodes. Off by default.
+      # Compact small text nodes.
       #
-      # ⚠ No modification of the DOM tree is allowed after parsing. libxml2 may crash if you try to
-      # modify the tree.
+      # ⚠ No modification of the DOM tree is allowed after parsing.
       COMPACT     = 1 << 16
 
-      # Parse using XML-1.0 before update 5. Off by default
+      # Parse using XML-1.0 before update 5.
       OLD10       = 1 << 17
 
-      # Do not fixup XInclude xml:base uris. Off by default
+      # Do not fixup XInclude xml:base URIs.
       NOBASEFIX   = 1 << 18
 
-      # Relax any hardcoded limit from the parser. Off by default.
+      # Relax any hardcoded limit from the parser.
       #
       # ⚠ <b>It is UNSAFE to set this option</b> when parsing untrusted documents.
       HUGE        = 1 << 19
 
-      # Support line numbers up to <code>long int</code> (default is a <code>short int</code>). On
-      # by default for for XML::Document, XML::DocumentFragment, HTML4::Document,
-      # HTML4::DocumentFragment, XSLT::Stylesheet, and XML::Schema.
+      # Support line numbers up to `long int` (default is a `short int`).
       BIG_LINES   = 1 << 22
 
-      # The options mask used by default for parsing XML::Document and XML::DocumentFragment
+      # Shorthand options mask useful for parsing XML:
+      # sets RECOVER,  NONET,  BIG_LINES.
       DEFAULT_XML  = RECOVER | NONET | BIG_LINES
 
-      # The options mask used by default used for parsing XSLT::Stylesheet
+      # Shorthand options mask useful for parsing XSLT stylesheets:
+      # sets RECOVER, NONET, NOENT, DTDLOAD, DTDATTR, NOCDATA, BIG_LINES.
       DEFAULT_XSLT = RECOVER | NONET | NOENT | DTDLOAD | DTDATTR | NOCDATA | BIG_LINES
 
-      # The options mask used by default used for parsing HTML4::Document and HTML4::DocumentFragment
+      # Shorthand options mask useful for parsing HTML4:
+      # sets RECOVER, NOERROR, NOWARNING, NONET, BIG_LINES.
       DEFAULT_HTML = RECOVER | NOERROR | NOWARNING | NONET | BIG_LINES
 
-      # The options mask used by default used for parsing XML::Schema
+      # Shorthand options mask useful for parsing \XML schemas:
+      # sets NONET, BIG_LINES.
       DEFAULT_SCHEMA = NONET | BIG_LINES
 
       attr_accessor :options
 
+      # :markup: markdown
+      #
+      # Returns a new \ParseOptions object with all options off
+      # (`strict` means `norecover`):
+      #
+      # ```
+      # ParseOptions.new
+      # # => #<Nokogiri::XML::ParseOptions: ... strict>
+      # ```
+      #
       def initialize(options = STRICT)
         @options = options
       end
@@ -339,18 +310,29 @@ module Nokogiri
         RUBY
       end
 
-      # :nodoc:
-      def strict
+      def strict # :nodoc:
         @options &= ~RECOVER
         self
       end
 
-      # :nodoc:
-      def strict?
+      def strict? # :nodoc:
         @options & RECOVER == STRICT
       end
 
-      # :doc:
+      # :markup: markdown
+      #
+      # :call-seq:
+      #    self == object
+      #
+      # Returns whether `object` is equal to `self` (`object.to_i == to_i`):
+      #
+      # ```
+      # options = ParseOptions.new
+      # # => #<Nokogiri::XML::ParseOptions: ... strict>
+      # options == options.dup         # => true
+      # options == options.dup.recover # => false
+      # ```
+      #
       def ==(other)
         other.to_i == to_i
       end
@@ -358,6 +340,9 @@ module Nokogiri
       alias_method :to_i, :options
 
       # :markup: markdown
+      #
+      # :call-seq:
+      #    inspect
       #
       # Returns a string representation of +self+ that includes
       # the numeric value of `@options`:

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -3,8 +3,91 @@
 
 module Nokogiri
   module XML
-    # Options that control the parsing behavior for XML::Document, XML::DocumentFragment,
-    # HTML4::Document, HTML4::DocumentFragment, XSLT::Stylesheet, and XML::Schema.
+    # :markup: markdown
+    #
+    # \Class to house parsing options.
+    #
+    # ## Methods That Use XML::ParseOptions:
+    #
+    # - Nokogiri.parse (but only when _not_ parsing HTML5).
+    # - HTML4.parse.
+    # - HTML4.parse.
+    # - HTML4::Document.parse.
+    # - HTML4::DocumentFragment.parse.
+    # - XML.parse.
+    # - XML::Document.parse.
+    # - XML::DocumentFragment.parse.
+    #
+    # Certain other parsing methods use different options;
+    # see HTML5.
+    #
+    # ## How to Set Options
+    #
+    # There are three ways to set options for an instance of this class:
+    #
+    # - Passing argument `options` with ::new.
+    # - Calling option methods on instance.
+    # - Giving a block with a parsing method.
+    #
+    # ### Passing Argument `options` with ::new
+    #
+    # Each of the methods listed above takes an optional argument `options`
+    # whose value is an integer.
+    #
+    # You can use bitmask constants to construct a suitable integer for the options you want:
+    #
+    # ```
+    # COMPACT                   # One option.
+    # COMPACT | DTDVALID        # Two options.
+    # COMPACT | DTDVALID | HUGE # Three options.
+    # ```
+    #
+    # The option bitmasks are:
+    #
+    # | Constant | Default | Meaning |
+    # |------|:-------:|---------|
+    # | BIG_LINES | On | Store big lines numbers in text PSVI field. |
+    # | COMPACT | Off | Compact small text nodes; no modification of the tree allowed afterwards (will possibly crash if you try to modify the tree). |
+    # | DTDATTR | See Note 1. | Default DTD attributes. |
+    # | DTDLOAD | See Note 1. | Load the external subset. |
+    # | DTDVALID | Off | Validate with the DTD. |
+    # | HUGE | Off | Relax any hardcoded limit from the parser. |
+    # | NOBASEFIX | Off | Do not fixup XINCLUDE xml:base uris. |
+    # | NOBLANKS | Off | Remove blank nodes. |
+    # | NOCDATA | See Note 1. | Merge CDATA as text nodes. |
+    # | NODICT | Off | Do not reuse the context dictionary. |
+    # | NOENT | Off | Substitute entities. |
+    # | NOERROR | On | Suppress error reports. |
+    # | NONET | See Note 2. | Forbid network access. |
+    # | NOWARNING | On | Suppress warning reports. |
+    # | NOXINCNODE | Off | Do not generate XINCLUDE START/END nodes. |
+    # | NSCLEAN | Off | Remove redundant namespaces declarations. |
+    # | OLD10 | Off| Parse using XML-1.0 before update 5. |
+    # | PEDANTIC | Off | Pedantic error reporting. |
+    # | RECOVER | See Note 2. | Recover on errors. |
+    # | SAX1 | Off | Use the SAX1 interface internally. |
+    # | XINCLUDE | Off | Implement XInclude substitution. |
+    #
+    # <br>
+    #
+    # Notes:
+    #
+    # 1. On only for XSML::Stylesheet; off otherwise.
+    # 2. On by default for XML::Document, XML::DocumentFragment, HTML4::Document,
+    #    HTML4::DocumentFragment, XSLT::Stylesheet, and XML::Schema; off otherwise.
+    #
+    #
+    # | STRICT | Off | Strict parsing. |
+    #
+    # - DEFAULT_HTML
+    # - DEFAULT_SCHEMA
+    # - DEFAULT_XML
+    # - DEFAULT_XSLT
+    #
+    #
+    # ### Calling Option Methods on Instance
+    #
+    # ### Giving a Block with a Parsing Method
     #
     # These options directly expose libxml2's parse options, which are all boolean in the sense that
     # an option is "on" or "off".
@@ -15,7 +98,7 @@ module Nokogiri
     # ⚠ Not all parse options are supported on JRuby. Nokogiri will attempt to invoke the equivalent
     # behavior in Xerces/NekoHTML on JRuby when it's possible.
     #
-    # == Setting and unsetting parse options
+    # ## Setting and unsetting parse options
     #
     # You can build your own combinations of parse options by using any of the following methods:
     #

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -5,7 +5,7 @@ module Nokogiri
   module XML
     # :markup: markdown
     #
-    # \Class to house parsing options.
+    # \Class to house options for parsing \XML or \HTML4 (but not \HTML5).
     #
     # ## About the Examples
     #
@@ -23,70 +23,104 @@ module Nokogiri
     #
     # ## Methods That Use \XML::ParseOptions
     #
-    # These methods use \XML::ParseOptions:
+    # Each of the methods listed below accepts an optional argument `options`,
+    # whose value may be either:
     #
-    # - Nokogiri.HTML
-    # - Nokogiri.HTML4
-    # - Nokogiri.XML
-    # - Nokogiri.make
-    # - Nokogiri.parse
-    # - Nokogiri::HTML.fragment
-    # - Nokogiri::HTML4.fragment
-    # - Nokogiri::HTML4.parse
-    # - Nokogiri::HTML4::Document.parse
-    # - Nokogiri::HTML4::DocumentFragment.new
-    # - Nokogiri::HTML4::DocumentFragment.parse
-    # - Nokogiri::XML.Reader
-    # - Nokogiri::XML.fragment
-    # - Nokogiri::XML.parse
-    # - Nokogiri::XML::Document.parse
-    # - Nokogiri::XML::Document.read_io (no block)
-    # - Nokogiri::XML::Document.read_memory (no block)
-    # - Nokogiri::XML::Document.read_memory (no block)
-    # - Nokogiri::XML::DocumentFragment.new
-    # - Nokogiri::XML::DocumentFragment.parse
-    # - Nokogiri::XML::Node#parse
-    # - Nokogiri::XML::ParseOptions.new (no block)
-    # - Nokogiri::XML::Reader.from_io (no block)
-    # - Nokogiri::XML::Reader.from_memory (no block)
-    # - Nokogiri::XML::RelaxNG.new (no block)
-    # - Nokogiri::XML::RelaxNG.read_memory (no block)
-    # - Nokogiri::XML::Schema.new (no block)
-    # - XSD::XMLParser::Nokogiri.new (no block)
+    # - An integer: see [Bitmap Constants](rdoc-ref:ParseOptions@Bitmap+Constants).
+    # - An instance of \ParseOptions: see ParseOptions.new.
+    #
+    # In addition (except as noted), each of the methods accepts a block:
+    # see [Options-Setting Blocks](rdoc-ref:ParseOptions@Options-Setting+Blocks).
+    #
+    # The methods:
+    #
+    # - Nokogiri.HTML.
+    # - Nokogiri.HTML4.
+    # - Nokogiri.XML.
+    # - Nokogiri.make.
+    # - Nokogiri.parse.
+    # - Nokogiri::HTML.fragment.
+    # - Nokogiri::HTML4.fragment.
+    # - Nokogiri::HTML4.parse.
+    # - Nokogiri::HTML4::Document.parse.
+    # - Nokogiri::HTML4::DocumentFragment.new.
+    # - Nokogiri::HTML4::DocumentFragment.parse.
+    # - Nokogiri::XML.Reader.
+    # - Nokogiri::XML.fragment.
+    # - Nokogiri::XML.parse.
+    # - Nokogiri::XML::Document.parse.
+    # - Nokogiri::XML::Document.read_io (no block).
+    # - Nokogiri::XML::Document.read_memory (no block).
+    # - Nokogiri::XML::Document.read_memory (no block).
+    # - Nokogiri::XML::DocumentFragment.new.
+    # - Nokogiri::XML::DocumentFragment.parse.
+    # - Nokogiri::XML::Node#parse.
+    # - Nokogiri::XML::ParseOptions.new (no block).
+    # - Nokogiri::XML::Reader.from_io (no block).
+    # - Nokogiri::XML::Reader.from_memory (no block).
+    # - Nokogiri::XML::RelaxNG.new (no block).
+    # - Nokogiri::XML::RelaxNG.read_memory (no block).
+    # - Nokogiri::XML::Schema.new (no block).
+    # - XSD::XMLParser::Nokogiri.new (no block).
     #
     # Certain other parsing methods use different options;
     # see HTML5.
     #
-    # ## How to Set Options
+    # ## Bitmap Constants
     #
-    # There are three ways to set options for an instance of this class:
-    #
-    # - Calling setter methods on instance (recommended).
-    # - Passing argument `options` with ::new.
-    # - Giving a block with a parsing method.
-    #
-    # ### Calling Setter Methods on Instance (Recommended)
-    #
-    # ### Passing Argument `options` with ::new
-    #
-    # Each of the methods that use \XML::ParseOptions takes an optional argument `options`
-    # whose value is an integer.
-    #
-    # You can use bitmask constants to construct a suitable integer for the options you want;
-    # use logical OR to combine multiple constants:
+    # Except for `STRICT` (see note below),
+    # each of the bitmap constants has a non-zero value
+    # that represents a bit;
+    # here we display a few constants in binary format (base 2):
     #
     # ```
-    # options = ParseOptions::COMPACT
-    # ParseOptions.new(options)
-    # # => #<Nokogiri::XML::ParseOptions: ... strict, compact>
-    # options = ParseOptions::COMPACT | ParseOptions::NOBLANKS
-    # ParseOptions.new(options)
-    # # => #<Nokogiri::XML::ParseOptions: ... strict, noblanks, compact>
+    # ParseOptions::RECOVER.to_s(2)  # => "1"
+    # ParseOptions::NOENT.to_s(2)    # => "10"
+    # ParseOptions::DTDLOAD.to_s(2)  # => "100"
+    # ParseOptions::DTDATTR.to_s(2)  # => "1000"
+    # ParseOptions::DTDVALID.to_s(2) # => "10000"
     # ```
+    #
+    # Any of these constants may be used alone to specify a single option:
+    #
+    # ```
+    # ParseOptions.new(ParseOptions::DTDLOAD)
+    # # => #<Nokogiri::XML::ParseOptions: ... strict, dtdload>
+    # ParseOptions.new(ParseOptions::DTDATTR)
+    # # => #<Nokogiri::XML::ParseOptions: ... strict, dtdattr>
+    # ```
+    #
+    # Multiple constants may be ORed together to specify multiple options:
+    #
+    # ```
+    # options = ParseOptions::BIG_LINES | ParseOptions::COMPACT | ParseOptions::NOCDATA
+    # ParseOptions.new(options)
+    # # => #<Nokogiri::XML::ParseOptions: ... strict, nocdata, compact, big_lines>
     #
     # The bitmask constants are:
     #
-    #
+    # - BIG_LINES.
+    # - COMPACT.
+    # - DTDATTR.
+    # - DTDLOAD.
+    # - DTDVALID.
+    # - HUGE.
+    # - NOBASEFIX.
+    # - NOBLANKS.
+    # - NOCDATA.
+    # - NODICT.
+    # - NOENT.
+    # - NOERROR.
+    # - NONET.
+    # - NOWARNING.
+    # - NOXINCNODE.
+    # - NSCLEAN.
+    # - OLD10.
+    # - PEDANTIC.
+    # - RECOVER.
+    # - SAX1.
+    # - STRICT.
+    # - XINCLUDE.
     #
     # There are also several "shorthand" constants that can set multiple options:
     #
@@ -101,16 +135,7 @@ module Nokogiri
     # # => #<Nokogiri::XML::ParseOptions: ... recover, noent, dtdload, dtdattr, nonet, nocdata, big_lines, default_xslt, default_schema, default_xml>    #
     # ```
     #
-    # ### Giving a Block with a Parsing Method
-    #
-    # These options directly expose libxml2's parse options, which are all boolean in the sense that
-    # an option is "on" or "off".
-    #
-    # 💡 Note that HTML5 parsing has a separate, orthogonal set of options due to the nature of the
-    # HTML5 specification. See Nokogiri::HTML5.
-    #
-    # ⚠ Not all parse options are supported on JRuby. Nokogiri will attempt to invoke the equivalent
-    # behavior in Xerces/NekoHTML on JRuby when it's possible.
+    # ## Options-Setting Blocks
     #
     # ## Convenience Methods
     #

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -71,10 +71,15 @@ module Nokogiri
     #
     # ## Bitmap Constants
     #
+    # Each of the [parsing methods](rdoc-ref:ParseOptions@Methods+That+Use+XML-3A-3AParseOptions)
+    # discussed here accept an integer argument `options` that specifies parsing options.
+    #
+    # That integer value may be constructed using the bitmap constants defined in \ParseOptions.
+    #
     # Except for `STRICT` (see note below),
     # each of the bitmap constants has a non-zero value
-    # that represents a bit;
-    # here we display a few constants in binary format (base 2):
+    # that represents a bit in an integer value;
+    # to illustrate, here are a few of the constants, displayed in binary format (base 2):
     #
     # ```
     # ParseOptions::RECOVER.to_s(2)  # => "1"
@@ -99,6 +104,17 @@ module Nokogiri
     # options = ParseOptions::BIG_LINES | ParseOptions::COMPACT | ParseOptions::NOCDATA
     # ParseOptions.new(options)
     # # => #<Nokogiri::XML::ParseOptions: ... strict, nocdata, compact, big_lines>
+    # ```
+    #
+    # Note:
+    # The value of constant `STRICT` is zero;
+    # it may be used alone to turn all options off:
+    #
+    # ```
+    # XML.parse('<root />') {|options| puts options.inspect }
+    # #<Nokogiri::XML::ParseOptions: recover, nonet, big_lines, default_schema, default_xml>
+    # XML.parse('<root />', nil, nil, ParseOptions::STRICT) {|options| puts options.inspect }
+    # #<Nokogiri::XML::ParseOptions: strict>
     # ```
     #
     # The bitmask constants are:

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -23,14 +23,18 @@ module Nokogiri
     #
     # ## Methods That Use \XML::ParseOptions
     #
-    # Each of the methods listed below accepts an optional argument `options`,
-    # whose value may be either:
+    # Each of the methods listed below performs parsing for an \XML or \HTML4 source.
+    # Each accepts an optional argument `options`
+    # that specifies parsing options;
+    # the argument's value may be either:
     #
     # - An integer: see [Bitmap Constants](rdoc-ref:ParseOptions@Bitmap+Constants).
     # - An instance of \ParseOptions: see ParseOptions.new.
     #
-    # In addition (except as noted), each of the methods accepts a block:
-    # see [Options-Setting Blocks](rdoc-ref:ParseOptions@Options-Setting+Blocks).
+    # In addition (except as noted), each of the methods:
+    #
+    # - Accepts a block that specifies parsing options;
+    #   see [Options-Setting Blocks](rdoc-ref:ParseOptions@Options-Setting+Blocks).
     #
     # The methods:
     #
@@ -55,7 +59,6 @@ module Nokogiri
     # - Nokogiri::XML::DocumentFragment.new.
     # - Nokogiri::XML::DocumentFragment.parse.
     # - Nokogiri::XML::Node#parse.
-    # - Nokogiri::XML::ParseOptions.new (no block).
     # - Nokogiri::XML::Reader.from_io (no block).
     # - Nokogiri::XML::Reader.from_memory (no block).
     # - Nokogiri::XML::RelaxNG.new (no block).
@@ -99,29 +102,28 @@ module Nokogiri
     # ```
     #
     # The bitmask constants are:
-    #
-    # - BIG_LINES.
-    # - COMPACT.
-    # - DTDATTR.
-    # - DTDLOAD.
-    # - DTDVALID.
-    # - HUGE.
-    # - NOBASEFIX.
-    # - NOBLANKS.
-    # - NOCDATA.
-    # - NODICT.
-    # - NOENT.
-    # - NOERROR.
-    # - NONET.
-    # - NOWARNING.
-    # - NOXINCNODE.
-    # - NSCLEAN.
-    # - OLD10.
-    # - PEDANTIC.
-    # - RECOVER.
-    # - SAX1.
-    # - STRICT.
-    # - XINCLUDE.
+    # BIG_LINES,
+    # COMPACT,
+    # DTDATTR,
+    # DTDLOAD,
+    # DTDVALID,
+    # HUGE,
+    # NOBASEFIX,
+    # NOBLANKS,
+    # NOCDATA,
+    # NODICT,
+    # NOENT,
+    # NOERROR,
+    # NONET,
+    # NOWARNING,
+    # NOXINCNODE,
+    # NSCLEAN,
+    # OLD10,
+    # PEDANTIC,
+    # RECOVER,
+    # SAX1,
+    # STRICT,
+    # XINCLUDE.
     #
     # There are also several "shorthand" constants that can set multiple options:
     #
@@ -336,12 +338,34 @@ module Nokogiri
         RUBY
       end
 
-      def strict # :nodoc:
+      # :markup: markdown
+      #
+      # Turns off option `recover`:
+      #
+      # ```
+      # options = ParseOptions.new.recover.compact.big_lines
+      # # => #<Nokogiri::XML::ParseOptions: ... recover, compact, big_lines>
+      # options.strict
+      # # => #<Nokogiri::XML::ParseOptions: ... strict, compact, big_lines>
+      # ```
+      def strict
         @options &= ~RECOVER
         self
       end
 
-      def strict? # :nodoc:
+      # :markup: markdown
+      #
+      # Returns whether option `strict` is on:
+      #
+      # ```
+      # options = ParseOptions.new.recover.compact.big_lines
+      # # => #<Nokogiri::XML::ParseOptions: ... recover, compact, big_lines>
+      # options.strict? # => false
+      # options.strict
+      # # => #<Nokogiri::XML::ParseOptions: ... strict, compact, big_lines>
+      # options.strict? # => true
+      # ```
+      def strict?
         @options & RECOVER == STRICT
       end
 

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -7,7 +7,9 @@ module Nokogiri
     #
     # \Class to house parsing options.
     #
-    # ## Methods That Use XML::ParseOptions:
+    # ## Methods That Use \XML::ParseOptions
+    #
+    # These methods use \XML::ParseOptions:
     #
     # - Nokogiri.parse (but only when _not_ parsing HTML5).
     # - HTML4.parse.
@@ -21,71 +23,106 @@ module Nokogiri
     # Certain other parsing methods use different options;
     # see HTML5.
     #
+    # ## About the Examples
+    #
+    # Examples on this page assume that the following code has been executed:
+    #
+    # ```
+    # require 'nokogiri' # Make Nokogiri available.
+    # include Nokogiri   # Allow omitting leading 'Nokogiri::'.
+    # include XML        # Allow omitting leading 'XML::'.
+    # xml = '<root />'   # Example XML string.
+    # ```
+    #
+    # Examples executed via `IRB` (interactive Ruby) display \ParseOptions instances
+    # using method #inspect.
+    #
     # ## How to Set Options
     #
     # There are three ways to set options for an instance of this class:
     #
+    # - Calling setter methods on instance (recommended).
     # - Passing argument `options` with ::new.
-    # - Calling option methods on instance.
     # - Giving a block with a parsing method.
+    #
+    # ### Calling Setter Methods on Instance (Recommended)
     #
     # ### Passing Argument `options` with ::new
     #
-    # Each of the methods listed above takes an optional argument `options`
+    # Each of the methods that use \XML::ParseOptions takes an optional argument `options`
     # whose value is an integer.
     #
-    # You can use bitmask constants to construct a suitable integer for the options you want:
+    # You can use bitmask constants to construct a suitable integer for the options you want;
+    # use logical OR to combine multiple constants:
     #
     # ```
-    # COMPACT                   # One option.
-    # COMPACT | DTDVALID        # Two options.
-    # COMPACT | DTDVALID | HUGE # Three options.
+    # options = ParseOptions::COMPACT
+    # ParseOptions.new(options)
+    # # => #<Nokogiri::XML::ParseOptions:0x00000198119ca3d8 ... strict, compact>
+    # options = ParseOptions::COMPACT | ParseOptions::NOBLANKS
+    # ParseOptions.new(options)
+    # # => #<Nokogiri::XML::ParseOptions:0x0000019811d5f098 ... strict, noblanks, compact>
     # ```
     #
-    # The option bitmasks are:
+    # The bitmask constants are:
     #
     # | Constant | Default | Meaning |
     # |------|:-------:|---------|
-    # | BIG_LINES | On | Store big lines numbers in text PSVI field. |
-    # | COMPACT | Off | Compact small text nodes; no modification of the tree allowed afterwards (will possibly crash if you try to modify the tree). |
+    # | BIG_LINES | **On** | Store big lines numbers in text PSVI field. |
+    # | COMPACT | **Off** | Compact small text nodes; no modification of the tree allowed afterwards (will possibly crash if you try to modify the tree). |
     # | DTDATTR | See Note 1. | Default DTD attributes. |
     # | DTDLOAD | See Note 1. | Load the external subset. |
-    # | DTDVALID | Off | Validate with the DTD. |
-    # | HUGE | Off | Relax any hardcoded limit from the parser. |
-    # | NOBASEFIX | Off | Do not fixup XINCLUDE xml:base uris. |
-    # | NOBLANKS | Off | Remove blank nodes. |
+    # | DTDVALID | **Off** | Validate with the DTD. |
+    # | HUGE | **Off** | Relax any hardcoded limit from the parser. |
+    # | NOBASEFIX | **Off** | Do not fixup XINCLUDE xml:base uris. |
+    # | NOBLANKS | **Off** | Remove blank nodes. |
     # | NOCDATA | See Note 1. | Merge CDATA as text nodes. |
-    # | NODICT | Off | Do not reuse the context dictionary. |
-    # | NOENT | Off | Substitute entities. |
-    # | NOERROR | On | Suppress error reports. |
+    # | NODICT | **Off** | Do not reuse the context dictionary. |
+    # | NOENT | **Off** | Substitute entities. |
+    # | NOERROR | **On** | Suppress error reports. |
     # | NONET | See Note 2. | Forbid network access. |
-    # | NOWARNING | On | Suppress warning reports. |
-    # | NOXINCNODE | Off | Do not generate XINCLUDE START/END nodes. |
-    # | NSCLEAN | Off | Remove redundant namespaces declarations. |
+    # | NOWARNING | **On** | Suppress warning reports. |
+    # | NOXINCNODE | **Off** | Do not generate XINCLUDE START/END nodes. |
+    # | NSCLEAN | **Off** | Remove redundant namespaces declarations. |
     # | OLD10 | Off| Parse using XML-1.0 before update 5. |
-    # | PEDANTIC | Off | Pedantic error reporting. |
-    # | RECOVER | See Note 2. | Recover on errors. |
-    # | SAX1 | Off | Use the SAX1 interface internally. |
-    # | XINCLUDE | Off | Implement XInclude substitution. |
+    # | PEDANTIC | **Off** | Pedantic error reporting. |
+    # | RECOVER | See Note 2. | Recover from errors in input; no strict parsing. |
+    # | SAX1 | **Off** | Use the SAX1 interface internally. |
+    # | STRICT | **Off** | Use strict parsing; do not recover from errors in input. See Note 3. |
+    # | XINCLUDE | **Off** | Implement XInclude substitution. |
     #
     # <br>
     #
     # Notes:
     #
-    # 1. On only for XSML::Stylesheet; off otherwise.
-    # 2. On by default for XML::Document, XML::DocumentFragment, HTML4::Document,
-    #    HTML4::DocumentFragment, XSLT::Stylesheet, and XML::Schema; off otherwise.
+    # 1. **On** only for XSLT::Stylesheet; **off** otherwise.
+    # 2. **On** by default for XML::Document, XML::DocumentFragment, HTML4::Document,
+    #    HTML4::DocumentFragment, XSLT::Stylesheet, and XML::Schema; **off** otherwise.
+    # 3. The numeric value of constant `STRICT` is zero.
+    #    Therefore using it alone sets all options to **off**;
+    #    ORing it with other non-zero constants is useless:
     #
+    #    ```
     #
-    # | STRICT | Off | Strict parsing. |
+    #    ```
     #
+    # There are also several "shorthand" constants that can set multiple options:
+    #
+    # ```
+    # ParseOptions.new(ParseOptions::DEFAULT_HTML)
+    # # => #<Nokogiri::XML::ParseOptions: ... recover, nowarning, nonet, big_lines, default_schema, noerror, default_html, default_xml>
+    # ParseOptions.new(ParseOptions::DEFAULT_SCHEMA)
+    # # => #<Nokogiri::XML::ParseOptions: ... strict, nonet, big_lines, default_schema>
+    # ParseOptions.new(ParseOptions::DEFAULT_XML)
+    # # => #<Nokogiri::XML::ParseOptions: ... recover, nonet, big_lines, default_schema, default_xml>
+    # ParseOptions.new(ParseOptions::DEFAULT_XSLT)
+    # # => #<Nokogiri::XML::ParseOptions: ... recover, noent, dtdload, dtdattr, nonet, nocdata, big_lines, default_xslt, default_schema, default_xml>    #
+    # ```
     # - DEFAULT_HTML
     # - DEFAULT_SCHEMA
     # - DEFAULT_XML
     # - DEFAULT_XSLT
     #
-    #
-    # ### Calling Option Methods on Instance
     #
     # ### Giving a Block with a Parsing Method
     #
@@ -148,7 +185,9 @@ module Nokogiri
     #     doc = Nokogiri::XML::Document.parse(xml, nil, nil, po)
     #
     class ParseOptions
-      # Strict parsing
+      # :markup: markdown
+      #
+      # Strict parsing; all options (including `recover`) **off**.
       STRICT      = 0
 
       # Recover from errors. On by default for XML::Document, XML::DocumentFragment,
@@ -284,6 +323,36 @@ module Nokogiri
 
       alias_method :to_i, :options
 
+      # :markup: markdown
+      #
+      # Returns a string representation of +self+ that includes
+      # the numeric value of `@options`:
+      #
+      # ```
+      # options = ParseOptions.new
+      # options.inspect
+      # # => "#<Nokogiri::XML::ParseOptions: @options=0 strict>"
+      #
+      # ```
+      #
+      # In general, the returned string also includes the (downcased) names of the options
+      # that are **on** (but omits the names of those that are **off**):
+      #
+      # ```
+      # options.recover.big_lines
+      # options.inspect
+      # # => "#<Nokogiri::XML::ParseOptions: @options=4194305 recover, big_lines>"
+      # ```
+      #
+      # The exception is that always either `recover` (i.e, *not strict*)
+      # or the pseudo-option `strict` is reported:
+      #
+      # ```
+      # options.norecover
+      # options.inspect
+      # # => "#<Nokogiri::XML::ParseOptions:0x0000020700c199f0 @options=4194304 strict, big_lines>"
+      # ```
+      #
       def inspect
         options = []
         self.class.constants.each do |k|

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -140,6 +140,29 @@ module Nokogiri
     #
     # ## Options-Setting Blocks
     #
+    # Many of the [parsing methods](rdoc-ref:ParseOptions@Methods+That+Use+XML-3A-3AParseOptions)
+    # discussed here accept an options-setting block.
+    #
+    # The block is called with a new instance of \ParseOptions
+    # created with the defaults for the specific method:
+    #
+    # ```
+    # XML::parse('<root />') {|options| puts options.inspect }
+    # #<Nokogiri::XML::ParseOptions: recover, nonet, big_lines, default_schema, default_xml>
+    # HTML4::parse('<html />') {|options| puts options.inspect }
+    # #<Nokogiri::XML::ParseOptions: recover, nowarning, nonet, big_lines, default_schema, noerror, default_html, default_xml>
+    # ```
+    #
+    # When the block returns, the parsing is performed using those `options`.
+    #
+    # The block may modify those options, which affects parsing:
+    #
+    # ```
+    # xml = '<root>'                              # Invalid XML (tag not closed).
+    # XML::parse(xml)                             # Parsing works okay because `recover` is on.
+    # XML::parse(xml) {|options| options.strict } # Turns strict on; parsing raises SyntaxError.
+    # ```
+    #
     # ## Convenience Methods
     #
     # A \ParseOptions object has three sets of convenience methods,

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -7,22 +7,6 @@ module Nokogiri
     #
     # \Class to house parsing options.
     #
-    # ## Methods That Use \XML::ParseOptions
-    #
-    # These methods use \XML::ParseOptions:
-    #
-    # - Nokogiri.parse (but only when _not_ parsing HTML5).
-    # - HTML4.parse.
-    # - HTML4.parse.
-    # - HTML4::Document.parse.
-    # - HTML4::DocumentFragment.parse.
-    # - XML.parse.
-    # - XML::Document.parse.
-    # - XML::DocumentFragment.parse.
-    #
-    # Certain other parsing methods use different options;
-    # see HTML5.
-    #
     # ## About the Examples
     #
     # Examples on this page assume that the following code has been executed:
@@ -36,6 +20,42 @@ module Nokogiri
     #
     # Examples executed via `IRB` (interactive Ruby) display \ParseOptions instances
     # using method #inspect.
+    #
+    # ## Methods That Use \XML::ParseOptions
+    #
+    # These methods use \XML::ParseOptions:
+    #
+    # - Nokogiri.HTML
+    # - Nokogiri.HTML4
+    # - Nokogiri.XML
+    # - Nokogiri.make
+    # - Nokogiri.parse
+    # - Nokogiri::HTML.fragment
+    # - Nokogiri::HTML4.fragment
+    # - Nokogiri::HTML4.parse
+    # - Nokogiri::HTML4::Document.parse
+    # - Nokogiri::HTML4::DocumentFragment.new
+    # - Nokogiri::HTML4::DocumentFragment.parse
+    # - Nokogiri::XML.Reader
+    # - Nokogiri::XML.fragment
+    # - Nokogiri::XML.parse
+    # - Nokogiri::XML::Document.parse
+    # - Nokogiri::XML::Document.read_io (no block)
+    # - Nokogiri::XML::Document.read_memory (no block)
+    # - Nokogiri::XML::Document.read_memory (no block)
+    # - Nokogiri::XML::DocumentFragment.new
+    # - Nokogiri::XML::DocumentFragment.parse
+    # - Nokogiri::XML::Node#parse
+    # - Nokogiri::XML::ParseOptions.new (no block)
+    # - Nokogiri::XML::Reader.from_io (no block)
+    # - Nokogiri::XML::Reader.from_memory (no block)
+    # - Nokogiri::XML::RelaxNG.new (no block)
+    # - Nokogiri::XML::RelaxNG.read_memory (no block)
+    # - Nokogiri::XML::Schema.new (no block)
+    # - XSD::XMLParser::Nokogiri.new (no block)
+    #
+    # Certain other parsing methods use different options;
+    # see HTML5.
     #
     # ## How to Set Options
     #
@@ -58,10 +78,10 @@ module Nokogiri
     # ```
     # options = ParseOptions::COMPACT
     # ParseOptions.new(options)
-    # # => #<Nokogiri::XML::ParseOptions:0x00000198119ca3d8 ... strict, compact>
+    # # => #<Nokogiri::XML::ParseOptions: ... strict, compact>
     # options = ParseOptions::COMPACT | ParseOptions::NOBLANKS
     # ParseOptions.new(options)
-    # # => #<Nokogiri::XML::ParseOptions:0x0000019811d5f098 ... strict, noblanks, compact>
+    # # => #<Nokogiri::XML::ParseOptions: ... strict, noblanks, compact>
     # ```
     #
     # The bitmask constants are:
@@ -118,11 +138,6 @@ module Nokogiri
     # ParseOptions.new(ParseOptions::DEFAULT_XSLT)
     # # => #<Nokogiri::XML::ParseOptions: ... recover, noent, dtdload, dtdattr, nonet, nocdata, big_lines, default_xslt, default_schema, default_xml>    #
     # ```
-    # - DEFAULT_HTML
-    # - DEFAULT_SCHEMA
-    # - DEFAULT_XML
-    # - DEFAULT_XSLT
-    #
     #
     # ### Giving a Block with a Parsing Method
     #
@@ -135,37 +150,53 @@ module Nokogiri
     # ⚠ Not all parse options are supported on JRuby. Nokogiri will attempt to invoke the equivalent
     # behavior in Xerces/NekoHTML on JRuby when it's possible.
     #
-    # ## Setting and unsetting parse options
+    # ## Convenience Methods
     #
-    # You can build your own combinations of parse options by using any of the following methods:
+    # A \ParseOptions object has three sets of convenience methods,
+    # each based on the name of one of the constants:
     #
-    # [ParseOptions method chaining]
+    # - **Setters**: each is the downcase of an option name, and turns on an option:
     #
-    #   Every option has an equivalent method in lowercase. You can chain these methods together to
-    #   set various combinations.
+    #     ```
+    #     options = ParseOptions.new
+    #     # => #<Nokogiri::XML::ParseOptions: ... strict>
+    #     options.big_lines
+    #     # => #<Nokogiri::XML::ParseOptions: ... strict, big_lines>
+    #     options.compact
+    #     # => #<Nokogiri::XML::ParseOptions: ... strict, compact, big_lines>
+    #     ```
     #
-    #     # Set the HUGE & PEDANTIC options
-    #     po = Nokogiri::XML::ParseOptions.new.huge.pedantic
-    #     doc = Nokogiri::XML::Document.parse(xml, nil, nil, po)
+    # - **Unsetters**: each begins with `no`, and turns off an option.
+    #   Note that there is no unsetter `nostrict`;
+    #   the setter `recover` serves the same purpose:
     #
-    #   Every option has an equivalent <code>no{option}</code> method in lowercase. You can call these
-    #   methods on an instance of ParseOptions to unset the option.
+    #     ```
+    #     options.nobig_lines
+    #     # => #<Nokogiri::XML::ParseOptions: ... strict, compact>
+    #     options.nocompact
+    #     # => #<Nokogiri::XML::ParseOptions: ... strict>
+    #     options.recover # Functionally equivalent to nostrict.
+    #     # => #<Nokogiri::XML::ParseOptions: ... recover>
+    #     options.noent   # Set NOENT.
+    #     # => #<Nokogiri::XML::ParseOptions: ... recover, noent>
+    #     options.nonoent # Unset NOENT.
+    #     # => #<Nokogiri::XML::ParseOptions: ... recover>
+    #     ```
     #
-    #     # Set the HUGE & PEDANTIC options
-    #     po = Nokogiri::XML::ParseOptions.new.huge.pedantic
+    # - **Queries**: each ends with `?`, and returns whether an option is on or off:
     #
-    #     # later we want to modify the options
-    #     po.nohuge # Unset the HUGE option
-    #     po.nopedantic # Unset the PEDANTIC option
+    #     ```
+    #     options.recover? # => true
+    #     options.strict?  # => false
+    #     ```
     #
-    #   💡 Note that some options begin with "no" leading to the logical but perhaps unintuitive
-    #   double negative:
+    # Each setter and unsetter method returns +self+,
+    # so the methods may be chained:
     #
-    #     po.nocdata # Set the NOCDATA parse option
-    #     po.nonocdata # Unset the NOCDATA parse option
-    #
-    #   💡 Note that negation is not available for STRICT, which is itself a negation of all other
-    #   features.
+    # ```
+    # options.compact.big_lines
+    # # => #<Nokogiri::XML::ParseOptions: ... strict, compact, big_lines>
+    # ```
     #
     #
     # [Using Ruby Blocks]
@@ -308,15 +339,18 @@ module Nokogiri
         RUBY
       end
 
+      # :nodoc:
       def strict
         @options &= ~RECOVER
         self
       end
 
+      # :nodoc:
       def strict?
         @options & RECOVER == STRICT
       end
 
+      # :doc:
       def ==(other)
         other.to_i == to_i
       end
@@ -350,7 +384,7 @@ module Nokogiri
       # ```
       # options.norecover
       # options.inspect
-      # # => "#<Nokogiri::XML::ParseOptions:0x0000020700c199f0 @options=4194304 strict, big_lines>"
+      # # => "#<Nokogiri::XML::ParseOptions: @options=4194304 strict, big_lines>"
       # ```
       #
       def inspect

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -228,23 +228,6 @@ module Nokogiri
     # # => #<Nokogiri::XML::ParseOptions: ... strict, compact, big_lines>
     # ```
     #
-    #
-    # [Using Ruby Blocks]
-    #
-    #   Most parsing methods will accept a block for configuration of parse options, and we
-    #   recommend chaining the setter methods:
-    #
-    #     doc = Nokogiri::XML::Document.parse(xml) { |config| config.huge.pedantic }
-    #
-    #
-    # [ParseOptions constants]
-    #
-    #   You can also use the constants declared under Nokogiri::XML::ParseOptions to set various
-    #   combinations. They are bits in a bitmask, and so can be combined with bitwise operators:
-    #
-    #     po = Nokogiri::XML::ParseOptions.new(Nokogiri::XML::ParseOptions::HUGE | Nokogiri::XML::ParseOptions::PEDANTIC)
-    #     doc = Nokogiri::XML::Document.parse(xml, nil, nil, po)
-    #
     class ParseOptions
 
       # Strict parsing; do not recover from errors in input.
@@ -341,6 +324,16 @@ module Nokogiri
       # sets NONET, BIG_LINES.
       DEFAULT_SCHEMA = NONET | BIG_LINES
 
+      # Returns or sets and returns the integer value of `self`:
+      #
+      # ```
+      # options = ParseOptions.new(ParseOptions::DEFAULT_HTML)
+      # # => #<Nokogiri::XML::ParseOptions: ... recover, nowarning, nonet, big_...
+      # options.options # => 4196449
+      # options.options = ParseOptions::STRICT
+      # options.options # => 0
+      # ```
+      #
       attr_accessor :options
 
       # :markup: markdown
@@ -418,7 +411,7 @@ module Nokogiri
 
       # :call-seq:
       #   strict?
-      # 
+      #
       # Returns whether option `strict` is on:
       #
       # ```

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -306,7 +306,14 @@ module Nokogiri
 
       # :markup: markdown
       #
-      # Returns a new \ParseOptions object with all options off
+      # :call-seq:
+      #   ParseOptions.new(options = ParseOptions::STRICT)
+      #
+      # Returns a new \ParseOptions object with options as specified by integer argument `options`.
+      # The value of `options` may be constructed
+      # using [Bitmap Constants](rdoc-ref:ParseOptions@Bitmap+Constants).
+      #
+      # With the simple constant `ParseOptions::STRICT` (the default), all options are off
       # (`strict` means `norecover`):
       #
       # ```
@@ -314,6 +321,22 @@ module Nokogiri
       # # => #<Nokogiri::XML::ParseOptions: ... strict>
       # ```
       #
+      # With a different simple constant, one option may be set:
+      #
+      # ```
+      # ParseOptions.new(ParseOptions::RECOVER)
+      # # => #<Nokogiri::XML::ParseOptions: ... recover>
+      # ParseOptions.new(ParseOptions::COMPACT)
+      # # => #<Nokogiri::XML::ParseOptions:  ... strict, compact>
+      # ```
+      #
+      # With multiple ORed constants, multiple options may be set:
+      #
+      # ```
+      # options = ParseOptions::COMPACT | ParseOptions::RECOVER | ParseOptions::BIG_LINES
+      # ParseOptions.new(options)
+      # # => #<Nokogiri::XML::ParseOptions: ... recover, compact, big_lines>
+      # ```
       def initialize(options = STRICT)
         @options = options
       end

--- a/lib/nokogiri/xml/parse_options.rb
+++ b/lib/nokogiri/xml/parse_options.rb
@@ -96,6 +96,7 @@ module Nokogiri
     # options = ParseOptions::BIG_LINES | ParseOptions::COMPACT | ParseOptions::NOCDATA
     # ParseOptions.new(options)
     # # => #<Nokogiri::XML::ParseOptions: ... strict, nocdata, compact, big_lines>
+    # ```
     #
     # The bitmask constants are:
     #


### PR DESCRIPTION
Revises the documentation for `XML::ParseOptions`.