### PR TITLE
fix: escape foreign style tag content when serializing HTML5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,13 @@ We've resolved many long-standing bugs in the various schema classes, validation
 * Passing libxml2 encoding IDs to `SAX::ParserContext` methods is now deprecated and will generate a warning. The use of `SAX::Parser::ENCODINGS` is also deprecated. Use `Encoding` objects or encoding names instead.
 
 
+## v1.16.8 / 2024-12-02
+
+### Fixed
+
+* [CRuby] When serializing HTML5 documents, properly escape foreign content "style" elements. Normally, a "style" tag contains  raw text that does not need entity-escaping, but when it appears in either SVG or MathML foreign content, the "style" tag is now correctly escaped when serialized. @flavorjones
+
+
 ## v1.16.7 / 2024-07-27
 
 ## Dependencies
@@ -257,6 +264,13 @@ The following people and organizations were kind enough to sponsor @flavorjones 
 * Frank Groeneveld @frenkel
 
 We'd also like to thank @github who donate a ton of compute time for our CI pipelines!
+
+
+## 1.15.7 / 2024-12-02
+
+### Fixed
+
+* [CRuby] When serializing HTML5 documents, properly escape foreign content "style" elements. Normally, a "style" tag contains  raw text that does not need entity-escaping, but when it appears in either SVG or MathML foreign content, the "style" tag is now correctly escaped when serialized. @flavorjones
 
 
 ## 1.15.6 / 2024-03-16

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1869,13 +1869,19 @@ is_one_of(xmlNodePtr node, char const *const *tagnames, size_t num_tagnames)
   if (name == NULL) { // fragments don't have a name
     return false;
   }
+
+  if (node->ns != NULL) {
+    // if the node has a namespace, it's in a foreign context and is not one of the HTML tags we're
+    // matching against.
+    return false;
+  }
+
   for (size_t idx = 0; idx < num_tagnames; ++idx) {
     if (!strcmp(name, tagnames[idx])) {
       return true;
     }
   }
   return false;
-
 }
 
 static void

--- a/test/html5/test_serialize.rb
+++ b/test/html5/test_serialize.rb
@@ -553,4 +553,20 @@ class TestHtml5Serialize < Nokogiri::TestCase
     refute(fragment.send(:prepend_newline?))
     assert_equal("<div>hello</div>goodbye", fragment.to_html)
   end
+
+  describe "foreign content style tag serialization is escaped" do
+    it "with svg parent" do
+      input = %{<svg><style>&lt;img src>}
+      expected = %{<svg><style>&lt;img src&gt;</style></svg>}
+
+      assert_equal(expected, Nokogiri::HTML5.fragment(input).to_html)
+    end
+
+    it "with math parent" do
+      input = %{<math><style>&lt;img src>}
+      expected = %{<math><style>&lt;img src&gt;</style></math>}
+
+      assert_equal(expected, Nokogiri::HTML5.fragment(input).to_html)
+    end
+  end
 end if Nokogiri.uses_gumbo?


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Normally, a `style` tag is considered to be a raw text element, meaning `<` is parsed as part of a possible "tag start" token, and is serialized literally (and not rendered as an escaped character reference `&lt;`).

However, when appearing in either SVG or MathML foreign content, a `style` tag should *not* be considered a raw text element, and should be escaped when serialized. libgumbo is parsing this case correctly, but our HTML5 serialization code does not escape the content.

This commit updates the static `is_one_of()` C function to consider the namespace of the parent node as well as the tag's local name when deciding whether the tag matches the list of HTML elements, so that a `style` tag in foreign content will *not* match, but a `style` tag in HTML content will match.


**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

HTML5 is only available in the CRuby impl.