### PR TITLE
fix: escape foreign style tag content when serializing HTML5 (v1.16.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
+## next / unreleased
+
+### Fixed
+
+* [CRuby] When serializing HTML5 documents, properly escape foreign content "style" elements. Normally, a "style" tag contains  raw text that does not need entity-escaping, but when it appears in either SVG or MathML foreign content, the "style" tag is now correctly escaped when serialized. @flavorjones
+
+
 ## v1.16.7 / 2024-07-27
 
 ## Dependencies

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -1849,13 +1849,19 @@ is_one_of(xmlNodePtr node, char const *const *tagnames, size_t num_tagnames)
   if (name == NULL) { // fragments don't have a name
     return false;
   }
+
+  if (node->ns != NULL) {
+    // if the node has a namespace, it's in a foreign context and is not one of the HTML tags we're
+    // matching against.
+    return false;
+  }
+
   for (size_t idx = 0; idx < num_tagnames; ++idx) {
     if (!strcmp(name, tagnames[idx])) {
       return true;
     }
   }
   return false;
-
 }
 
 static void

--- a/test/html5/test_serialize.rb
+++ b/test/html5/test_serialize.rb
@@ -553,4 +553,20 @@ class TestHtml5Serialize < Nokogiri::TestCase
     refute(fragment.send(:prepend_newline?))
     assert_equal("<div>hello</div>goodbye", fragment.to_html)
   end
+
+  describe "foreign content style tag serialization is escaped" do
+    it "with svg parent" do
+      input = %{<svg><style>&lt;img src>}
+      expected = %{<svg><style>&lt;img src&gt;</style></svg>}
+
+      assert_equal(expected, Nokogiri::HTML5.fragment(input).to_html)
+    end
+
+    it "with math parent" do
+      input = %{<math><style>&lt;img src>}
+      expected = %{<math><style>&lt;img src&gt;</style></math>}
+
+      assert_equal(expected, Nokogiri::HTML5.fragment(input).to_html)
+    end
+  end
 end if Nokogiri.uses_gumbo?


### PR DESCRIPTION
Backport of #3348 to v1.16.x