### PR TITLE
ci: drop rdoc from the upstream jruby bundle

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -178,6 +178,8 @@ jobs:
 
   jruby-head:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: "rdoc"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

drop rdoc from the upstream jruby bundle to work around:

- https://github.com/mkristian/jar-dependencies/issues/86
- https://github.com/jruby/jruby/issues/8488

Example failure in CI: https://github.com/sparklemotion/nokogiri/actions/runs/12231301150/job/34114096440
