### PR TITLE
fix(jruby): XML::DocumentFragment.dup to another document

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -978,10 +978,11 @@ public class XmlNode extends RubyObject
 
   @JRubyMethod(visibility = Visibility.PROTECTED)
   public IRubyObject
-  initialize_copy_with_args(ThreadContext context, IRubyObject other, IRubyObject level, IRubyObject _ignored)
+  initialize_copy_with_args(ThreadContext context, IRubyObject other, IRubyObject level, IRubyObject document)
   {
     boolean deep = level instanceof RubyInteger && RubyFixnum.fix2int(level) != 0;
     this.node = asXmlNode(context, other).node.cloneNode(deep);
+    setDocument(context, (XmlDocument)document);
     return this;
   }
 

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -238,8 +238,6 @@ module Nokogiri
         end
 
         def test_dup_different_parent_document
-          skip_unless_libxml2("Node.dup with new_parent arg is only implemented on CRuby")
-
           doc1 = XML::Document.parse("<root><div><p>hello</p></div></root>")
           doc2 = XML::Document.parse("<div></div>")
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Back in b92660e6 (#1834 fixing #1063) I omitted support in JRuby for the "new_parent_document" argument to `Node#dup` because there was no performance reason to implement it. So the test was skipped.

However, in 1e7d38af and other commits in #3117 (fixing #316), I introduced a call to `initialize_copy_with_args` that passes the new parent document as an argument on both CRuby and JRuby implementations. Because the test was skipped, I didn't catch that this broke on JRuby.

In particular this was a problem for Loofah which relies on decorators, and even more particularly this broke the `Loofah::TextBehavior` formatting concern for `Loofah::*::DocumentFragment` objects.


**Have you included adequate test coverage?**

The skipped test is no longer skipped!

Maybe we should be running downstream tests with JRuby, too? But that feels like a big investment right now so I'll avoid scarring on the first cut, and wait to see if it happens again.


**Does this change affect the behavior of either the C or the Java implementations?**

Brings the Java impl into agreement with the C impl.
