### PR TITLE
fix(jruby): XML::DocumentFragment.dup to another document (v1.17.x)

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -978,10 +978,11 @@ public class XmlNode extends RubyObject
 
   @JRubyMethod(visibility = Visibility.PROTECTED)
   public IRubyObject
-  initialize_copy_with_args(ThreadContext context, IRubyObject other, IRubyObject level, IRubyObject _ignored)
+  initialize_copy_with_args(ThreadContext context, IRubyObject other, IRubyObject level, IRubyObject document)
   {
     boolean deep = level instanceof RubyInteger && RubyFixnum.fix2int(level) != 0;
     this.node = asXmlNode(context, other).node.cloneNode(deep);
+    setDocument(context, (XmlDocument)document);
     return this;
   }
 

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -238,8 +238,6 @@ module Nokogiri
         end
 
         def test_dup_different_parent_document
-          skip_unless_libxml2("Node.dup with new_parent arg is only implemented on CRuby")
-
           doc1 = XML::Document.parse("<root><div><p>hello</p></div></root>")
           doc2 = XML::Document.parse("<div></div>")
 


### PR DESCRIPTION
Backport of https://github.com/sparklemotion/nokogiri/pull/3372