### PR TITLE
ext: add Ruby 3.4 to the precompiled native gems

### DIFF
--- a/.cross_rubies
+++ b/.cross_rubies
@@ -25,3 +25,12 @@
 3.3.5:x86_64-darwin
 3.3.5:x86_64-linux-gnu
 3.3.5:x86_64-linux-musl
+3.4.0:aarch64-linux-gnu
+3.4.0:aarch64-linux-musl
+3.4.0:arm-linux-gnu
+3.4.0:arm-linux-musl
+3.4.0:arm64-darwin
+3.4.0:x64-mingw-ucrt
+3.4.0:x86_64-darwin
+3.4.0:x86_64-linux-gnu
+3.4.0:x86_64-linux-musl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,9 @@ jobs:
   ruby_versions:
     needs: ["basic"]
     outputs:
-      minors: "['3.1', '3.2', '3.3']"
+      setup_ruby: "['3.1', '3.2', '3.3', '3.4.0-rc1']"
+      setup_ruby_windows: "['3.1', '3.2', '3.3', 'head']"
+      nokogiri_test_image: "['3.1', '3.2', '3.3', '3.4-rc']"
     runs-on: ubuntu-latest
     steps:
       - run: echo "generating rubies ..."
@@ -124,7 +126,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.nokogiri_test_image) }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
@@ -148,7 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.nokogiri_test_image) }}
         mem: ["ruby"]
         include:
           - sys: "disable"
@@ -264,7 +266,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby) }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -319,7 +321,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_windows) }}
     runs-on: windows-2022
     steps:
       - name: configure git crlf
@@ -496,7 +498,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -518,7 +520,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby) }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -539,7 +541,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_windows) }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -596,7 +598,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -624,7 +626,7 @@ jobs:
           - arm-linux-musl
           - x86_64-linux-gnu
           - x86_64-linux-musl
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby) }}
         include:
           # declare docker image for each platform
           - { platform: aarch64-linux-musl, docker_tag: "-alpine", bootstrap: "apk add bash build-base &&" }
@@ -663,7 +665,7 @@ jobs:
         platform:
           - arm64-darwin
           - x86_64-darwin
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby) }}
         include:
           - { platform: arm64-darwin, os: macos-14 }
           - { platform: x86_64-darwin, os: macos-13 }
@@ -686,7 +688,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.minors) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_windows) }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/generate-ci-images.yml
+++ b/.github/workflows/generate-ci-images.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["alpine", "mri-3.1", "mri-3.2", "mri-3.3", "ubuntu", "upstream-libxml"]
+        tag: ["alpine", "mri-3.1", "mri-3.2", "mri-3.3", "mri-3.4-rc", "ubuntu", "upstream-libxml"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/generate-ci-images.yml
+++ b/.github/workflows/generate-ci-images.yml
@@ -35,3 +35,5 @@ jobs:
           push: true
           tags: ghcr.io/sparklemotion/nokogiri-test:${{matrix.tag}}
           file: oci-images/nokogiri-test/${{matrix.tag}}.dockerfile
+          cache-from: type=registry,ref=ghcr.io/sparklemotion/nokogiri-test:${{ matrix.tag }}-cache
+          cache-to: type=registry,ref=ghcr.io/sparklemotion/nokogiri-test:${{ matrix.tag }}-cache,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 #### Ruby
 
+This release introduces native gem support for Ruby 3.4.
+
 This release ends support for Ruby 3.0, for which [upstream support ended 2024-04-23](https://www.ruby-lang.org/en/downloads/branches/).
+
+This release ships separate precompiled GNU and Musl gems for all linux platforms. Previously both GNU and Musl target systems could use and install the same gem, e.g., the platform gem for `x86_64-linux`. Now, however, the precompiled gem platforms would be `x86_64-linux-gnu` and `x86_64-linux-musl`. So long as you're on `bundler >= 2.5.6` this should be seamless other than perhaps needing to update the platforms in your "Gemfile.lock".
 
 This release drops precompiled native platform gems for `x86-linux` and `x86-mingw32`. **These platforms are still supported.** Users on these platforms must install the "ruby platform" gem which requires a compiler toolchain. See [Installing the `ruby` platform gem](https://nokogiri.org/tutorials/installing_nokogiri.html#installing-the-ruby-platform-gem) in the installation docs. (#3369, #3081)
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
 
   # building extensions
   gem "rake-compiler", "1.2.8"
-  gem "rake-compiler-dock", "1.6.0"
+  gem "rake-compiler-dock", "1.7.0.rc1"
 
   # parser generator
   gem "rexical", "1.0.8"

--- a/oci-images/nokogiri-test/mri-3.4-rc.dockerfile
+++ b/oci-images/nokogiri-test/mri-3.4-rc.dockerfile
@@ -1,0 +1,46 @@
+FROM ruby:3.4-rc
+
+# include_file debian-prelude.step
+# -*- dockerfile -*-
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y apt-utils
+
+
+# include_file valgrind-from-source.step
+# -*- dockerfile -*-
+
+RUN apt-get install -y libc6-dbg
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.21.0.tar.bz2 && \
+    tar -xf valgrind-3.21.0.tar.bz2 && \
+    cd valgrind-3.21.0 && \
+    ./configure && \
+    make && \
+    make install
+
+
+# include_file debian-libxml-et-al.step
+# -*- dockerfile -*-
+
+RUN apt-get install -y libxslt-dev libxml2-dev zlib1g-dev pkg-config
+RUN apt-get install -y libyaml-dev # for psych 5
+
+
+# include_file update-bundler.step
+# -*- dockerfile -*-
+
+RUN gem install bundler
+
+
+# include_file bundle-install.step
+# -*- dockerfile -*-
+
+COPY Gemfile nokogiri/
+COPY Gemfile.lock nokogiri/
+COPY nokogiri.gemspec nokogiri/
+
+RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" nokogiri/Gemfile.lock | tail -n 1)"
+RUN cd nokogiri && bundle install
+

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -8,8 +8,8 @@ module DockerHelper
   IMAGE_DIR = "oci-images/nokogiri-test"
   IMAGE_NAME = "ghcr.io/sparklemotion/nokogiri-test"
   RUBIES = {
-    # engine → array of ruby minor versions
-    mri: File.read(".cross_rubies").lines.map { _1.split(":").first }.uniq.map { _1.split(".").take(2).join(".") },
+    # engine → array of ruby minor version docker tags
+    mri: ["3.1", "3.2", "3.3", "3.4-rc"],
   }
 
   class << self

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -87,6 +87,8 @@ module DockerHelper
                   push: true
                   tags: #{IMAGE_NAME}:${{matrix.tag}}
                   file: #{IMAGE_DIR}/${{matrix.tag}}.dockerfile
+                  cache-from: type=registry,ref=ghcr.io/sparklemotion/nokogiri-test:${{ matrix.tag }}-cache
+                  cache-to: type=registry,ref=ghcr.io/sparklemotion/nokogiri-test:${{ matrix.tag }}-cache,mode=max
       YAML
 
       puts "writing #{filename} ..."


### PR DESCRIPTION

**What problem is this PR intended to solve?**

ext: add Ruby 3.4 to the precompiled native gems

Closes #3273.


**Have you included adequate test coverage?**

Yes.


**Does this change affect the behavior of either the C or the Java implementations?**

CRuby only, obvs.