### PR TITLE
Support compiled XPath expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ This release ships separate precompiled GNU and Musl gems for all linux platform
 This release drops precompiled native platform gems for `x86-linux` and `x86-mingw32`. **These platforms are still supported.** Users on these platforms must install the "ruby platform" gem which requires a compiler toolchain. See [Installing the `ruby` platform gem](https://nokogiri.org/tutorials/installing_nokogiri.html#installing-the-ruby-platform-gem) in the installation docs. (#3369, #3081)
 
 
+### Improved
+
+* CSS and XPath queries are faster now that `Node#xpath`, `Node#css`, and related functions are re-using the underlying xpath context object (which is expensive to initialize). We benchmarked a 2.8x improvement for a 6kb file, and a more modest 1.3x improvement for a 70kb file. (#3378) @flavorjones
+
+
 ## v1.17.2 / 2024-12-12
 
 ### Fixed

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -179,7 +179,7 @@ public class XmlXpathContext extends RubyObject
     final NokogiriXPathFunctionResolver fnResolver = NokogiriXPathFunctionResolver.create(handler);
     try {
       return tryGetNodeSet(context, expr, fnResolver);
-    } catch (TransformerException ex) {
+    } catch (TransformerException | RuntimeException ex) {
       throw XmlSyntaxError.createXMLXPathSyntaxError(context.runtime,
           (expr + ": " + ex.toString()),
           ex).toThrowable();

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -40,6 +40,7 @@ void noko_init_xml_schema(void);
 void noko_init_xml_syntax_error(void);
 void noko_init_xml_text(void);
 void noko_init_xml_xpath_context(void);
+void noko_init_xml_xpath_expression(void);
 void noko_init_xslt_stylesheet(void);
 void noko_init_html_document(void);
 void noko_init_html_element_description(void);
@@ -253,6 +254,7 @@ Init_nokogiri(void)
   noko_init_html4_sax_parser();
 
   noko_init_xml_xpath_context();
+  noko_init_xml_xpath_expression();
   noko_init_xslt_stylesheet();
   noko_init_html_element_description();
   noko_init_html_entity_lookup();

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -211,6 +211,8 @@ VALUE noko_xml_sax_parser_context_wrap(VALUE klass, xmlParserCtxtPtr c_context);
 xmlParserCtxtPtr noko_xml_sax_parser_context_unwrap(VALUE rb_context);
 void noko_xml_sax_parser_context_set_encoding(xmlParserCtxtPtr c_context, VALUE rb_encoding);
 
+xmlXPathCompExprPtr noko_xml_xpath_expression_unwrap(VALUE rb_expression);
+
 #define DOC_RUBY_OBJECT_TEST(x) ((nokogiriTuplePtr)(x->_private))
 #define DOC_RUBY_OBJECT(x) (((nokogiriTuplePtr)(x->_private))->doc)
 #define DOC_UNLINKED_NODE_HASH(x) (((nokogiriTuplePtr)(x->_private))->unlinkedNodes)

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -146,6 +146,7 @@ NOKOPUBVAR VALUE cNokogiriXmlSchema;
 NOKOPUBVAR VALUE cNokogiriXmlSyntaxError;
 NOKOPUBVAR VALUE cNokogiriXmlText ;
 NOKOPUBVAR VALUE cNokogiriXmlXpathContext;
+NOKOPUBVAR VALUE cNokogiriXmlXpathExpression;
 NOKOPUBVAR VALUE cNokogiriXmlXpathSyntaxError;
 NOKOPUBVAR VALUE cNokogiriXsltStylesheet ;
 

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -327,7 +327,7 @@ method_caller(xmlXPathParserContextPtr ctxt, int argc)
 }
 
 static xmlXPathFunction
-handler_lookup(void *data, const xmlChar *c_name, const xmlChar *c_ns_uri)
+_noko_xml_xpath_context_handler_lookup(void *data, const xmlChar *c_name, const xmlChar *c_ns_uri)
 {
   VALUE rb_handler = (VALUE)data;
   if (rb_respond_to(rb_handler, rb_intern((const char *)c_name))) {
@@ -376,59 +376,54 @@ generic_exception_pusher(void *data, const char *msg, ...)
  * a +Float+, or a boolean.
  */
 static VALUE
-rb_xml_xpath_context_evaluate(int argc, VALUE *argv, VALUE rb_context)
+noko_xml_xpath_context_evaluate(int argc, VALUE *argv, VALUE rb_context)
 {
-  VALUE search_path, xpath_handler;
-  VALUE retval = Qnil;
   xmlXPathContextPtr c_context;
-  xmlXPathObjectPtr xpath;
-  xmlChar *query;
-  VALUE errors = rb_ary_new();
+  VALUE rb_expression = Qnil;
+  VALUE rb_function_lookup_handler = Qnil;
+  xmlChar *c_expression_str = NULL;
+  VALUE rb_errors = rb_ary_new();
+  xmlXPathObjectPtr c_xpath_object;
+  VALUE rb_xpath_object = Qnil;
 
-  TypedData_Get_Struct(
-    rb_context,
-    xmlXPathContext,
-    &xml_xpath_context_type,
-    c_context
-  );
+  TypedData_Get_Struct(rb_context, xmlXPathContext, &xml_xpath_context_type, c_context);
 
-  if (rb_scan_args(argc, argv, "11", &search_path, &xpath_handler) == 1) {
-    xpath_handler = Qnil;
-  }
+  rb_scan_args(argc, argv, "11", &rb_expression, &rb_function_lookup_handler);
 
-  query = (xmlChar *)StringValueCStr(search_path);
+  c_expression_str = (xmlChar *)StringValueCStr(rb_expression);
 
-  if (Qnil != xpath_handler) {
+  if (Qnil != rb_function_lookup_handler) {
     /* FIXME: not sure if this is the correct place to shove private data. */
-    c_context->userData = (void *)xpath_handler;
+    c_context->userData = (void *)rb_function_lookup_handler;
     xmlXPathRegisterFuncLookup(
       c_context,
-      handler_lookup,
-      (void *)xpath_handler
+      _noko_xml_xpath_context_handler_lookup,
+      (void *)rb_function_lookup_handler
     );
   }
 
-  xmlSetStructuredErrorFunc((void *)errors, noko__error_array_pusher);
-  xmlSetGenericErrorFunc((void *)errors, generic_exception_pusher);
+  xmlSetStructuredErrorFunc((void *)rb_errors, noko__error_array_pusher);
+  xmlSetGenericErrorFunc((void *)rb_errors, generic_exception_pusher);
 
-  xpath = xmlXPathEvalExpression(query, c_context);
+  c_xpath_object = xmlXPathEvalExpression(c_expression_str, c_context);
 
   xmlSetStructuredErrorFunc(NULL, NULL);
   xmlSetGenericErrorFunc(NULL, NULL);
+
   xmlXPathRegisterFuncLookup(c_context, NULL, NULL);
 
-  if (xpath == NULL) {
-    rb_exc_raise(rb_ary_entry(errors, 0));
+  if (c_xpath_object == NULL) {
+    rb_exc_raise(rb_ary_entry(rb_errors, 0));
   }
 
-  retval = xpath2ruby(xpath, c_context);
-  if (retval == Qundef) {
-    retval = noko_xml_node_set_wrap(NULL, DOC_RUBY_OBJECT(c_context->doc));
+  rb_xpath_object = xpath2ruby(c_xpath_object, c_context);
+  if (rb_xpath_object == Qundef) {
+    rb_xpath_object = noko_xml_node_set_wrap(NULL, DOC_RUBY_OBJECT(c_context->doc));
   }
 
-  xmlXPathFreeNodeSetList(xpath);
+  xmlXPathFreeNodeSetList(c_xpath_object);
 
-  return retval;
+  return rb_xpath_object;
 }
 
 /*
@@ -505,7 +500,7 @@ noko_init_xml_xpath_context(void)
 
   rb_define_singleton_method(cNokogiriXmlXpathContext, "new", rb_xml_xpath_context_new, 1);
 
-  rb_define_method(cNokogiriXmlXpathContext, "evaluate", rb_xml_xpath_context_evaluate, -1);
+  rb_define_method(cNokogiriXmlXpathContext, "evaluate", noko_xml_xpath_context_evaluate, -1);
   rb_define_method(cNokogiriXmlXpathContext, "register_variable", rb_xml_xpath_context_register_variable, 2);
   rb_define_method(cNokogiriXmlXpathContext, "register_ns", rb_xml_xpath_context_register_ns, 2);
   rb_define_method(cNokogiriXmlXpathContext, "node=", rb_xml_xpath_context_set_node, 1);

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -382,6 +382,7 @@ noko_xml_xpath_context_evaluate(int argc, VALUE *argv, VALUE rb_context)
   VALUE rb_expression = Qnil;
   VALUE rb_function_lookup_handler = Qnil;
   xmlChar *c_expression_str = NULL;
+  xmlXPathCompExprPtr c_expression_comp = NULL;
   VALUE rb_errors = rb_ary_new();
   xmlXPathObjectPtr c_xpath_object;
   VALUE rb_xpath_object = Qnil;
@@ -390,7 +391,11 @@ noko_xml_xpath_context_evaluate(int argc, VALUE *argv, VALUE rb_context)
 
   rb_scan_args(argc, argv, "11", &rb_expression, &rb_function_lookup_handler);
 
-  c_expression_str = (xmlChar *)StringValueCStr(rb_expression);
+  if (rb_obj_is_kind_of(rb_expression, cNokogiriXmlXpathExpression)) {
+    c_expression_comp = noko_xml_xpath_expression_unwrap(rb_expression);
+  } else {
+    c_expression_str = (xmlChar *)StringValueCStr(rb_expression);
+  }
 
   if (Qnil != rb_function_lookup_handler) {
     /* FIXME: not sure if this is the correct place to shove private data. */
@@ -405,7 +410,11 @@ noko_xml_xpath_context_evaluate(int argc, VALUE *argv, VALUE rb_context)
   xmlSetStructuredErrorFunc((void *)rb_errors, noko__error_array_pusher);
   xmlSetGenericErrorFunc((void *)rb_errors, generic_exception_pusher);
 
-  c_xpath_object = xmlXPathEvalExpression(c_expression_str, c_context);
+  if (c_expression_comp) {
+    c_xpath_object = xmlXPathCompiledEval(c_expression_comp, c_context);
+  } else {
+    c_xpath_object = xmlXPathEvalExpression(c_expression_str, c_context);
+  }
 
   xmlSetStructuredErrorFunc(NULL, NULL);
   xmlSetGenericErrorFunc(NULL, NULL);

--- a/ext/nokogiri/xml_xpath_expression.c
+++ b/ext/nokogiri/xml_xpath_expression.c
@@ -1,0 +1,55 @@
+#include <nokogiri.h>
+
+VALUE cNokogiriXmlXpathExpression;
+
+static void
+_noko_xml_xpath_expression_dfree(void *data)
+{
+  xmlXPathCompExprPtr c_expr = (xmlXPathCompExprPtr)data;
+  xmlXPathFreeCompExpr(c_expr);
+}
+
+static size_t
+_noko_xml_xpath_expression_dsize(const void *data)
+{
+  return 0; // TODO
+}
+
+static const rb_data_type_t _noko_xml_xpath_expression_type = {
+  .wrap_struct_name = "xmlXPathCompExpr",
+  .function = {
+    .dfree = _noko_xml_xpath_expression_dfree,
+    .dsize = _noko_xml_xpath_expression_dsize,
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+static VALUE
+noko_xml_xpath_expression_s_new(VALUE klass, VALUE rb_input)
+{
+  xmlXPathCompExprPtr c_expr;
+  VALUE rb_expr = Qnil;
+
+  c_expr = xmlXPathCompile((const xmlChar *)StringValueCStr(rb_input));
+  if (c_expr) {
+    rb_expr = TypedData_Wrap_Struct(klass, &_noko_xml_xpath_expression_type, c_expr);
+  }
+
+  return rb_expr;
+}
+
+void
+noko_init_xml_xpath_expression(void)
+{
+  /*
+   *  Nokogiri::XML::XPath::Expression is a compiled XPath expression that can be created to
+   *  prepare frequently-used search queries. Preparing them once and re-using them is generally
+   *  faster than re-parsing the expression from a string each time it's used.
+   */
+  cNokogiriXmlXpathExpression = rb_define_class_under(mNokogiriXmlXpath, "Expression", rb_cObject);
+  rb_gc_register_mark_object(cNokogiriXmlXpathExpression);
+
+  rb_undef_alloc_func(cNokogiriXmlXpathExpression);
+
+  rb_define_singleton_method(cNokogiriXmlXpathExpression, "new", noko_xml_xpath_expression_s_new, 1);
+}

--- a/ext/nokogiri/xml_xpath_expression.c
+++ b/ext/nokogiri/xml_xpath_expression.c
@@ -27,15 +27,30 @@ static const rb_data_type_t _noko_xml_xpath_expression_type = {
 static VALUE
 noko_xml_xpath_expression_s_new(VALUE klass, VALUE rb_input)
 {
-  xmlXPathCompExprPtr c_expr;
+  xmlXPathCompExprPtr c_expr = NULL;
   VALUE rb_expr = Qnil;
+  VALUE rb_errors = rb_ary_new();
+
+  xmlSetStructuredErrorFunc((void *)rb_errors, noko__error_array_pusher);
 
   c_expr = xmlXPathCompile((const xmlChar *)StringValueCStr(rb_input));
-  if (c_expr) {
-    rb_expr = TypedData_Wrap_Struct(klass, &_noko_xml_xpath_expression_type, c_expr);
+
+  xmlSetStructuredErrorFunc(NULL, NULL);
+
+  if (c_expr == NULL) {
+    rb_exc_raise(rb_ary_entry(rb_errors, 0));
   }
 
+  rb_expr = TypedData_Wrap_Struct(klass, &_noko_xml_xpath_expression_type, c_expr);
   return rb_expr;
+}
+
+xmlXPathCompExprPtr
+noko_xml_xpath_expression_unwrap(VALUE rb_expression)
+{
+  xmlXPathCompExprPtr c_expression;
+  TypedData_Get_Struct(rb_expression, xmlXPathCompExpr, &_noko_xml_xpath_expression_type, c_expression);
+  return c_expression;
 }
 
 void

--- a/lib/nokogiri/css.rb
+++ b/lib/nokogiri/css.rb
@@ -116,6 +116,11 @@ module Nokogiri
           Parser.new.xpath_for(selector, visitor)
         end
       end
+
+      # TODO: document me
+      def selector(expr)
+        expr
+      end
     end
   end
 end

--- a/lib/nokogiri/xml/searchable.rb
+++ b/lib/nokogiri/xml/searchable.rb
@@ -209,7 +209,7 @@ module Nokogiri
 
       def extract_params(params) # :nodoc:
         handler = params.find do |param|
-          ![Hash, String, Symbol].include?(param.class)
+          ![Hash, String, Symbol, XPath::Expression].include?(param.class)
         end
         params -= [handler] if handler
 

--- a/lib/nokogiri/xml/xpath.rb
+++ b/lib/nokogiri/xml/xpath.rb
@@ -14,6 +14,11 @@ module Nokogiri
 
       # The XPath search prefix to search anywhere in the current element's subtree, +.//+
       SUBTREE_SEARCH_PREFIX = ".//"
+
+      # TODO: document me
+      def self.expression(expr)
+        Nokogiri::XML::XPath::Expression.new(expr)
+      end
     end
   end
 end

--- a/lib/nokogiri/xml/xpath_context.rb
+++ b/lib/nokogiri/xml/xpath_context.rb
@@ -22,6 +22,28 @@ module Nokogiri
           register_variable(key, value)
         end
       end
+
+      if Nokogiri.uses_libxml?
+        def reset
+          return unless
+
+          @registered_namespaces.each do |key, _|
+            register_ns(key, nil)
+          end
+          unless @registered_namespaces.empty?
+            warn "Nokogiri::XML::XPathContext#reset: unexpected registered namespaces: #{@registered_namespaces.keys}"
+            @registered_namespaces.clear
+          end
+
+          @registered_variables.each do |key, _|
+            register_variable(key, nil)
+          end
+          unless @registered_variables.empty?
+            warn "Nokogiri::XML::XPathContext#reset: unexpected registered variables: #{@registered_variables.keys}"
+            @registered_variables.clear
+          end
+        end
+      end
     end
   end
 end

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -698,6 +698,86 @@ module Nokogiri
           assert_equal(3, doc.xpath("//self::*:child").length)
         end
       end
+
+      describe "re-using XPathContext objects within a thread" do
+        # see https://github.com/sparklemotion/nokogiri/issues/3266
+        # this optimization is CRuby-only, but we run the tests on JRuby for consistency
+        let(:doc) {
+          Nokogiri::XML::Document.parse(<<~XML)
+            <root xmlns="http://nokogiri.org/default" xmlns:ns1="http://nokogiri.org/ns1">
+              <child>default</child>
+              <ns1:child>ns1</ns1:child>
+            </root>
+          XML
+        }
+
+        it "clears registered namespaces" do
+          # make sure the thread-local XPathContext is initialized
+          doc.xpath("//xmlns:child")
+
+          # do namespaces behave the way we expect?
+          node = doc.at_xpath("//ns:child", { "ns" => "http://nokogiri.org/ns1" })
+          assert_equal("ns1", node.text)
+
+          assert_raises(XPath::SyntaxError) {
+            doc.at_xpath("//ns:child")
+          }
+
+          node = doc.at_xpath("//child")
+          assert_nil(node)
+
+          # make sure the nokogiri and nokogiri-builting namespaces are re-registered
+          doc.xpath("//xmlns:child[nokogiri:thing(.)]", @handler)
+          assert_equal(1, @handler.things.length)
+
+          if Nokogiri.uses_libxml?
+            nodes = doc.xpath("//xmlns:child[nokogiri-builtin:local-name-is('child')]")
+            assert_equal(1, nodes.length)
+          end
+        end
+
+        it "clears registered handlers and functions" do
+          # make sure the thread-local XPathContext is initialized
+          doc.xpath("//xmlns:child")
+
+          doc.xpath("//xmlns:child[nokogiri:thing(.)]", @handler)
+          assert_equal(1, @handler.things.length)
+
+          assert_raises(XPath::SyntaxError) {
+            doc.xpath("//xmlns:child[nokogiri:thing(.)]")
+          }
+
+          doc.xpath("//xmlns:child[nokogiri:thing(.)]", @handler)
+          assert_equal(2, @handler.things.length)
+
+          if Nokogiri.uses_libxml?
+            nodes = doc.xpath("//xmlns:child[nokogiri-builtin:local-name-is('child')]")
+            assert_equal(1, nodes.length)
+          end
+        end
+
+        it "clears registered variables" do
+          # make sure the thread-local XPathContext is initialized
+          doc.xpath("//xmlns:child")
+
+          nodes = @xml.xpath("//address[@domestic=$value]", nil, value: "Yes")
+          assert_equal(4, nodes.length)
+
+          assert_raises(XPath::SyntaxError) {
+            @xml.xpath("//address[@domestic=$value]")
+          }
+
+          nodes = @xml.xpath("//address[@domestic=$value]", nil, value: "Qwerty")
+          assert_empty(nodes)
+
+          assert_raises(XPath::SyntaxError) {
+            @xml.xpath("//address[@domestic=$value]")
+          }
+
+          nodes = @xml.xpath("//address[@domestic=$value]", nil, value: "Yes")
+          assert_equal(4, nodes.length)
+        end
+      end
     end
   end
 end

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -719,9 +719,9 @@ module Nokogiri
           node = doc.at_xpath("//ns:child", { "ns" => "http://nokogiri.org/ns1" })
           assert_equal("ns1", node.text)
 
-          assert_raises(XPath::SyntaxError) {
+          assert_raises(XPath::SyntaxError) do
             doc.at_xpath("//ns:child")
-          }
+          end
 
           node = doc.at_xpath("//child")
           assert_nil(node)
@@ -743,9 +743,9 @@ module Nokogiri
           doc.xpath("//xmlns:child[nokogiri:thing(.)]", @handler)
           assert_equal(1, @handler.things.length)
 
-          assert_raises(XPath::SyntaxError) {
+          assert_raises(XPath::SyntaxError) do
             doc.xpath("//xmlns:child[nokogiri:thing(.)]")
-          }
+          end
 
           doc.xpath("//xmlns:child[nokogiri:thing(.)]", @handler)
           assert_equal(2, @handler.things.length)
@@ -763,16 +763,16 @@ module Nokogiri
           nodes = @xml.xpath("//address[@domestic=$value]", nil, value: "Yes")
           assert_equal(4, nodes.length)
 
-          assert_raises(XPath::SyntaxError) {
+          assert_raises(XPath::SyntaxError) do
             @xml.xpath("//address[@domestic=$value]")
-          }
+          end
 
           nodes = @xml.xpath("//address[@domestic=$value]", nil, value: "Qwerty")
           assert_empty(nodes)
 
-          assert_raises(XPath::SyntaxError) {
+          assert_raises(XPath::SyntaxError) do
             @xml.xpath("//address[@domestic=$value]")
-          }
+          end
 
           nodes = @xml.xpath("//address[@domestic=$value]", nil, value: "Yes")
           assert_equal(4, nodes.length)
@@ -780,8 +780,8 @@ module Nokogiri
       end
 
       describe "compiled" do
-        let(:doc) {
-          Nokogiri::XML::Document.parse(<<~XML)
+        let(:xml) {
+          <<~XML
             <root xmlns="http://nokogiri.org/default" xmlns:ns1="http://nokogiri.org/ns1">
               <child>default</child>
               <ns1:child>ns1</ns1:child>
@@ -789,8 +789,10 @@ module Nokogiri
           XML
         }
 
+        let(:doc) { Nokogiri::XML::Document.parse(xml) }
+
         describe "XPath expressions" do
-          it "works" do
+          it "works in the trivial case" do
             expr = Nokogiri::XML::XPath.expression("//xmlns:child")
 
             result = doc.xpath(expr)
@@ -800,13 +802,55 @@ module Nokogiri
             end
           end
 
-          it "can be evaluated in different documents"
+          it "works as expected with namespace bindings" do
+            expr = Nokogiri::XML::XPath.expression("//ns:child")
 
-          it "work with function handlers"
+            node = doc.at_xpath(expr, { "ns" => "http://nokogiri.org/ns1" })
+            assert_equal("ns1", node.text)
 
-          it "work with variable bindings"
+            assert_raises(XPath::SyntaxError) do
+              doc.at_xpath("//ns:child")
+            end
+          end
 
-          it "work with namespace bindings"
+          it "works as expected with a function handler" do
+            expr = Nokogiri::XML::XPath.expression("//xmlns:child[nokogiri:thing(.)]")
+
+            doc.xpath(expr, @handler)
+            assert_equal(1, @handler.things.length)
+
+            assert_raises(XPath::SyntaxError) do
+              doc.xpath("//xmlns:child[nokogiri:thing(.)]")
+            end
+          end
+
+          it "works as expected with bound variables" do
+            expr = Nokogiri::XML::XPath.expression("//address[@domestic=$value]")
+
+            nodes = @xml.xpath("//address[@domestic=$value]", nil, value: "Yes")
+            assert_equal(4, nodes.length)
+
+            assert_raises(XPath::SyntaxError) do
+              @xml.xpath(expr)
+            end
+          end
+
+          it "can be evaluated in different documents" do
+            doc1 = Nokogiri::XML::Document.parse(xml)
+            doc2 = Nokogiri::XML::Document.parse(xml)
+
+            expr = Nokogiri::XML::XPath.expression("//xmlns:child")
+
+            result1 = doc1.xpath(expr)
+            result2 = doc2.xpath(expr)
+
+            assert_pattern do
+              result1 => [{name: "child", namespace: { href: "http://nokogiri.org/default" }}]
+            end
+            assert_pattern do
+              result2 => [{name: "child", namespace: { href: "http://nokogiri.org/default" }}]
+            end
+          end
         end
 
         describe "CSS selectors" do

--- a/test/xml/test_xpath.rb
+++ b/test/xml/test_xpath.rb
@@ -778,6 +778,57 @@ module Nokogiri
           assert_equal(4, nodes.length)
         end
       end
+
+      describe "compiled" do
+        let(:doc) {
+          Nokogiri::XML::Document.parse(<<~XML)
+            <root xmlns="http://nokogiri.org/default" xmlns:ns1="http://nokogiri.org/ns1">
+              <child>default</child>
+              <ns1:child>ns1</ns1:child>
+            </root>
+          XML
+        }
+
+        describe "XPath expressions" do
+          it "works" do
+            expr = Nokogiri::XML::XPath.expression("//xmlns:child")
+
+            result = doc.xpath(expr)
+            assert_equal(doc.xpath("//xmlns:child"), result)
+            assert_pattern do
+              result => [{name: "child", namespace: { href: "http://nokogiri.org/default" }}]
+            end
+          end
+
+          it "can be evaluated in different documents"
+
+          it "work with function handlers"
+
+          it "work with variable bindings"
+
+          it "work with namespace bindings"
+        end
+
+        describe "CSS selectors" do
+          it "works" do
+            expr = Nokogiri::CSS.selector("child")
+
+            result = doc.css(expr)
+            assert_equal(doc.css("child"), result)
+            assert_pattern do
+              result => [{name: "child", namespace: { href: "http://nokogiri.org/default" }}]
+            end
+          end
+
+          it "can be evaluated in different documents"
+
+          it "work with function handlers"
+
+          it "work with variable bindings"
+
+          it "work with namespace bindings"
+        end
+      end
     end
   end
 end

--- a/test/xml/test_xpath_expression.rb
+++ b/test/xml/test_xpath_expression.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "helper"
+
+describe Nokogiri::XML::XPath::Expression do
+  it ".new" do
+    assert_kind_of(Nokogiri::XML::XPath::Expression, Nokogiri::XML::XPath::Expression.new("//foo"))
+  end
+
+  it "raises an exception when there are compile-time errors" do
+    assert_raises(Nokogiri::XML::XPath::SyntaxError) do
+      Nokogiri::XML::XPath.expression("//foo[")
+    end
+  end
+end
+
+describe Nokogiri::XML::XPath do
+  it "XPath.expression" do
+    assert_kind_of(Nokogiri::XML::XPath::Expression, Nokogiri::XML::XPath.expression("//foo"))
+  end
+end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

There has been some discussion, summarized at #3266, about exposing libxml2's support for compiled XPath expressions. The idea is that, if you have a complex expression that you use a lot and you don't want to pay the cost of parsing/compiling it multiple times, then you can compile it once and presumably your document search will be faster.

This PR implements a new T_DATA class, `XML::XPath::Expression`, which stores the result of compiling an XPath expression via `xmlXPathCompile`. The `XPathContext` class knows how to accept either a String or an Expression.

However, I'm not seeing noticeable improvements in speed, though my benchmark may not capture the benefits.

I'm posting this as a draft in case someone wants to write me a benchmark that shows compiled XPath expressions are compellingly faster than just using Strings. Right now, based on what I'm seeing, I'm not at all sure the complexity is worth the benefit.


**Have you included adequate test coverage?**

Yes.


**Does this change affect the behavior of either the C or the Java implementations?**

This is an optimization available on CRuby only; though the idea is that the shorthand methods `Nokogiri::XML::XPath.expression` and `Nokogiri::CSS.selector` will be no-ops on JRuby (returning the string argument) and code that uses Expressions could be portable across both implementations.
