### PR TITLE
ext: revert hacks for GNU/Musl compatibility

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -847,7 +847,7 @@ else
         # The libiconv configure script doesn't accept "arm64" host string but "aarch64"
         recipe.host = recipe.host.gsub("arm64-apple-darwin", "aarch64-apple-darwin")
 
-        cflags = concat_flags(ENV["CFLAGS"], "-O2", "-U_FORTIFY_SOURCE", "-g")
+        cflags = concat_flags(ENV["CFLAGS"], "-O2", "-g")
 
         recipe.configure_options += [
           "--disable-dependency-tracking",
@@ -911,7 +911,7 @@ else
     end
 
     cppflags = concat_flags(ENV["CPPFLAGS"])
-    cflags = concat_flags(ENV["CFLAGS"], "-O2", "-U_FORTIFY_SOURCE", "-g")
+    cflags = concat_flags(ENV["CFLAGS"], "-O2", "-g")
 
     if cross_build_p
       cppflags = concat_flags(cppflags, "-DNOKOGIRI_PRECOMPILED_LIBRARIES")
@@ -971,7 +971,7 @@ else
       recipe.patch_files = Dir[File.join(PACKAGE_ROOT_DIR, "patches", "libxslt", "*.patch")].sort
     end
 
-    cflags = concat_flags(ENV["CFLAGS"], "-O2", "-U_FORTIFY_SOURCE", "-g")
+    cflags = concat_flags(ENV["CFLAGS"], "-O2", "-g")
 
     if darwin? && !cross_build_p
       recipe.configure_options << "RANLIB=/usr/bin/ranlib" unless ENV.key?("RANLIB")

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -952,7 +952,6 @@ else
       "--with-c14n",
       "--with-debug",
       "--with-threads",
-      "--without-tls", # see https://github.com/sparklemotion/nokogiri/issues/3031
       "CPPFLAGS=#{cppflags}",
       "CFLAGS=#{cflags}",
     ]


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Over time, we've accumulated a couple of hacks specifically aimed at improving the compatibility of the `-linux` native gem on Musl systems.

With #3375 we're building separate `-linux-gnu` and `-linux-musl` gems, so these hacks should no longer be needed. Let's remove them.


**Have you included adequate test coverage?**

We're testing on a matrix that includes Musl systems, so existing coverage should be adequate.


**Does this change affect the behavior of either the C or the Java implementations?**

N/A