### PR TITLE
Reset xmlXPathContext state variables before each evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ---
 
-## 1.18.0.rc1 / 2024-12-16
+## v1.18.0.rc1 / 2024-12-16
 
 ### Notable Changes
 

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -480,6 +480,17 @@ noko_xml_xpath_context_set_node(VALUE rb_context, VALUE rb_node)
   c_context->doc = c_node->doc;
   c_context->node = c_node;
 
+  /* Note from @nwellnof in https://github.com/sparklemotion/nokogiri/pull/3378#issuecomment-2557001734:
+   *
+   * > Note that if you use a single XPath context and support custom XPath extension functions, a
+   * > custom function could evaluate XPath expressions recursively which will lead to corruption of
+   * > context variables. This is mostly due to some design mistakes in libxml2.
+   *
+   * So let's set these context variables back to their default.
+   */
+  c_context->contextSize = -1;
+  c_context->proximityPosition = -1;
+
   return rb_node;
 }
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

In #3378 we implemented re-used of xmlXPathContext objects for performance.

If we're re-using the xmlXPathContext object, there's a chance that the context variables will be trashed by recursive custom functions.

In https://github.com/sparklemotion/nokogiri/pull/3378#issuecomment-2557001734, @nwellnhof advised:

> Note that if you use a single XPath context and support custom XPath
> extension functions, a custom function could evaluate XPath
> expressions recursively which will lead to corruption of context
> variables. This is mostly due to some design mistakes in libxml2.

So let's set these context variables back to their default.


**Have you included adequate test coverage?**

Functional test coverage should be sufficient to show the features still work, but I did not add test coverage that would have revealed a bug.


**Does this change affect the behavior of either the C or the Java implementations?**

CRuby only fix
