### PR TITLE
Try to initialize xmlXPathContext faster

### DIFF
--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -144,13 +144,6 @@ noko_xml_xpath_context_register_ns(VALUE rb_context, VALUE prefix, VALUE uri)
 
   xmlXPathRegisterNs(c_context, (const xmlChar *)StringValueCStr(prefix), ns_uri);
 
-  VALUE registered_namespaces = rb_iv_get(rb_context, "@registered_namespaces");
-  if (NIL_P(uri)) {
-    rb_hash_delete(registered_namespaces, prefix);
-  } else {
-    rb_hash_aset(registered_namespaces, prefix, Qtrue);
-  }
-
   return rb_context;
 }
 
@@ -178,13 +171,6 @@ noko_xml_xpath_context_register_variable(VALUE rb_context, VALUE name, VALUE val
   }
 
   xmlXPathRegisterVariable(c_context, (const xmlChar *)StringValueCStr(name), xmlValue);
-
-  VALUE registered_variables = rb_iv_get(rb_context, "@registered_variables");
-  if (NIL_P(value)) {
-    rb_hash_delete(registered_variables, name);
-  } else {
-    rb_hash_aset(registered_variables, name, Qtrue);
-  }
 
   return rb_context;
 }
@@ -459,9 +445,6 @@ noko_xml_xpath_context_new(VALUE klass, VALUE rb_node)
                          noko_xml_xpath_context_xpath_func_local_name_is);
 
   rb_context = TypedData_Wrap_Struct(klass, &_noko_xml_xpath_context_type, c_context);
-
-  rb_iv_set(rb_context, "@registered_namespaces", rb_hash_new());
-  rb_iv_set(rb_context, "@registered_variables", rb_hash_new());
 
   return rb_context;
 }

--- a/lib/nokogiri/xml/searchable.rb
+++ b/lib/nokogiri/xml/searchable.rb
@@ -261,36 +261,13 @@ module Nokogiri
       end
 
       def xpath_impl(node, path, handler, ns, binds)
-        get_xpath_context(node) do |context|
-          context.register_namespaces(ns)
-          context.register_variables(binds)
+        context = XPathContext.new(node)
+        context.register_namespaces(ns)
+        context.register_variables(binds)
 
-          path = path.gsub("xmlns:", " :") unless Nokogiri.uses_libxml?
+        path = path.gsub("xmlns:", " :") unless Nokogiri.uses_libxml?
 
-          context.evaluate(path, handler)
-        end
-      end
-
-      if Nokogiri.uses_libxml? && ENV["NOKOGIRI_DEOPTIMIZE_XPATH"].nil? # env var is an escape hatch
-        # optimized path
-        def get_xpath_context(node)
-          context = Thread.current.thread_variable_get(:nokogiri_xpath_context)
-          if context
-            context.node = node
-          else
-            context = Thread.current.thread_variable_set(:nokogiri_xpath_context, XPathContext.new(node))
-          end
-
-          begin
-            yield context
-          ensure
-            context.reset
-          end
-        end
-      else
-        def get_xpath_context(node)
-          yield XPathContext.new(node)
-        end
+        context.evaluate(path, handler)
       end
     end
   end

--- a/lib/nokogiri/xml/xpath_context.rb
+++ b/lib/nokogiri/xml/xpath_context.rb
@@ -22,28 +22,6 @@ module Nokogiri
           register_variable(key, value)
         end
       end
-
-      if Nokogiri.uses_libxml?
-        def reset
-          return unless
-
-          @registered_namespaces.each do |key, _|
-            register_ns(key, nil)
-          end
-          unless @registered_namespaces.empty?
-            warn "Nokogiri::XML::XPathContext#reset: unexpected registered namespaces: #{@registered_namespaces.keys}"
-            @registered_namespaces.clear
-          end
-
-          @registered_variables.each do |key, _|
-            register_variable(key, nil)
-          end
-          unless @registered_variables.empty?
-            warn "Nokogiri::XML::XPathContext#reset: unexpected registered variables: #{@registered_variables.keys}"
-            @registered_variables.clear
-          end
-        end
-      end
     end
   end
 end

--- a/test/xml/test_xpath_context.rb
+++ b/test/xml/test_xpath_context.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "helper"
+
+module Nokogiri
+  module XML
+    describe XPathContext do
+      it "can register and deregister namespaces" do
+        doc = Document.parse(<<~XML)
+          <root xmlns="http://nokogiri.org/default" xmlns:ns1="http://nokogiri.org/ns1">
+            <child>default</child>
+            <ns1:child>ns1</ns1:child>
+          </root>
+        XML
+
+        xc = XPathContext.new(doc)
+
+        assert_raises(XPath::SyntaxError) do
+          xc.evaluate("//xmlns:child")
+        end
+
+        xc.register_namespaces({ "xmlns" => "http://nokogiri.org/default" })
+        assert_pattern do
+          xc.evaluate("//xmlns:child") => [
+            { name: "child", namespace: { href: "http://nokogiri.org/default" } }
+          ]
+        end
+
+        xc.register_namespaces({ "xmlns" => nil })
+        assert_raises(XPath::SyntaxError) do
+          xc.evaluate("//xmlns:child")
+        end
+      end
+
+      it "can register and deregister variables" do
+        doc = Nokogiri::XML.parse(File.read(TestBase::XML_FILE), TestBase::XML_FILE)
+
+        xc = XPathContext.new(doc)
+
+        assert_raises(XPath::SyntaxError) do
+          xc.evaluate("//address[@domestic=$value]")
+        end
+
+        xc.register_variables({ "value" => "Yes" })
+        nodes = xc.evaluate("//address[@domestic=$value]")
+        assert_equal(4, nodes.length)
+
+        xc.register_variables({ "value" => "Qwerty" })
+        nodes = xc.evaluate("//address[@domestic=$value]")
+        assert_empty(nodes)
+
+        xc.register_variables({ "value" => nil })
+        assert_raises(XPath::SyntaxError) do
+          xc.evaluate("//address[@domestic=$value]")
+        end
+      end
+
+      it "#node=" do
+        doc = Nokogiri::XML::Document.parse(<<~XML)
+          <root>
+            <child><foo>one</foo></child>
+            <child><foo>two</foo></child>
+            <child><foo>three</foo></child>
+          </root>
+        XML
+
+        xc = XPathContext.new(doc)
+        results = xc.evaluate(".//foo")
+        assert_equal(3, results.length)
+
+        xc.node = doc.root.elements[0]
+        assert_pattern { xc.evaluate(".//foo") => [{ name: "foo", inner_html: "one" }] }
+
+        xc.node = doc.root.elements[1]
+        assert_pattern { xc.evaluate(".//foo") => [{ name: "foo", inner_html: "two" }] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

A variation on solving the "slow xpath context creation" problem described in #3266. See first attempt at #3378.

Copying the struct and the hash tables is slightly faster than calling `xmlXpathNewContext`:

    Comparison:
        large: optimized:    17780.0 i/s
             large: main:    15143.4 i/s - same-ish: difference falls within error

    Comparison:
        small: optimized:    62891.9 i/s
             small: main:    49413.5 i/s - 1.27x  slower

But still slower than re-using the context object ("edge", v1.18.0.rc1):

    Comparison:
             large: edge:    22230.9 i/s
        large: optimized:    17780.0 i/s - 1.25x  slower
             large: main:    15143.4 i/s - 1.47x  slower

    Comparison:
             small: edge:   129162.0 i/s
        small: optimized:    62891.9 i/s - 2.05x  slower
             small: main:    49413.5 i/s - 2.61x  slower


I probably won't merge this, but thought it was worth sharing for posterity.

Next I'm going to try an extension of #3378 that will push and pop "eval frames" that include the internal state but also the registered functions/namespaces/lookup handlers.
