### PR TITLE
ci: bump everything to use 3.4 final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.3
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.4
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,7 +69,7 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
           bundler: latest
       - run: bundle exec rake gumbo:test
@@ -95,8 +95,9 @@ jobs:
   ruby_versions:
     needs: ["basic"]
     outputs:
-      setup_ruby: "['3.1', '3.2', '3.3', 'head']"
-      image_tag: "['3.1', '3.2', '3.3', '3.4-rc']"
+      # these are usually the same, but are different once we get to ruby release candidates
+      setup_ruby: "['3.1', '3.2', '3.3', '3.4']"
+      image_tag: "['3.1', '3.2', '3.3', '3.4']"
     runs-on: ubuntu-latest
     steps:
       - run: echo "generating rubies ..."
@@ -110,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
           bundler: latest
       - id: rcd_image_version
@@ -153,7 +154,7 @@ jobs:
         mem: ["ruby"]
         include:
           - sys: "disable"
-            ruby: "3.3"
+            ruby: "3.4"
             mem: "default"
     runs-on: ubuntu-latest
     container:
@@ -215,7 +216,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable"]
-        ruby: ["3.3"]
+        ruby: ["3.4"]
     env:
       BUNDLE_GEMFILE: "Gemfile-libxml-ruby"
     runs-on: ubuntu-latest
@@ -240,7 +241,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["disable"]
-        ruby: ["3.3"]
+        ruby: ["3.4"]
     env:
       BUNDLE_GEMFILE: "Gemfile-libxml-ruby"
     runs-on: ubuntu-latest
@@ -426,7 +427,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["disable"]
-        ruby: ["3.3"]
+        ruby: ["3.4"]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}
@@ -449,7 +450,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["disable"]
-        ruby: ["3.3"]
+        ruby: ["3.4"]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sparklemotion/nokogiri-test:mri-${{matrix.ruby}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "3.3"
           bundler-cache: true
           bundler: latest
       - run: bundle exec rake gumbo:test
@@ -97,6 +97,7 @@ jobs:
     outputs:
       # these are usually the same, but are different once we get to ruby release candidates
       setup_ruby: "['3.1', '3.2', '3.3', '3.4']"
+      setup_ruby_win: "['3.1', '3.2', '3.3', 'head']"
       image_tag: "['3.1', '3.2', '3.3', '3.4']"
     runs-on: ubuntu-latest
     steps:
@@ -321,7 +322,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_win) }}
     runs-on: windows-2022
     steps:
       - name: configure git crlf
@@ -541,7 +542,7 @@ jobs:
       fail-fast: false
       matrix:
         sys: ["enable", "disable"]
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_win) }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -687,7 +688,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby) }}
+        ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_win) }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -27,16 +27,16 @@ jobs:
           - url: https://github.com/flavorjones/loofah
             name: loofah
             command: "bundle exec rake test"
-            ruby: "3.3"
+            ruby: "3.4"
           - url: https://github.com/rails/rails-html-sanitizer
             name: rails-html-sanitizer
             command: "bundle exec rake test"
-            ruby: "3.3"
+            ruby: "3.4"
           # # pending a fix for https://github.com/sparklemotion/nokogiri/pull/3348
           # - url: https://github.com/rgrove/sanitize
           #   name: sanitize
           #   command: "bundle exec rake test"
-          #   ruby: "3.3"
+          #   ruby: "3.4"
           - url: https://github.com/ebeigarts/signer
             name: signer
             command: "bundle exec rake spec"
@@ -48,7 +48,7 @@ jobs:
           - url: https://github.com/rails/rails
             name: xmlmini
             command: "cd activesupport && bundle exec rake test TESTOPTS=-n/XmlMini/"
-            ruby: "3.3"
+            ruby: "3.4"
           - url: https://github.com/pythonicrubyist/creek
             name: creek
             command: "bundle exec rake spec"
@@ -60,11 +60,11 @@ jobs:
           - url: https://github.com/sparklemotion/mechanize
             name: mechanize
             command: "bundle exec rake test"
-            ruby: "3.3"
+            ruby: "3.4"
           - url: https://github.com/stimulusreflex/stimulus_reflex
             name: stimulus_reflex
             command: "bundle exec rake test"
-            ruby: "3.3"
+            ruby: "3.4"
           # - url: https://github.com/instructure/nokogiri-xmlsec-instructure
           #   name: nokogiri-xmlsec-instructure
           #   precommand: "apt install -y libxmlsec1-dev"

--- a/.github/workflows/generate-ci-images.yml
+++ b/.github/workflows/generate-ci-images.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["alpine", "mri-3.1", "mri-3.2", "mri-3.3", "mri-3.4-rc", "ubuntu", "upstream-libxml"]
+        tag: ["alpine", "mri-3.1", "mri-3.2", "mri-3.3", "mri-3.4", "ubuntu", "upstream-libxml"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "3.3"
           apt-get: "autogen libtool shtool"
           brew: "automake autogen libtool shtool"
           mingw: "autotools xz"

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           apt-get: "autogen libtool shtool"
           brew: "automake autogen libtool shtool"
           mingw: "autotools xz"
@@ -63,7 +63,7 @@ jobs:
   xmlsoft-head-valgrind:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.3
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.4
     steps:
       - uses: actions/checkout@v4
         with:
@@ -193,7 +193,7 @@ jobs:
   html5lib-tests:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.3
+      image: ghcr.io/sparklemotion/nokogiri-test:mri-3.4
     steps:
       - uses: actions/checkout@v4
         with:
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ports
-          key: ports-ubuntu-3.3-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
+          key: ports-ubuntu-3.4-${{hashFiles('dependencies.yml', 'patches/**/*.patch', 'ext/nokogiri/extconf.rb')}}
       - name: Update html5lib-tests
         run: |
           cd test/html5lib-tests

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,8 @@ end
 # If Psych doesn't build, you can disable this group locally by running
 # `bundle config set --local without rdoc`
 # Then re-run `bundle install`.
-group :rdoc do
-  gem "rdoc", "6.10.0"
-  gem "jar-dependencies", "0.4.1" if RUBY_PLATFORM == "java" # https://github.com/jruby/jruby/issues/7262
+unless RUBY_PLATFORM == "java" # see #3391 and https://github.com/jruby/jruby/issues/7262
+  group :rdoc do
+    gem "rdoc", "6.10.0"
+  end
 end

--- a/oci-images/nokogiri-test/mri-3.4.dockerfile
+++ b/oci-images/nokogiri-test/mri-3.4.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4-rc
+FROM ruby:3.4
 
 # include_file debian-prelude.step
 # -*- dockerfile -*-
@@ -9,16 +9,10 @@ RUN apt-get upgrade -y
 RUN apt-get install -y apt-utils
 
 
-# include_file valgrind-from-source.step
+# include_file debian-valgrind.step
 # -*- dockerfile -*-
 
-RUN apt-get install -y libc6-dbg
-RUN wget https://sourceware.org/pub/valgrind/valgrind-3.21.0.tar.bz2 && \
-    tar -xf valgrind-3.21.0.tar.bz2 && \
-    cd valgrind-3.21.0 && \
-    ./configure && \
-    make && \
-    make install
+RUN apt-get install -y valgrind
 
 
 # include_file debian-libxml-et-al.step

--- a/oci-images/nokogiri-test/mri.erb
+++ b/oci-images/nokogiri-test/mri.erb
@@ -2,7 +2,7 @@ FROM ruby:<%= version %>
 
 <%= include_file "debian-prelude.step" %>
 
-<% if version >= "3.2" -%>
+<% if version >= "3.2" && version < "3.4" -%>
 <%= include_file "valgrind-from-source.step" %>
 <% else -%>
 <%= include_file "debian-valgrind.step" %>

--- a/rakelib/docker.rake
+++ b/rakelib/docker.rake
@@ -9,7 +9,7 @@ module DockerHelper
   IMAGE_NAME = "ghcr.io/sparklemotion/nokogiri-test"
   RUBIES = {
     # engine → array of ruby minor version docker tags
-    mri: ["3.1", "3.2", "3.3", "3.4-rc"],
+    mri: ["3.1", "3.2", "3.3", "3.4"],
   }
 
   class << self


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Now that both docker/ruby and setup-ruby have 3.4 releases, let's update CI.
