### PR TITLE
ci: re-enable downstream sanitize test

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -32,11 +32,10 @@ jobs:
             name: rails-html-sanitizer
             command: "bundle exec rake test"
             ruby: "3.4"
-          # # pending a fix for https://github.com/sparklemotion/nokogiri/pull/3348
-          # - url: https://github.com/rgrove/sanitize
-          #   name: sanitize
-          #   command: "bundle exec rake test"
-          #   ruby: "3.4"
+          - url: https://github.com/rgrove/sanitize
+            name: sanitize
+            command: "bundle exec rake test"
+            ruby: "3.4"
           - url: https://github.com/ebeigarts/signer
             name: signer
             command: "bundle exec rake spec"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

In #3348, downstream CI tests for Sanitize were temporarily disabled because the changes in that PR (intentionally) caused some of Sanitize's tests to fail.

As of Sanitize 7.0.0, tests are passing again with the latest Nokogiri and it's safe to re-enable the downstream tests. 🎉 
