### PR TITLE
ci: bump windows test images from "head" to "3.4"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     outputs:
       # these are usually the same, but are different once we get to ruby release candidates
       setup_ruby: "['3.1', '3.2', '3.3', '3.4']"
-      setup_ruby_win: "['3.1', '3.2', '3.3', 'head']"
+      setup_ruby_win: "['3.1', '3.2', '3.3', '3.4']"
       image_tag: "['3.1', '3.2', '3.3', '3.4']"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**What problem is this PR intended to solve?**

bump windows test images from "head" to "3.4" now that rubyinstaller has been released

