### PR TITLE
ci: make sure liblzma is installed

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: "3.3"
-          apt-get: "autogen libtool shtool"
+          apt-get: "autogen libtool shtool liblzma-dev"
           brew: "automake autogen libtool shtool"
           mingw: "autotools xz"
           bundler-cache: true


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Recently we've been getting upstream CI failures for libxml2 head on ubuntu: https://github.com/sparklemotion/nokogiri/actions/runs/12705536326/job/35416744559

```
configure:15841: checking for liblzma
configure:15848: $PKG_CONFIG --exists --print-errors "liblzma"
Package liblzma was not found in the pkg-config search path.
Perhaps you should add the directory containing `liblzma.pc'
to the PKG_CONFIG_PATH environment variable
Package 'liblzma', required by 'virtual:world', not found
configure:15851: $? = 1
configure:15865: $PKG_CONFIG --exists --print-errors "liblzma"
*** ../../../../ext/nokogiri/extconf.rb failed ***
```

