### PR TITLE
backport: fix(css-selector): default XML namespace should not be applied to wildcard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     outputs:
       # these are usually the same, but are different once we get to ruby release candidates
       setup_ruby: "['3.1', '3.2', '3.3', '3.4']"
-      setup_ruby_win: "['3.1', '3.2', '3.3', 'head']"
+      setup_ruby_win: "['3.1', '3.2', '3.3', '3.4']"
       image_tag: "['3.1', '3.2', '3.3', '3.4']"
     runs-on: ubuntu-latest
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,6 @@ end
 # If Psych doesn't build, you can disable this group locally by running
 # `bundle config set --local without rdoc`
 # Then re-run `bundle install`.
-unless RUBY_PLATFORM == "java" # see #3391 and https://github.com/jruby/jruby/issues/7262
-  group :rdoc do
-    gem "rdoc", "6.10.0"
-  end
+group :rdoc do
+  gem "rdoc", "6.10.0" unless RUBY_PLATFORM == "java" || ENV["CI"]
 end

--- a/lib/nokogiri/css/xpath_visitor.rb
+++ b/lib/nokogiri/css/xpath_visitor.rb
@@ -283,7 +283,8 @@ module Nokogiri
           else
             node.value.join(":")
           end
-        elsif @namespaces&.key?("xmlns") # apply the default namespace if it's declared
+        elsif node.value.first != "*" && @namespaces&.key?("xmlns")
+          # apply the default namespace (if one is present) to a non-wildcard selector
           "xmlns:#{node.value.first}"
         else
           node.value.first

--- a/scripts/test-gem-install
+++ b/scripts/test-gem-install
@@ -28,6 +28,7 @@ popd
 # 2.3.21 because https://github.com/rubygems/rubygems/issues/5914
 # 2.3.22 because https://github.com/rubygems/rubygems/issues/5940
 gem install bundler -v "~> 2.2, != 2.3.21, != 2.3.22"
+bundle config set --local without rdoc
 bundle install --local || bundle install
 
 rm -rf lib ext # ensure we don't use the local files

--- a/test/css/test_xpath_visitor.rb
+++ b/test/css/test_xpath_visitor.rb
@@ -164,6 +164,13 @@ describe Nokogiri::CSS::XPathVisitor do
         )
       end
 
+      it "default namespace is not applied to wildcard selectors" do
+        assert_equal(
+          ["//xmlns:a//*"],
+          Nokogiri::CSS.xpath_for("a *", ns: ns, cache: false),
+        )
+      end
+
       it "intentionally-empty namespace omits the default xmlns" do
         # An intentionally-empty namespace
         assert_equal(["//a"], Nokogiri::CSS.xpath_for("|a", ns: ns, cache: false))

--- a/test/css/test_xpath_visitor.rb
+++ b/test/css/test_xpath_visitor.rb
@@ -143,12 +143,38 @@ describe Nokogiri::CSS::XPathVisitor do
       )
     end
 
-    it "# id" do
-      assert_xpath("//*[@id='foo']", "#foo")
-      assert_xpath("//*[@id='escape:needed,']", "#escape\\:needed\\,")
-      assert_xpath("//*[@id='escape:needed,']", '#escape\3Aneeded\,')
-      assert_xpath("//*[@id='escape:needed,']", '#escape\3A needed\2C')
-      assert_xpath("//*[@id='escape:needed']", '#escape\00003Aneeded')
+    describe "namespaces" do
+      let(:ns) do
+        {
+          "xmlns" => "http://default.example.com/",
+          "hoge" => "http://hoge.example.com/",
+        }
+      end
+
+      it "basic mechanics" do
+        assert_xpath("//a[@flavorjones:href]", "a[flavorjones|href]")
+        assert_xpath("//a[@href]", "a[|href]")
+        assert_xpath("//*[@flavorjones:href]", "*[flavorjones|href]")
+      end
+
+      it "default namespace is applied to elements but not attributes" do
+        assert_equal(
+          ["//xmlns:a[@class='bar']"],
+          Nokogiri::CSS.xpath_for("a[class='bar']", ns: ns, cache: false),
+        )
+      end
+
+      it "intentionally-empty namespace omits the default xmlns" do
+        # An intentionally-empty namespace
+        assert_equal(["//a"], Nokogiri::CSS.xpath_for("|a", ns: ns, cache: false))
+      end
+
+      it "explicit namespaces are applied to attributes" do
+        assert_equal(
+          ["//xmlns:a[@hoge:class='bar']"],
+          Nokogiri::CSS.xpath_for("a[hoge|class='bar']", ns: ns, cache: false),
+        )
+      end
     end
 
     describe "attribute" do
@@ -159,36 +185,18 @@ describe Nokogiri::CSS::XPathVisitor do
         assert_xpath("//h1[@a='test']", %q{h1[a=\te\st]})
       end
 
+      it "#id escaping" do
+        assert_xpath("//*[@id='foo']", "#foo")
+        assert_xpath("//*[@id='escape:needed,']", "#escape\\:needed\\,")
+        assert_xpath("//*[@id='escape:needed,']", '#escape\3Aneeded\,')
+        assert_xpath("//*[@id='escape:needed,']", '#escape\3A needed\2C')
+        assert_xpath("//*[@id='escape:needed']", '#escape\00003Aneeded')
+      end
+
       it "parses leading @ (extended-syntax)" do
         assert_xpath("//a[@id='Boing']", "a[@id='Boing']")
         assert_xpath("//a[@id='Boing']", "a[@id = 'Boing']")
         assert_xpath("//a[@id='Boing']//div", "a[@id='Boing'] div")
-      end
-
-      it "namespacing" do
-        assert_xpath("//a[@flavorjones:href]", "a[flavorjones|href]")
-        assert_xpath("//a[@href]", "a[|href]")
-        assert_xpath("//*[@flavorjones:href]", "*[flavorjones|href]")
-
-        ns = {
-          "xmlns" => "http://default.example.com/",
-          "hoge" => "http://hoge.example.com/",
-        }
-
-        # An intentionally-empty namespace means "don't use the default xmlns"
-        assert_equal(["//a"], Nokogiri::CSS.xpath_for("|a", ns: ns, cache: false))
-
-        # The default namespace is not applied to attributes (just elements)
-        assert_equal(
-          ["//xmlns:a[@class='bar']"],
-          Nokogiri::CSS.xpath_for("a[class='bar']", ns: ns, cache: false),
-        )
-
-        # We can explicitly apply a namespace to an attribue
-        assert_equal(
-          ["//xmlns:a[@hoge:class='bar']"],
-          Nokogiri::CSS.xpath_for("a[hoge|class='bar']", ns: ns, cache: false),
-        )
       end
 
       it "rhs with quotes" do


### PR DESCRIPTION
Backport of https://github.com/sparklemotion/nokogiri/pull/3413 to v1.18.x