### PR TITLE
[DOC] :nodoc: for Node#accept

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -1340,7 +1340,7 @@ module Nokogiri
         yield(self)
       end
 
-      ###
+      # :nodoc:
       # Accept a visitor.  This method calls "visit" on +visitor+ with self.
       def accept(visitor)
         visitor.visit(self)


### PR DESCRIPTION
I had thought to put in an Issue for this, but instead will make bold and propose to `:nodoc:` `Node#accept`.

Reason:  I was unable to find out how I would use this (so maybe it should be internal?).  I found nothing in `test`, and on the wide web, saw only that accept/visit often have to do with data locking.

If this is to be retained as user documentation, I'd like to be able to document it properly, but would need help (pointers to relevant docs both within `nokogiri` and elsewhere).