### PR TITLE
dep: update libxml2 to v2.13.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
     branches:
       - '*'
 
+env:
+  NOKOGIRI_USE_CANONICAL_GNOME_SOURCE: t
+
 jobs:
   #
   #  SECTION pre-checks for fast feedback loops, and to gate the rest of the suite
@@ -409,6 +412,7 @@ jobs:
           submodules: true
       - uses: vmactions/freebsd-vm@v1
         with:
+          envs: NOKOGIRI_USE_CANONICAL_GNOME_SOURCE
           usesh: true
           copyback: false
           prepare: pkg install -y ruby devel/ruby-gems pkgconf libxml2 libxslt git

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -16,6 +16,8 @@ on:
     types: [opened, synchronize]
     branches:
       - '*'
+env:
+  NOKOGIRI_USE_CANONICAL_GNOME_SOURCE: t
 
 jobs:
   downstream:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.13.5"
-  sha256: "74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.5.sha256sum
+  version: "2.13.6"
+  sha256: "f453480307524968f7a04ec65e64f2a83a825973bcd260a2e7691be82ae70c96"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.6.sha256sum
 
 libxslt:
   version: "1.1.42"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Update vendored libxml2 to v2.13.6

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.6

Security note: the changelog mentions CVE-2025-24928 and CVE-2024-56171, but it's not obvious that those vulnerabilities affect Nokogiri users.
