### PR TITLE
dep: update libxml2 to v2.13.6 (v1.17.x branch)

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -16,7 +16,6 @@ on:
     types: [opened, synchronize]
     branches:
       - '*'
-
 jobs:
   downstream:
     name: downstream-${{matrix.name}}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.13.5"
-  sha256: "74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.5.sha256sum
+  version: "2.13.6"
+  sha256: "f453480307524968f7a04ec65e64f2a83a825973bcd260a2e7691be82ae70c96"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.6.sha256sum
 
 libxslt:
   version: "1.1.42"

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -240,15 +240,7 @@ def zlib_source(version_string)
 end
 
 def gnome_source
-  # As of 2022-02-20, some mirrors have expired SSL certificates. I'm able to retrieve from my home,
-  # but whatever host is resolved on the github actions workers see an expired cert.
-  #
-  # See https://github.com/sparklemotion/nokogiri/runs/5266206403?check_suite_focus=true
-  if ENV["NOKOGIRI_USE_CANONICAL_GNOME_SOURCE"]
-    "https://download.gnome.org"
-  else
-    "https://muug.ca/mirror/gnome" # old reliable
-  end
+  "https://download.gnome.org"
 end
 
 LOCAL_PACKAGE_RESPONSE = Object.new


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.6

See related #3437 and #3438

I'm not making any kind of statement or promises about whether I'll cut security releases for v1.17.x in the future. I'm doing this because Mastodon 4.2 still supports Ruby 3.0 and its dependency on ruby-saml makes it potentially impacted by the underlying libxml2 fixes.

I know somebody out there, somewhere, is going to say "I'll stay on Ruby 3.0 if Mike is going to keep cutting security updates", and hoo boy that is NOT a bet you should be making. I am the most enthusiastic supporter of "dropping support for EOL versions of Ruby" that you will ever meet, and this is NOT going to continue.

I know somebody out there, somewhere, is going to try to convince me that because I made this one security update, I'm somehow _obligated_ to continue supporting the v1.17.x branch. If you feel the urge to send me a message like that, please restrain yourself and do not make me regret doing this thing.