### PR TITLE
[skip ci] Add links to local pages in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Please use the "Bug Report" or "Installation Difficulties" templates.
 
 Please report vulnerabilities at https://hackerone.com/nokogiri
 
-See SECURITY.md for full information and description of our security policy.
+See [SECURITY.md](SECURITY.md) for full information and description of our security policy.
 
 
 ### Semantic Versioning Policy
@@ -83,7 +83,6 @@ We bump `Major.Minor.Patch` versions following this guidance:
 `Major`: (we've never done this)
 
 - Significant backwards-incompatible changes to the public API that would require rewriting existing application code.
-- See ROADMAP.md or examples of backwards-incompatible changes we might someday consider for a Major release.
 
 `Minor`:
 
@@ -242,7 +241,7 @@ These dependencies are met by default by Nokogiri's packaged versions of the lib
 
 We provide native gems by pre-compiling libxml2 and libxslt (and potentially zlib and libiconv) and packaging them into the gem file. In this case, no compilation is necessary at installation time, which leads to faster and more reliable installation.
 
-See LICENSE-DEPENDENCIES.md for more information on which dependencies are provided in which native and source gems.
+See [LICENSE-DEPENDENCIES.md](LICENSE-DEPENDENCIES.md) for more information on which dependencies are provided in which native and source gems.
 
 
 ### JRuby
@@ -251,31 +250,31 @@ The Java (a.k.a. JRuby) implementation is a Java extension that depends primaril
 
 These dependencies are provided by pre-compiled jar files packaged in the `java` platform gem.
 
-See LICENSE-DEPENDENCIES.md
+See [LICENSE-DEPENDENCIES.md](LICENSE-DEPENDENCIES.md)
 for more information on which dependencies are provided in which native and source gems.
 
 
 ## Contributing
 
-See CONTRIBUTING.md for an intro guide to developing Nokogiri.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for an intro guide to developing Nokogiri.
 
 
 ## Code of Conduct
 
-See the CODE_OF_CONDUCT.md)
+See the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 
 ## License
 
 This project is licensed under the terms of the MIT license.
 
-See LICENSE.md.
+See [LICENSE.md](LICENSE.md).
 
 
 ### Dependencies
 
 Some additional libraries may be distributed with your version of Nokogiri.
-See LICENSE-DEPENDENCIES.md for a discussion of the variations as well as the licenses thereof.
+See [LICENSE-DEPENDENCIES.md](LICENSE-DEPENDENCIES.md) for a discussion of the variations as well as the licenses thereof.
 
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ Please use the "Bug Report" or "Installation Difficulties" templates.
 
 Please report vulnerabilities at https://hackerone.com/nokogiri
 
-See [Security and Vulnerability Reporting](rdoc-ref:SECURITY.md)
-for full information and description of our security policy.
+See SECURITY.md for full information and description of our security policy.
 
 
 ### Semantic Versioning Policy
@@ -84,8 +83,7 @@ We bump `Major.Minor.Patch` versions following this guidance:
 `Major`: (we've never done this)
 
 - Significant backwards-incompatible changes to the public API that would require rewriting existing application code.
-- See [Roadmap for API Changes](rdoc-ref:ROADMAP.md).
-  for examples of backwards-incompatible changes we might someday consider for a Major release.
+- See ROADMAP.md or examples of backwards-incompatible changes we might someday consider for a Major release.
 
 `Minor`:
 
@@ -244,7 +242,7 @@ These dependencies are met by default by Nokogiri's packaged versions of the lib
 
 We provide native gems by pre-compiling libxml2 and libxslt (and potentially zlib and libiconv) and packaging them into the gem file. In this case, no compilation is necessary at installation time, which leads to faster and more reliable installation.
 
-See [Vendored Dependency Licenses](rdoc-ref:LICENSE-DEPENDENCIES.md) for more information on which dependencies are provided in which native and source gems.
+See LICENSE-DEPENDENCIES.md for more information on which dependencies are provided in which native and source gems.
 
 
 ### JRuby
@@ -253,31 +251,31 @@ The Java (a.k.a. JRuby) implementation is a Java extension that depends primaril
 
 These dependencies are provided by pre-compiled jar files packaged in the `java` platform gem.
 
-See [Vendored Dependency Licenses](rdoc-ref:LICENSE-DEPENDENCIES.md)
+See LICENSE-DEPENDENCIES.md
 for more information on which dependencies are provided in which native and source gems.
 
 
 ## Contributing
 
-See [Contributing to Nokogiri](rdoc-ref:CONTRIBUTING.md) for an intro guide to developing Nokogiri.
+See CONTRIBUTING.md for an intro guide to developing Nokogiri.
 
 
 ## Code of Conduct
 
-See the [Contributor Covenant Code of Conduct](rdoc-ref:CODE_OF_CONDUCT.md).
+See the CODE_OF_CONDUCT.md)
 
 
 ## License
 
 This project is licensed under the terms of the MIT license.
 
-See the [MIT License](rdoc-ref:LICENSE.md).
+See LICENSE.md.
 
 
 ### Dependencies
 
 Some additional libraries may be distributed with your version of Nokogiri.
-See [Vendored Dependency Licenses](rdoc-ref:LICENSE-DEPENDENCIES.md) for a discussion of the variations as well as the licenses thereof.
+See LICENSE-DEPENDENCIES.md for a discussion of the variations as well as the licenses thereof.
 
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Please use the "Bug Report" or "Installation Difficulties" templates.
 
 Please report vulnerabilities at https://hackerone.com/nokogiri
 
-Full information and description of our security policy is in [`SECURITY.md`](SECURITY.md)
+See [Security and Vulnerability Reporting](rdoc-ref:SECURITY.md)
+for full information and description of our security policy.
 
 
 ### Semantic Versioning Policy
@@ -83,7 +84,8 @@ We bump `Major.Minor.Patch` versions following this guidance:
 `Major`: (we've never done this)
 
 - Significant backwards-incompatible changes to the public API that would require rewriting existing application code.
-- Some examples of backwards-incompatible changes we might someday consider for a Major release are at [`ROADMAP.md`](ROADMAP.md).
+- See [Roadmap for API Changes](rdoc-ref:ROADMAP.md).
+  for examples of backwards-incompatible changes we might someday consider for a Major release.
 
 `Minor`:
 
@@ -242,7 +244,7 @@ These dependencies are met by default by Nokogiri's packaged versions of the lib
 
 We provide native gems by pre-compiling libxml2 and libxslt (and potentially zlib and libiconv) and packaging them into the gem file. In this case, no compilation is necessary at installation time, which leads to faster and more reliable installation.
 
-See [`LICENSE-DEPENDENCIES.md`](LICENSE-DEPENDENCIES.md) for more information on which dependencies are provided in which native and source gems.
+See [Vendored Dependency Licenses](rdoc-ref:LICENSE-DEPENDENCIES.md) for more information on which dependencies are provided in which native and source gems.
 
 
 ### JRuby
@@ -251,29 +253,31 @@ The Java (a.k.a. JRuby) implementation is a Java extension that depends primaril
 
 These dependencies are provided by pre-compiled jar files packaged in the `java` platform gem.
 
-See [`LICENSE-DEPENDENCIES.md`](LICENSE-DEPENDENCIES.md) for more information on which dependencies are provided in which native and source gems.
+See [Vendored Dependency Licenses](rdoc-ref:LICENSE-DEPENDENCIES.md)
+for more information on which dependencies are provided in which native and source gems.
 
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for an intro guide to developing Nokogiri.
+See [Contributing to Nokogiri](rdoc-ref:CONTRIBUTING.md) for an intro guide to developing Nokogiri.
 
 
 ## Code of Conduct
 
-We've adopted the Contributor Covenant code of conduct, which you can read in full in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+See the [Contributor Covenant Code of Conduct](rdoc-ref:CODE_OF_CONDUCT.md).
 
 
 ## License
 
 This project is licensed under the terms of the MIT license.
 
-See this license at [`LICENSE.md`](LICENSE.md).
+See the [MIT License](rdoc-ref:LICENSE.md).
 
 
 ### Dependencies
 
-Some additional libraries may be distributed with your version of Nokogiri. Please see [`LICENSE-DEPENDENCIES.md`](LICENSE-DEPENDENCIES.md) for a discussion of the variations as well as the licenses thereof.
+Some additional libraries may be distributed with your version of Nokogiri.
+See [Vendored Dependency Licenses](rdoc-ref:LICENSE-DEPENDENCIES.md) for a discussion of the variations as well as the licenses thereof.
 
 
 ## Authors

--- a/rakelib/rdoc.rake
+++ b/rakelib/rdoc.rake
@@ -5,8 +5,8 @@ begin
 
   def rdoc_nokogiri_common_options(rdoc)
     rdoc.rdoc_files
-      .include("README.md", "lib/**/*.rb", "ext/**/*.c", "doc/*md")
-      .exclude("ext/nokogiri/test_global_handlers.c")
+      .include("*.md", "lib/**/*.rb", "ext/**/*.c", "doc/*md")
+      .exclude("CHANGELOG.md", "ext/nokogiri/test_global_handlers.c")
     rdoc.options << "--embed-mixins"
     rdoc.options << "--main=README.md"
   end

--- a/rakelib/rdoc.rake
+++ b/rakelib/rdoc.rake
@@ -6,7 +6,7 @@ begin
   def rdoc_nokogiri_common_options(rdoc)
     rdoc.rdoc_files
       .include("*.md", "lib/**/*.rb", "ext/**/*.c", "doc/*md")
-      .exclude("CHANGELOG.md", "ext/nokogiri/test_global_handlers.c")
+      .exclude("CHANGELOG.md", "ROADMAP.md", "ext/nokogiri/test_global_handlers.c")
     rdoc.options << "--embed-mixins"
     rdoc.options << "--main=README.md"
   end


### PR DESCRIPTION
README.md urges the reader to "See CONTRIBUTING.md."  But the reader cannot do so because the page is not included in the Nokogiri documentation

 So:
- First, I've modified `rake.rdoc` to generate the page.
- Second, I've changed the reference into a link to the page.
- Third, I've given the the link's text as the page title, "Contributing to Nokogiri" (not the page path `CONTRIBUTING.md).
- Finally, I've given the url as an `rdoc-ref:`, which will give a warning if the page is not found.

Besides `README.md`, there are several other cited-but-missing pages, which I've treated similarly.