### PR TITLE
fix(java): stop using the cache for Node#namespace_definitions

### DIFF
--- a/test/namespaces/test_namespace_definitions.rb
+++ b/test/namespaces/test_namespace_definitions.rb
@@ -26,12 +26,10 @@ describe "namespace definitions" do
     end
 
     child2 = doc.create_element("b", "xmlns:foo" => "http://nokogiri.org/ns/foo")
-    pending_if("https://github.com/sparklemotion/nokogiri/issues/2543", Nokogiri.jruby?) do
-      assert_equal(1, child2.namespace_definitions.length)
-      child2.namespace_definitions.first.tap do |ns|
-        assert_equal("foo", ns.prefix)
-        assert_equal("http://nokogiri.org/ns/foo", ns.href)
-      end
+    assert_equal(1, child2.namespace_definitions.length)
+    child2.namespace_definitions.first.tap do |ns|
+      assert_equal("foo", ns.prefix)
+      assert_equal("http://nokogiri.org/ns/foo", ns.href)
     end
   end
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

In this PR, I've updated `Node#namespace_definitions` to no longer uses the namespace cache, meaning it uses the attributes defined on the node to determine the return value(s).

Removing this use of the cache revealed a separate bug in the `relink_namespace` java function, which suddenly became better tested on JRuby as a result of removing the cache usage (which was hiding the bug).

Finally, removing the cache also means that `relink_namespace` now needs to remove namespace definitions that are redundant (that is, the exact prefix and URI resolve in the parent) in order to match the CRuby implementation, so I've done that, too.

Closes #2543 


**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

Only the Java implementation, which now behaves like the CRuby implementation (and I've resolved a pending JRuby test).

cc @johnnyshields 