### PR TITLE
fix: XML::Builder namespace stitching

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -266,19 +266,19 @@ module Nokogiri
       document.decorate!
     end
 
-    def pending(msg)
+    def pending(msg, extra_uplevel = 0)
       begin
         yield
       rescue Minitest::Assertion
-        skip("pending #{msg} [#{caller(2..2).first}]")
+        skip("pending #{msg} [#{caller(2 + extra_uplevel, 1).first}]")
       end
-      flunk("pending test unexpectedly passed: #{msg} [#{caller(1..1).first}]")
+      flunk("pending test unexpectedly passed: #{msg} [#{caller(1 + extra_uplevel, 1).first}]")
     end
 
     def pending_if(msg, pend_eh, &block)
       return yield unless pend_eh
 
-      pending(msg, &block)
+      pending(msg, 1, &block)
     end
 
     # returns the page size in bytes

--- a/test/namespaces/test_serializing_namespaces.rb
+++ b/test/namespaces/test_serializing_namespaces.rb
@@ -47,11 +47,7 @@ describe "serializing namespaces" do
     assert_includes(doc, '<dnd:adventure xmlns:dnd="http://www.w3.org/dungeons#">')
     assert_includes(doc, '<dnd:party xmlns:dnd="http://www.w3.org/dragons#">')
     assert_includes(doc, "<dnd:members>")
-    pending_if("https://github.com/sparklemotion/nokogiri/issues/3458", !Nokogiri.jruby?) do
-      # Here MRI Ruby is incorrectly omitting the xmlns namespace declaration, i.e.:
-      # '<dnd:character>'
-      assert_includes(doc, '<dnd:character xmlns:dnd="http://www.w3.org/dungeons#">')
-    end
+    assert_includes(doc, '<dnd:character xmlns:dnd="http://www.w3.org/dungeons#">')
     assert_includes(doc, "<dnd:name>Nigel</dnd:name>")
   end
 

--- a/test/xml/test_builder.rb
+++ b/test/xml/test_builder.rb
@@ -78,6 +78,30 @@ module Nokogiri
         assert_equal({ "xmlns:a" => "x", "xmlns:c" => "z" }, namespaces_defined_on(b))
       end
 
+      def test_builder_namespaces_part_three
+        doc = Nokogiri::XML::Builder.new do |xml|
+          xml["dnd"].adventure("xmlns:dnd" => "http://www.w3.org/dungeons#") do
+            xml["dnd"].party("xmlns:dnd" => "http://www.w3.org/dragons#") do
+              xml["dnd"].character("xmlns:dnd" => "http://www.w3.org/dungeons#") do
+                xml["dnd"].name("Nigel", "xmlns:dnd" => "http://www.w3.org/dungeons#")
+              end
+            end
+          end
+        end.doc
+
+        adventure_node = doc.at_xpath("//*[local-name()='adventure']")
+        assert_equal("http://www.w3.org/dungeons#", adventure_node.namespace.href)
+
+        party_node = doc.at_xpath("//*[local-name()='party']")
+        assert_equal("http://www.w3.org/dragons#", party_node.namespace.href)
+
+        character_node = doc.at_xpath("//*[local-name()='character']")
+        assert_equal("http://www.w3.org/dungeons#", character_node.namespace.href)
+
+        name_node = doc.at_xpath("//*[local-name()='name']")
+        assert_equal("http://www.w3.org/dungeons#", name_node.namespace.href)
+      end
+
       def test_builder_with_unlink
         b = Nokogiri::XML::Builder.new do |xml|
           xml.foo do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Simplify Builder to do late binding on namespaces, so that nodes can be built that rely on namespaces they define.

Fixes #3458

**Have you included adequate test coverage?**

Existing pending coverage (now resolved) is sufficient.

**Does this change affect the behavior of either the C or the Java implementations?**

This really only affects the CRuby implementation, which now behaves like the JRuby impl does.