### PR TITLE
dep: update libxslt to 1.1.43 (v1.18.x branch)

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -16,9 +16,6 @@ on:
     types: [opened, synchronize]
     branches:
       - '*'
-env:
-  NOKOGIRI_USE_CANONICAL_GNOME_SOURCE: t
-
 jobs:
   downstream:
     name: downstream-${{matrix.name}}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -5,9 +5,9 @@ libxml2:
   # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.6.sha256sum
 
 libxslt:
-  version: "1.1.42"
-  sha256: "85ca62cac0d41fc77d3f6033da9df6fd73d20ea2fc18b0a3609ffb4110e1baeb"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.42.sha256sum
+  version: "1.1.43"
+  sha256: "5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.sha256sum
 
 zlib:
   version: "1.3.1"

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -240,15 +240,7 @@ def zlib_source(version_string)
 end
 
 def gnome_source
-  # As of 2022-02-20, some mirrors have expired SSL certificates. I'm able to retrieve from my home,
-  # but whatever host is resolved on the github actions workers see an expired cert.
-  #
-  # See https://github.com/sparklemotion/nokogiri/runs/5266206403?check_suite_focus=true
-  if ENV["NOKOGIRI_USE_CANONICAL_GNOME_SOURCE"]
-    "https://download.gnome.org"
-  else
-    "https://muug.ca/mirror/gnome" # old reliable
-  end
+  "https://download.gnome.org"
 end
 
 LOCAL_PACKAGE_RESPONSE = Object.new


### PR DESCRIPTION
**What problem is this PR intended to solve?**

https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.43

Note that this release is documented as fixing:

* CVE-2025-24855: Fix use-after-free of XPath context node
* CVE-2024-55549: Fix UAF related to excluded namespaces

so this will be a security release.
