### PR TITLE
dep: update minimum java version from 1.8 to 21

### DIFF
--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -181,6 +181,14 @@ def java?
   RUBY_PLATFORM.include?("java")
 end
 
+def java_min_version
+  if java? && JRUBY_VERSION.start_with?("10.")
+    "21"
+  else
+    "1.8"
+  end
+end
+
 def add_file_to_gem(relative_source_path)
   if relative_source_path.nil? || !File.exist?(relative_source_path)
     raise "Cannot find file '#{relative_source_path}'"
@@ -331,8 +339,8 @@ if java?
 
     ext.ext_dir = "ext/java"
     ext.lib_dir = "lib/nokogiri"
-    ext.source_version = "1.8"
-    ext.target_version = "1.8"
+    ext.source_version = java_min_version
+    ext.target_version = java_min_version
     ext.classpath = ext.gem_spec.files.select { |path| File.fnmatch?("**/*.jar", path) }.join(":")
     ext.debug = true if ENV["JAVA_DEBUG"]
   end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Github Actions started failing on jruby-head builds this week with an error message like:

```
  bad class file: /home/runner/.rubies/jruby-head/lib/jruby.jar(/org/jruby/Ruby.class)
    class file has wrong version 65.0, should be 61.0
```

Example failure: https://github.com/sparklemotion/nokogiri/actions/runs/13852274600/job/38789085283#step:4:17

If I understand correctly, the class file version is correlated with the JDK version, so I'm trying this to see if it fixes the issues with jruby-head.

See related commit 86652b15 which updated the minimum from 1.7 to 1.8 in 2024, and 08e55603 which updated the minimum from 1.6 to 1.7 in 2020.

@headius am I doing this right, and what would you recommend as far as timing of when to drop support for 1.8 in Nokogiri?