### PR TITLE
Fixes for recent JRuby updates

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -182,6 +182,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "jruby-head"

--- a/nokogiri.gemspec
+++ b/nokogiri.gemspec
@@ -333,10 +333,6 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
 
   if java_p
-    # loosen after jruby fixes https://github.com/jruby/jruby/issues/7262
-    # also see https://github.com/mkristian/jar-dependencies/commit/006fb254
-    spec.add_development_dependency("jar-dependencies", "= 0.4.1")
-
     spec.require_paths << "lib/nokogiri/jruby" # where we install the jars, see the :vendor_jars rake task
     spec.requirements << "jar isorelax, isorelax, 20030108" # https://search.maven.org/artifact/isorelax/isorelax
     spec.requirements << "jar org.nokogiri, nekodtd, 0.1.11.noko2"


### PR DESCRIPTION
This PR will contain fixes for recent JRuby updates, including:

* jar-dependencies unpinning
* running jruby-head builds on appropriate Java setup
* anything else I find that needs updating