### PR TITLE
Clean up and modernize the JRuby extension

### DIFF
--- a/ext/java/nokogiri/Html4Document.java
+++ b/ext/java/nokogiri/Html4Document.java
@@ -52,7 +52,7 @@ public class Html4Document extends XmlDocument
     super(ruby, klazz, doc);
   }
 
-  @JRubyMethod(name = "new", meta = true, rest = true, required = 0)
+  @JRubyMethod(name = "new", meta = true, rest = true)
   public static IRubyObject
   rbNew(ThreadContext context, IRubyObject klazz, IRubyObject[] args)
   {

--- a/ext/java/nokogiri/Html4ElementDescription.java
+++ b/ext/java/nokogiri/Html4ElementDescription.java
@@ -33,7 +33,7 @@ public class Html4ElementDescription extends RubyObject
   static
   {
     Map<Short, List<String>> _subElements =
-      new HashMap<Short, List<String>>();
+      new HashMap<>();
     subElements = Collections.synchronizedMap(_subElements);
   }
 
@@ -56,7 +56,7 @@ public class Html4ElementDescription extends RubyObject
     List<String> subs = subElements.get(elem.code);
 
     if (subs == null) {
-      subs = new ArrayList<String>();
+      subs = new ArrayList<>();
 
       /*
        * A bit of a hack.  NekoHtml source code shows that
@@ -127,6 +127,7 @@ public class Html4ElementDescription extends RubyObject
       ary[i] = ruby.newString(subs.get(i));
     }
 
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     return ruby.newArray(ary);
   }
 

--- a/ext/java/nokogiri/Html4EntityLookup.java
+++ b/ext/java/nokogiri/Html4EntityLookup.java
@@ -29,7 +29,7 @@ public class Html4EntityLookup extends RubyObject
 
   /**
    * Looks up an HTML entity <code>key</code>.
-   *
+   * <p>
    * The description is a bit lacking.
    */
   @JRubyMethod()
@@ -53,11 +53,10 @@ public class Html4EntityLookup extends RubyObject
 
     IRubyObject edClass =
       ruby.getClassFromPath("Nokogiri::HTML4::EntityDescription");
-    IRubyObject edObj = invoke(context, edClass, "new",
+
+    return invoke(context, edClass, "new",
                                ruby.newFixnum(val), ruby.newString(name),
                                ruby.newString(name + " entity"));
-
-    return edObj;
   }
 
 }

--- a/ext/java/nokogiri/Html4SaxParserContext.java
+++ b/ext/java/nokogiri/Html4SaxParserContext.java
@@ -1,6 +1,5 @@
 package nokogiri;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import org.apache.xerces.parsers.AbstractSAXParser;
@@ -8,8 +7,6 @@ import net.sourceforge.htmlunit.cyberneko.parsers.SAXParser;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyEncoding;
-import org.jruby.RubyFixnum;
-import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
@@ -17,7 +14,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.xml.sax.SAXException;
 
 import nokogiri.internals.NokogiriHandler;
-import static nokogiri.internals.NokogiriHelpers.rubyStringToString;
 
 import static org.jruby.runtime.Helpers.invoke;
 
@@ -65,7 +61,7 @@ public class Html4SaxParserContext extends XmlSaxParserContext
       return parser;
     } catch (SAXException ex) {
       throw new SAXException(
-        "Problem while creating HTML4 SAX Parser: " + ex.toString());
+        "Problem while creating HTML4 SAX Parser: " + ex);
     }
   }
 
@@ -76,9 +72,10 @@ public class Html4SaxParserContext extends XmlSaxParserContext
     String java_encoding = null;
     if (encoding != context.runtime.getNil()) {
       if (!(encoding instanceof RubyEncoding)) {
+        // TODO: switch to common undeprecated API when 9.4 adds 10 methods
         throw context.runtime.newTypeError("encoding must be kind_of Encoding");
       }
-      java_encoding = ((RubyEncoding)encoding).toString();
+      java_encoding = encoding.toString();
     }
 
     Html4SaxParserContext ctx = Html4SaxParserContext.newInstance(context.runtime, (RubyClass) klazz);
@@ -98,9 +95,10 @@ public class Html4SaxParserContext extends XmlSaxParserContext
     String java_encoding = null;
     if (encoding != context.runtime.getNil()) {
       if (!(encoding instanceof RubyEncoding)) {
+        // TODO: switch to common undeprecated API when 9.4 adds 10 methods
         throw context.runtime.newTypeError("encoding must be kind_of Encoding");
       }
-      java_encoding = ((RubyEncoding)encoding).toString();
+      java_encoding = encoding.toString();
     }
 
     Html4SaxParserContext ctx = Html4SaxParserContext.newInstance(context.runtime, (RubyClass) klass);
@@ -118,15 +116,17 @@ public class Html4SaxParserContext extends XmlSaxParserContext
   parse_io(ThreadContext context, IRubyObject klazz, IRubyObject data, IRubyObject encoding)
   {
     if (!invoke(context, data, "respond_to?", context.runtime.newSymbol("read")).isTrue()) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw context.runtime.newTypeError("argument expected to respond to :read");
     }
 
     String java_encoding = null;
     if (encoding != context.runtime.getNil()) {
       if (!(encoding instanceof RubyEncoding)) {
+        // TODO: switch to common undeprecated API when 9.4 adds 10 methods
         throw context.runtime.newTypeError("encoding must be kind_of Encoding");
       }
-      java_encoding = ((RubyEncoding)encoding).toString();
+      java_encoding = encoding.toString();
     }
 
     Html4SaxParserContext ctx = Html4SaxParserContext.newInstance(context.runtime, (RubyClass) klazz);

--- a/ext/java/nokogiri/NokogiriService.java
+++ b/ext/java/nokogiri/NokogiriService.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jruby.Ruby;
-import org.jruby.RubyArray;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyModule;
@@ -33,13 +32,14 @@ public class NokogiriService implements BasicLibraryService
   public static Map<String, RubyClass>
   getNokogiriClassCache(Ruby ruby)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     return (Map<String, RubyClass>) ruby.getModule("Nokogiri").getInternalVariable("cache");
   }
 
   private static Map<String, RubyClass>
   populateNokogiriClassCache(Ruby ruby)
   {
-    Map<String, RubyClass> nokogiriClassCache = new HashMap<String, RubyClass>();
+    Map<String, RubyClass> nokogiriClassCache = new HashMap<>();
     nokogiriClassCache.put("Nokogiri::HTML4::Document", (RubyClass)ruby.getClassFromPath("Nokogiri::HTML4::Document"));
     nokogiriClassCache.put("Nokogiri::HTML4::ElementDescription",
                            (RubyClass)ruby.getClassFromPath("Nokogiri::HTML4::ElementDescription"));
@@ -78,6 +78,7 @@ public class NokogiriService implements BasicLibraryService
   private void
   init(Ruby ruby)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     RubyModule nokogiri = ruby.defineModule("Nokogiri");
     RubyModule xmlModule = nokogiri.defineModuleUnder("XML");
     RubyModule xmlSaxModule = xmlModule.defineModuleUnder("SAX");
@@ -97,6 +98,7 @@ public class NokogiriService implements BasicLibraryService
   private void
   createSyntaxErrors(Ruby ruby, RubyModule nokogiri, RubyModule xmlModule)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     RubyClass syntaxError = nokogiri.defineClassUnder("SyntaxError", ruby.getStandardError(),
                             ruby.getStandardError().getAllocator());
     RubyClass xmlSyntaxError = xmlModule.defineClassUnder("SyntaxError", syntaxError, XML_SYNTAXERROR_ALLOCATOR);
@@ -106,6 +108,7 @@ public class NokogiriService implements BasicLibraryService
   private RubyClass
   createXmlModule(Ruby ruby, RubyModule xmlModule)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     RubyClass node = xmlModule.defineClassUnder("Node", ruby.getObject(), XML_NODE_ALLOCATOR);
     node.defineAnnotatedMethods(XmlNode.class);
 
@@ -183,6 +186,7 @@ public class NokogiriService implements BasicLibraryService
   private void
   createHtmlModule(Ruby ruby, RubyModule htmlModule)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     RubyClass htmlElemDesc = htmlModule.defineClassUnder("ElementDescription", ruby.getObject(),
                              HTML_ELEMENT_DESCRIPTION_ALLOCATOR);
     htmlElemDesc.defineAnnotatedMethods(Html4ElementDescription.class);
@@ -195,6 +199,7 @@ public class NokogiriService implements BasicLibraryService
   private void
   createDocuments(Ruby ruby, RubyModule xmlModule, RubyModule htmlModule, RubyClass node)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     RubyClass xmlDocument = xmlModule.defineClassUnder("Document", node, XML_DOCUMENT_ALLOCATOR);
     xmlDocument.defineAnnotatedMethods(XmlDocument.class);
 
@@ -206,6 +211,7 @@ public class NokogiriService implements BasicLibraryService
   private void
   createSaxModule(Ruby ruby, RubyModule xmlSaxModule, RubyModule htmlSaxModule)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     RubyClass xmlSaxParserContext = xmlSaxModule.defineClassUnder("ParserContext", ruby.getObject(),
                                     XML_SAXPARSER_CONTEXT_ALLOCATOR);
     xmlSaxParserContext.defineAnnotatedMethods(XmlSaxParserContext.class);
@@ -225,6 +231,7 @@ public class NokogiriService implements BasicLibraryService
   private void
   createXsltModule(Ruby ruby, RubyModule xsltModule)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     RubyClass stylesheet = xsltModule.defineClassUnder("Stylesheet", ruby.getObject(), XSLT_STYLESHEET_ALLOCATOR);
     stylesheet.defineAnnotatedMethods(XsltStylesheet.class);
   }
@@ -259,21 +266,9 @@ public class NokogiriService implements BasicLibraryService
     }
   };
 
-  private static ObjectAllocator HTML_ELEMENT_DESCRIPTION_ALLOCATOR =
-    new ObjectAllocator()
-  {
-    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-      return new Html4ElementDescription(runtime, klazz);
-    }
-  };
+  private static final ObjectAllocator HTML_ELEMENT_DESCRIPTION_ALLOCATOR = Html4ElementDescription::new;
 
-  private static ObjectAllocator HTML_ENTITY_LOOKUP_ALLOCATOR =
-    new ObjectAllocator()
-  {
-    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-      return new Html4EntityLookup(runtime, klazz);
-    }
-  };
+  private static final ObjectAllocator HTML_ENTITY_LOOKUP_ALLOCATOR = Html4EntityLookup::new;
 
   public static final ObjectAllocator XML_ATTR_ALLOCATOR = new ObjectAllocator()
   {
@@ -486,25 +481,12 @@ public class NokogiriService implements BasicLibraryService
     }
   };
 
-  private static ObjectAllocator XML_ATTRIBUTE_DECL_ALLOCATOR = new ObjectAllocator()
-  {
-    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-      return new XmlAttributeDecl(runtime, klazz);
-    }
-  };
+  private static final ObjectAllocator XML_ATTRIBUTE_DECL_ALLOCATOR = XmlAttributeDecl::new;
 
-  private static ObjectAllocator XML_ENTITY_DECL_ALLOCATOR = new ObjectAllocator()
-  {
-    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-      return new XmlEntityDecl(runtime, klazz);
-    }
-  };
+  private static final ObjectAllocator XML_ENTITY_DECL_ALLOCATOR = XmlEntityDecl::new;
 
-  private static ObjectAllocator XML_ELEMENT_CONTENT_ALLOCATOR = new ObjectAllocator()
-  {
-    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-      throw runtime.newNotImplementedError("not implemented");
-    }
+  private static final ObjectAllocator XML_ELEMENT_CONTENT_ALLOCATOR = (runtime, klazz) -> {
+    throw runtime.newNotImplementedError("not implemented");
   };
 
   public static final ObjectAllocator XML_RELAXNG_ALLOCATOR = new ObjectAllocator()
@@ -537,19 +519,9 @@ public class NokogiriService implements BasicLibraryService
     }
   };
 
-  private static final ObjectAllocator XML_SAXPUSHPARSER_ALLOCATOR = new ObjectAllocator()
-  {
-    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-      return new XmlSaxPushParser(runtime, klazz);
-    }
-  };
+  private static final ObjectAllocator XML_SAXPUSHPARSER_ALLOCATOR = XmlSaxPushParser::new;
 
-  private static final ObjectAllocator HTML_SAXPUSHPARSER_ALLOCATOR = new ObjectAllocator()
-  {
-    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-      return new Html4SaxPushParser(runtime, klazz);
-    }
-  };
+  private static final ObjectAllocator HTML_SAXPUSHPARSER_ALLOCATOR = Html4SaxPushParser::new;
 
   public static final ObjectAllocator XML_SCHEMA_ALLOCATOR = new ObjectAllocator()
   {
@@ -566,12 +538,7 @@ public class NokogiriService implements BasicLibraryService
     }
   };
 
-  public static final ObjectAllocator XML_SYNTAXERROR_ALLOCATOR = new ObjectAllocator()
-  {
-    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-      return new XmlSyntaxError(runtime, klazz);
-    }
-  };
+  public static final ObjectAllocator XML_SYNTAXERROR_ALLOCATOR = XmlSyntaxError::new;
 
   public static final ObjectAllocator XML_TEXT_ALLOCATOR = new ObjectAllocator()
   {
@@ -588,12 +555,7 @@ public class NokogiriService implements BasicLibraryService
     }
   };
 
-  public static final ObjectAllocator XML_XPATHCONTEXT_ALLOCATOR = new ObjectAllocator()
-  {
-    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-      return new XmlXpathContext(runtime, klazz);
-    }
-  };
+  public static final ObjectAllocator XML_XPATHCONTEXT_ALLOCATOR = XmlXpathContext::new;
 
   public static ObjectAllocator XSLT_STYLESHEET_ALLOCATOR = new ObjectAllocator()
   {

--- a/ext/java/nokogiri/XmlAttr.java
+++ b/ext/java/nokogiri/XmlAttr.java
@@ -27,6 +27,8 @@ public class XmlAttr extends XmlNode
 {
   private static final long serialVersionUID = 1L;
 
+  // unused
+  @Deprecated
   public static final String[] HTML_BOOLEAN_ATTRS = {
     "checked", "compact", "declare", "defer", "disabled", "ismap",
     "multiple", "nohref", "noresize", "noshade", "nowrap", "readonly",
@@ -45,6 +47,8 @@ public class XmlAttr extends XmlNode
     super(ruby, rubyClass);
   }
 
+  // unused
+  @Deprecated
   public
   XmlAttr(Ruby ruby, RubyClass rubyClass, Node attr)
   {
@@ -56,6 +60,7 @@ public class XmlAttr extends XmlNode
   init(ThreadContext context, IRubyObject[] args)
   {
     if (args.length < 2) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw context.runtime.newArgumentError(args.length, 2);
     }
 

--- a/ext/java/nokogiri/XmlAttributeDecl.java
+++ b/ext/java/nokogiri/XmlAttributeDecl.java
@@ -32,7 +32,7 @@ public class XmlAttributeDecl extends XmlNode
   /**
    * Initialize based on an attributeDecl node from a NekoDTD parsed
    * DTD.
-   *
+   * <p>
    * Internally, XmlAttributeDecl combines these into a single node.
    */
   public
@@ -102,17 +102,19 @@ public class XmlAttributeDecl extends XmlNode
   {
     final String atype = ((Element) node).getAttribute("atype");
 
-    if (atype != null && atype.length() != 0 && atype.charAt(0) == '(') {
+    if (!atype.isEmpty() && atype.charAt(0) == '(') {
       // removed enclosing parens
       String valueStr = atype.substring(1, atype.length() - 1);
       String[] values = valueStr.split("\\|");
       RubyArray<?> enumVals = RubyArray.newArray(context.runtime, values.length);
-      for (int i = 0; i < values.length; i++) {
-        enumVals.append(context.runtime.newString(values[i]));
+      for (String value : values) {
+        // TODO: switch to common undeprecated API when 9.4 adds 10 methods
+        enumVals.append(context.runtime.newString(value));
       }
       return enumVals;
     }
 
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     return context.runtime.newEmptyArray();
   }
 

--- a/ext/java/nokogiri/XmlCdata.java
+++ b/ext/java/nokogiri/XmlCdata.java
@@ -30,6 +30,8 @@ public class XmlCdata extends XmlText
     super(ruby, rubyClass);
   }
 
+  // unused
+  @Deprecated
   public
   XmlCdata(Ruby ruby, RubyClass rubyClass, Node node)
   {
@@ -41,16 +43,19 @@ public class XmlCdata extends XmlText
   init(ThreadContext context, IRubyObject[] args)
   {
     if (args.length < 2) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw getRuntime().newArgumentError(args.length, 2);
     }
     IRubyObject rbDocument = args[0];
     content = args[1];
 
     if (content.isNil()) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw context.runtime.newTypeError("expected second parameter to be a String, received NilClass");
     }
     if (!(rbDocument instanceof XmlNode)) {
       String msg = "expected first parameter to be a Nokogiri::XML::Document, received " + rbDocument.getMetaClass();
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw context.runtime.newTypeError(msg);
     }
     if (!(rbDocument instanceof XmlDocument)) {

--- a/ext/java/nokogiri/XmlComment.java
+++ b/ext/java/nokogiri/XmlComment.java
@@ -23,6 +23,8 @@ public class XmlComment extends XmlNode
 {
   private static final long serialVersionUID = 1L;
 
+  // unused
+  @Deprecated
   public
   XmlComment(Ruby ruby, RubyClass rubyClass, Node node)
   {
@@ -40,6 +42,7 @@ public class XmlComment extends XmlNode
   init(ThreadContext context, IRubyObject[] args)
   {
     if (args.length < 2) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw getRuntime().newArgumentError(args.length, 2);
     }
 

--- a/ext/java/nokogiri/XmlDocumentFragment.java
+++ b/ext/java/nokogiri/XmlDocumentFragment.java
@@ -1,29 +1,13 @@
 package nokogiri;
 
-import static nokogiri.internals.NokogiriHelpers.getLocalNameForNamespace;
 import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
-import static nokogiri.internals.NokogiriHelpers.getPrefix;
-import static nokogiri.internals.NokogiriHelpers.isNamespace;
-import static nokogiri.internals.NokogiriHelpers.rubyStringToString;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.jruby.Ruby;
-import org.jruby.RubyArray;
 import org.jruby.RubyClass;
-import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.runtime.Block;
-import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.ByteList;
-import org.w3c.dom.Attr;
-import org.w3c.dom.NamedNodeMap;
 
 /**
  * Class for Nokogiri::XML::DocumentFragment
@@ -36,6 +20,8 @@ public class XmlDocumentFragment extends XmlNode
 {
   private static final long serialVersionUID = 1L;
 
+  // unused
+  @Deprecated
   public
   XmlDocumentFragment(Ruby ruby)
   {

--- a/ext/java/nokogiri/XmlDtd.java
+++ b/ext/java/nokogiri/XmlDtd.java
@@ -138,7 +138,7 @@ public class XmlDtd extends XmlNode
    * <code>doc</code>.  The attached dtd must be the tree from
    * NekoDTD. The owner document of the returned tree will be
    * <code>doc</doc>.
-   *
+   * <p>
    * NekoDTD parser returns a new document node containing elements
    * representing the dtd declarations. The plan is to get the root
    * element and adopt it into the correct document, stripping the
@@ -332,6 +332,7 @@ public class XmlDtd extends XmlNode
   public IRubyObject
   validate(ThreadContext context, IRubyObject doc)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     RubyArray<?> errors = RubyArray.newArray(context.getRuntime());
     if (doc instanceof XmlDocument) {
       errors = (RubyArray)((XmlDocument)doc).getInstanceVariable("@errors");
@@ -450,7 +451,7 @@ public class XmlDtd extends XmlNode
    * The <code>node</code> is either the first child of the root dtd
    * node (as returned by getInternalSubset()) or the first child of
    * the external subset node (as returned by getExternalSubset()).
-   *
+   * <p>
    * This recursive function will not descend into an
    * 'externalSubset' node, thus for an internal subset it only
    * extracts nodes in the internal subset, and for an external
@@ -460,7 +461,7 @@ public class XmlDtd extends XmlNode
   protected IRubyObject[]
   extractDecls(ThreadContext context, Node node)
   {
-    List<IRubyObject> decls = new ArrayList<IRubyObject>();
+    List<IRubyObject> decls = new ArrayList<>();
     while (node != null) {
       if (isExternalSubset(node)) {
         break;

--- a/ext/java/nokogiri/XmlElement.java
+++ b/ext/java/nokogiri/XmlElement.java
@@ -4,7 +4,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.anno.JRubyClass;
 import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.builtin.IRubyObject;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
@@ -27,6 +26,8 @@ public class XmlElement extends XmlNode
     super(runtime, klazz);
   }
 
+  // unused
+  @Deprecated
   public
   XmlElement(Ruby runtime, RubyClass klazz, Node element)
   {

--- a/ext/java/nokogiri/XmlElementContent.java
+++ b/ext/java/nokogiri/XmlElementContent.java
@@ -325,7 +325,7 @@ public class XmlElementContent extends RubyObject
    * moves to the parent of previous sibling).  The null position is
    * used to indicate the end of a list.
    */
-  protected static class NodeIter
+  public static class NodeIter
   {
     protected Node pre;
     protected Node cur;

--- a/ext/java/nokogiri/XmlElementDecl.java
+++ b/ext/java/nokogiri/XmlElementDecl.java
@@ -31,6 +31,7 @@ public class XmlElementDecl extends XmlNode
   XmlElementDecl(Ruby runtime, RubyClass klazz)
   {
     super(runtime, klazz);
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     attrDecls = RubyArray.newArray(runtime);
     contentModel = runtime.getNil();
   }
@@ -49,6 +50,7 @@ public class XmlElementDecl extends XmlNode
   setNode(Ruby runtime, Node node)
   {
     super.setNode(runtime, node);
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     attrDecls = RubyArray.newArray(runtime);
     contentModel = runtime.getNil();
   }
@@ -136,6 +138,7 @@ public class XmlElementDecl extends XmlNode
   public void
   appendAttrDecl(XmlAttributeDecl decl)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     attrDecls.append(decl);
   }
 

--- a/ext/java/nokogiri/XmlEntityReference.java
+++ b/ext/java/nokogiri/XmlEntityReference.java
@@ -1,6 +1,5 @@
 package nokogiri;
 
-import static nokogiri.internals.NokogiriHelpers.getCachedNodeOrCreate;
 import static nokogiri.internals.NokogiriHelpers.rubyStringToString;
 import nokogiri.internals.SaveContextVisitor;
 
@@ -31,6 +30,8 @@ public class XmlEntityReference extends XmlNode
     super(ruby, klazz);
   }
 
+  // unused
+  @Deprecated
   public
   XmlEntityReference(Ruby ruby, RubyClass klass, Node node)
   {
@@ -41,6 +42,7 @@ public class XmlEntityReference extends XmlNode
   init(ThreadContext context, IRubyObject[] args)
   {
     if (args.length < 2) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw context.runtime.newArgumentError(args.length, 2);
     }
 

--- a/ext/java/nokogiri/XmlNamespace.java
+++ b/ext/java/nokogiri/XmlNamespace.java
@@ -106,7 +106,8 @@ public class XmlNamespace extends RubyObject
     Document document = owner.getOwnerDocument();
     XmlDocument xmlDocument = (XmlDocument) getCachedNodeOrCreate(runtime, document);
 
-    assert xmlDocument.getNamespaceCache().get(prefixStr, hrefStr) == null;
+    XmlNamespace cachedNamespace = xmlDocument.getNamespaceCache().get(prefixStr, hrefStr);
+    assert cachedNamespace == null;
 
     // creating XmlNamespace instance
     String attrName = "xmlns";

--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -2,7 +2,6 @@ package nokogiri;
 
 import static nokogiri.XmlNode.setDocumentAndDecorate;
 import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
-import static nokogiri.internals.NokogiriHelpers.nodeListToRubyArray;
 
 import java.util.Arrays;
 
@@ -151,11 +150,9 @@ public class XmlNodeSet extends RubyObject implements NodeList
 
     int last = 0;
     outer:
-    for (int i = 0; i < curr.length; i++) {
-      IRubyObject n = curr[i];
-
-      for (int j = 0; j < other.length; j++) {
-        if (other[j] == n) {
+    for (IRubyObject n : curr) {
+      for (IRubyObject iRubyObject : other) {
+        if (iRubyObject == n) {
           result[last++] = n;
           continue outer;
         }
@@ -182,9 +179,7 @@ public class XmlNodeSet extends RubyObject implements NodeList
 
     int last = 0;
 
-    for (int i = 0; i < orig.length; i++) {
-      IRubyObject n = orig[i];
-
+    for (IRubyObject n : orig) {
       if (n == nodeOrNamespace) {
         continue;
       }
@@ -223,8 +218,8 @@ public class XmlNodeSet extends RubyObject implements NodeList
   public IRubyObject
   include_p(ThreadContext context, IRubyObject node_or_namespace)
   {
-    for (int i = 0; i < nodes.length; i++) {
-      if (nodes[i] == node_or_namespace) {
+    for (IRubyObject node : nodes) {
+      if (node == node_or_namespace) {
         return context.tru;
       }
     }
@@ -259,11 +254,9 @@ public class XmlNodeSet extends RubyObject implements NodeList
 
     int last = 0;
     outer:
-    for (int i = 0; i < curr.length; i++) {
-      IRubyObject n = curr[i];
-
-      for (int j = 0; j < other.length; j++) {
-        if (other[j] == n) {
+    for (IRubyObject n : curr) {
+      for (IRubyObject iRubyObject : other) {
+        if (iRubyObject == n) {
           continue outer;
         }
       }
@@ -283,6 +276,8 @@ public class XmlNodeSet extends RubyObject implements NodeList
     IRubyObject[] otherNodes = getNodes(context, nodeSet);
 
     if (nodes.length == 0) {
+      // TODO: switch to interface method when it has been in 9.4 for a year.
+      //       The "useless" cast here on JRuby 10 is necessary on 9.4 for now.
       return ((XmlNodeSet) nodeSet).dup(context);
     }
 
@@ -296,11 +291,9 @@ public class XmlNodeSet extends RubyObject implements NodeList
 
     int last = curr.length;
     outer:
-    for (int i = 0; i < other.length; i++) {
-      IRubyObject n = other[i];
-
-      for (int j = 0; j < curr.length; j++) {
-        if (curr[j] == n) {
+    for (IRubyObject n : other) {
+      for (IRubyObject iRubyObject : curr) {
+        if (iRubyObject == n) {
           continue outer;
         }
       }
@@ -329,6 +322,7 @@ public class XmlNodeSet extends RubyObject implements NodeList
   rangeBeginLength(ThreadContext context, IRubyObject rangeMaybe, int len, int[] begLen)
   {
     RubyRange range = (RubyRange) rangeMaybe;
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     int min = range.begin(context).convertToInteger().getIntValue();
     int max = range.end(context).convertToInteger().getIntValue();
 
@@ -358,6 +352,7 @@ public class XmlNodeSet extends RubyObject implements NodeList
   slice(ThreadContext context, IRubyObject indexOrRange)
   {
     if (indexOrRange instanceof RubyFixnum) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       return slice(context, ((RubyFixnum) indexOrRange).getIntValue());
     }
     if (indexOrRange instanceof RubyRange) {
@@ -367,6 +362,7 @@ public class XmlNodeSet extends RubyObject implements NodeList
       int max = begLen[1];
       return subseq(context, min, max - min);
     }
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     throw context.runtime.newTypeError("index must be an Integer or a Range");
   }
 
@@ -388,6 +384,7 @@ public class XmlNodeSet extends RubyObject implements NodeList
   public IRubyObject
   slice(ThreadContext context, IRubyObject start, IRubyObject length)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     int s = ((RubyFixnum) start).getIntValue();
     int l = ((RubyFixnum) length).getIntValue();
 
@@ -422,6 +419,7 @@ public class XmlNodeSet extends RubyObject implements NodeList
   public RubyArray<?>
   to_a(ThreadContext context)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     return context.runtime.newArrayNoCopy(nodes);
   }
 

--- a/ext/java/nokogiri/XmlProcessingInstruction.java
+++ b/ext/java/nokogiri/XmlProcessingInstruction.java
@@ -65,6 +65,8 @@ public class XmlProcessingInstruction extends XmlNode
     return self;
   }
 
+  // unused
+  @Deprecated
   @Override
   public boolean
   isProcessingInstruction() { return true; }

--- a/ext/java/nokogiri/XmlReader.java
+++ b/ext/java/nokogiri/XmlReader.java
@@ -93,7 +93,7 @@ public class XmlReader extends RubyObject
   public void
   init(Ruby runtime)
   {
-    nodeQueue = new LinkedList<ReaderNode>();
+    nodeQueue = new LinkedList<>();
     nodeQueue.add(new ReaderNode.EmptyNode(runtime));
   }
 
@@ -181,8 +181,8 @@ public class XmlReader extends RubyObject
     ensureNodeClosed(context);
 
     if (readerNode == null) { return context.getRuntime().getNil(); }
-    if (!(readerNode instanceof ElementNode)) { context.getRuntime().getFalse(); }
-    return RubyBoolean.newBoolean(context.getRuntime(), !readerNode.hasChildren);
+    if (!(readerNode instanceof ElementNode)) { return context.getRuntime().getFalse(); }
+    return RubyBoolean.newBoolean(context, !readerNode.hasChildren);
   }
 
   @JRubyMethod
@@ -210,6 +210,7 @@ public class XmlReader extends RubyObject
                        "Nokogiri::XML::Reader"));
     reader.init(runtime);
     reader.setInstanceVariable("@source", args[0]);
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     reader.setInstanceVariable("@errors", runtime.newArray());
     IRubyObject url = context.nil;
     if (args.length > 1) { url = args[1]; }
@@ -241,6 +242,7 @@ public class XmlReader extends RubyObject
                        "Nokogiri::XML::Reader"));
     reader.init(runtime);
     reader.setInstanceVariable("@source", args[0]);
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     reader.setInstanceVariable("@errors", runtime.newArray());
     IRubyObject url = context.nil;
     if (args.length > 1) { url = args[1]; }
@@ -280,7 +282,7 @@ public class XmlReader extends RubyObject
   {
     if (current.depth < 0) { return null; }
     if (!current.hasChildren) { return null; }
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     for (int i = current.startOffset + 1; i <= current.endOffset - 1; i++) {
       sb.append(nodeQueue.get(i).getString());
     }
@@ -396,8 +398,9 @@ public class XmlReader extends RubyObject
     final ReaderNode currentNode = currentNode();
     if (currentNode == null) { return runtime.getNil(); }
     if (currentNode.isError()) {
-      RubyArray<?> errors = (RubyArray) getInstanceVariable("@errors");
+      RubyArray<?> errors = (RubyArray<?>) getInstanceVariable("@errors");
       IRubyObject error = currentNode.toSyntaxError();
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       errors.append(error);
       setInstanceVariable("@errors", errors);
 
@@ -492,9 +495,9 @@ public class XmlReader extends RubyObject
     startDocument(XMLLocator locator, String encoding, NamespaceContext context, Augmentations augs)
     {
       depth = 0;
-      langStack = new Stack<String>();
-      xmlBaseStack = new Stack<String>();
-      elementStack = new Stack<ReaderNode.ElementNode>();
+      langStack = new Stack<>();
+      xmlBaseStack = new Stack<>();
+      elementStack = new Stack<>();
     }
 
     @Override
@@ -552,7 +555,7 @@ public class XmlReader extends RubyObject
       String qName = element.rawname;
       String uri = element.uri;
       String localName = element.localpart;
-      ReaderNode readerNode = ReaderNode.createElementNode(ruby, uri, localName, qName, attrs, depth, langStack,
+      ElementNode readerNode = ReaderNode.createElementNode(ruby, uri, localName, qName, attrs, depth, langStack,
                               xmlBaseStack);
       if (!elementStack.isEmpty()) {
         ElementNode parent = elementStack.peek();
@@ -564,7 +567,7 @@ public class XmlReader extends RubyObject
         depth++;
         if (readerNode.lang != null) { langStack.push(readerNode.lang); }
         if (readerNode.xmlBase != null) { xmlBaseStack.push(readerNode.xmlBase); }
-        elementStack.push((ReaderNode.ElementNode)readerNode);
+        elementStack.push(readerNode);
       } else {
         readerNode.endOffset = readerNode.startOffset;
         readerNode.hasChildren = false;

--- a/ext/java/nokogiri/XmlRelaxng.java
+++ b/ext/java/nokogiri/XmlRelaxng.java
@@ -1,15 +1,12 @@
 package nokogiri;
 
-import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.transform.Source;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -63,6 +60,7 @@ public class XmlRelaxng extends XmlSchema
       parseOptions = defaultParseOptions(context.getRuntime());
     }
 
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     xmlRelaxng.setInstanceVariable("@errors", runtime.newEmptyArray());
     xmlRelaxng.setInstanceVariable("@parse_options", parseOptions);
 
@@ -89,27 +87,16 @@ public class XmlRelaxng extends XmlSchema
       StreamResult result = new StreamResult(xmlAsWriter);
       try {
         TransformerFactory.newInstance().newTransformer().transform(ds, result);
-      } catch (TransformerConfigurationException ex) {
-        throw context.getRuntime()
-        .newRuntimeError("Could not parse document: " + ex.getMessage());
       } catch (TransformerException ex) {
         throw context.getRuntime()
         .newRuntimeError("Could not parse document: " + ex.getMessage());
       }
-      try {
-        is = new ByteArrayInputStream(xmlAsWriter.toString().getBytes("UTF-8"));
-      } catch (UnsupportedEncodingException ex) {
-        throw context.getRuntime()
-        .newRuntimeError("Could not parse document: " + ex.getMessage());
-      }
+      is = new ByteArrayInputStream(xmlAsWriter.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     try {
       return factory.compileSchema(is);
-    } catch (VerifierConfigurationException ex) {
-      throw context.getRuntime()
-      .newRuntimeError("Could not parse document: " + ex.getMessage());
-    } catch (SAXException ex) {
+    } catch (VerifierConfigurationException | SAXException ex) {
       throw context.getRuntime()
       .newRuntimeError("Could not parse document: " + ex.getMessage());
     } catch (IOException ex) {

--- a/ext/java/nokogiri/XmlSaxParserContext.java
+++ b/ext/java/nokogiri/XmlSaxParserContext.java
@@ -1,14 +1,12 @@
 package nokogiri;
 
 import nokogiri.internals.*;
-import static nokogiri.internals.NokogiriHelpers.rubyStringToString;
 
 import org.apache.xerces.parsers.AbstractSAXParser;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyEncoding;
 import org.jruby.RubyFixnum;
-import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
@@ -18,7 +16,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -104,7 +101,7 @@ public class XmlSaxParserContext extends ParserContext
       if (!(encoding instanceof RubyEncoding)) {
         throw context.runtime.newTypeError("encoding must be kind_of Encoding");
       }
-      java_encoding = ((RubyEncoding)encoding).toString();
+      java_encoding = encoding.toString();
     }
 
     XmlSaxParserContext ctx = newInstance(context.runtime, (RubyClass) klazz);
@@ -129,9 +126,10 @@ public class XmlSaxParserContext extends ParserContext
     String java_encoding = null;
     if (encoding != context.runtime.getNil()) {
       if (!(encoding instanceof RubyEncoding)) {
+        // TODO: switch to common undeprecated API when 9.4 adds 10 methods
         throw context.runtime.newTypeError("encoding must be kind_of Encoding");
       }
-      java_encoding = ((RubyEncoding)encoding).toString();
+      java_encoding = encoding.toString();
     }
 
     XmlSaxParserContext ctx = newInstance(context.runtime, (RubyClass) klazz);
@@ -156,15 +154,17 @@ public class XmlSaxParserContext extends ParserContext
   parse_io(ThreadContext context, IRubyObject klazz, IRubyObject data, IRubyObject encoding)
   {
     if (!invoke(context, data, "respond_to?", context.runtime.newSymbol("read")).isTrue()) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw context.runtime.newTypeError("argument expected to respond to :read");
     }
 
     String java_encoding = null;
     if (encoding != context.runtime.getNil()) {
       if (!(encoding instanceof RubyEncoding)) {
+        // TODO: switch to common undeprecated API when 9.4 adds 10 methods
         throw context.runtime.newTypeError("encoding must be kind_of Encoding");
       }
-      java_encoding = ((RubyEncoding)encoding).toString();
+      java_encoding = encoding.toString();
     }
 
     XmlSaxParserContext ctx = newInstance(context.runtime, (RubyClass) klazz);
@@ -236,9 +236,10 @@ public class XmlSaxParserContext extends ParserContext
   protected static Options
   defaultParseOptions(ThreadContext context)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     return new ParserContext.Options(
              RubyFixnum.fix2long(Helpers.invoke(context,
-                                 ((RubyClass)context.getRuntime().getClassFromPath("Nokogiri::XML::ParseOptions"))
+                                 context.getRuntime().getClassFromPath("Nokogiri::XML::ParseOptions")
                                  .getConstant("DEFAULT_XML"),
                                  "to_i"))
            );
@@ -272,7 +273,7 @@ public class XmlSaxParserContext extends ParserContext
       parser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);
       parser.setProperty("http://xml.org/sax/properties/declaration-handler", handler);
     } catch (Exception ex) {
-      throw runtime.newRuntimeError("Problem while creating XML SAX Parser: " + ex.toString());
+      throw runtime.newRuntimeError("Problem while creating XML SAX Parser: " + ex);
     }
 
     try {

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -6,21 +6,17 @@ import static nokogiri.internals.NokogiriHelpers.getNokogiriClass;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.StringReader;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import nokogiri.internals.IgnoreSchemaErrorsErrorHandler;
 import nokogiri.internals.SchemaErrorHandler;
 import nokogiri.internals.XmlDomParserContext;
 import nokogiri.internals.ParserContext;
-import nokogiri.internals.ParserContext.Options;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -29,7 +25,6 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -106,14 +101,16 @@ public class XmlSchema extends RubyObject
     if (parseOptions == null) {
       parseOptions = defaultParseOptions(context.getRuntime());
     }
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     long intParseOptions = RubyFixnum.fix2long(Helpers.invoke(context, parseOptions, "to_i"));
 
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     xmlSchema.setInstanceVariable("@errors", runtime.newEmptyArray());
     xmlSchema.setInstanceVariable("@parse_options", parseOptions);
 
     try {
       SchemaErrorHandler errorHandler =
-        new SchemaErrorHandler(context.getRuntime(), (RubyArray)xmlSchema.getInstanceVariable("@errors"));
+        new SchemaErrorHandler(context.getRuntime(), (RubyArray<?>)xmlSchema.getInstanceVariable("@errors"));
       Schema schema =
         xmlSchema.getSchema(source,
                             context.getRuntime().getCurrentDirectory(),
@@ -130,7 +127,7 @@ public class XmlSchema extends RubyObject
   protected static IRubyObject
   defaultParseOptions(Ruby runtime)
   {
-    return ((RubyClass)runtime.getClassFromPath("Nokogiri::XML::ParseOptions")).getConstant("DEFAULT_SCHEMA");
+    return runtime.getClassFromPath("Nokogiri::XML::ParseOptions").getConstant("DEFAULT_SCHEMA");
   }
 
   /*
@@ -151,6 +148,7 @@ public class XmlSchema extends RubyObject
 
     if (!(rbDocument instanceof XmlNode)) {
       String msg = "expected parameter to be a Nokogiri::XML::Document, received " + rbDocument.getMetaClass();
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw context.runtime.newTypeError(msg);
     }
     if (!(rbDocument instanceof XmlDocument)) {
@@ -159,8 +157,9 @@ public class XmlSchema extends RubyObject
 
     XmlDocument doc = ((XmlDocument)((XmlNode) rbDocument).document(context));
 
-    RubyArray<?> errors = (RubyArray) doc.getInstanceVariable("@errors");
+    RubyArray<?> errors = (RubyArray<?>) doc.getInstanceVariable("@errors");
     if (!errors.isEmpty()) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw((XmlSyntaxError) errors.first()).toThrowable();
     }
 
@@ -178,6 +177,7 @@ public class XmlSchema extends RubyObject
   private static IRubyObject
   getSchema(ThreadContext context, RubyClass klazz, Source source, IRubyObject parseOptions)
   {
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
     String moduleName = klazz.getName();
     if ("Nokogiri::XML::Schema".equals(moduleName)) {
       return XmlSchema.createSchemaInstance(context, klazz, source, parseOptions);
@@ -206,9 +206,11 @@ public class XmlSchema extends RubyObject
       XmlDocument xmlDocument = ctx.parse(context, getNokogiriClass(runtime, "Nokogiri::XML::Document"), context.nil);
       return validate_document_or_file(context, xmlDocument);
     } catch (Exception ex) {
-      RubyArray errors = (RubyArray)context.runtime.newEmptyArray();
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
+      RubyArray<?> errors = context.runtime.newEmptyArray();
       XmlSyntaxError xmlSyntaxError = XmlSyntaxError.createXMLSyntaxError(context.runtime);
       xmlSyntaxError.setException(ex);
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       errors.append(xmlSyntaxError);
       return errors;
     }
@@ -217,7 +219,8 @@ public class XmlSchema extends RubyObject
   IRubyObject
   validate_document_or_file(ThreadContext context, XmlDocument xmlDocument)
   {
-    RubyArray errors = context.runtime.newEmptyArray();
+    // TODO: switch to common undeprecated API when 9.4 adds 10 methods
+    RubyArray<?> errors = context.runtime.newEmptyArray();
     ErrorHandler errorHandler = new SchemaErrorHandler(context.runtime, errors);
     setErrorHandler(errorHandler);
 
@@ -226,6 +229,7 @@ public class XmlSchema extends RubyObject
     } catch (SAXException ex) {
       XmlSyntaxError xmlSyntaxError = XmlSyntaxError.createXMLSyntaxError(context.runtime);
       xmlSyntaxError.setException(ex);
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       errors.append(xmlSyntaxError);
     } catch (IOException ex) {
       throw context.runtime.newIOError(ex.getMessage());
@@ -291,7 +295,7 @@ public class XmlSchema extends RubyObject
         }
         try {
           this.errorHandler.warning(new SAXParseException(String.format("Attempt to load network entity '%s'", systemId), null));
-        } catch (SAXException ex) {
+        } catch (SAXException ignored) {
         }
       } else {
         String adjusted = adjustSystemIdIfNecessary(currentDir, scriptFileName, baseURI, systemId);
@@ -303,7 +307,7 @@ public class XmlSchema extends RubyObject
     }
   }
 
-  private class SchemaLSInput implements LSInput
+  private static class SchemaLSInput implements LSInput
   {
     protected String fPublicId;
     protected String fSystemId;

--- a/ext/java/nokogiri/XmlSyntaxError.java
+++ b/ext/java/nokogiri/XmlSyntaxError.java
@@ -91,6 +91,8 @@ public class XmlSyntaxError extends RubyException
     return xmlSyntaxError;
   }
 
+  // unused
+  @Deprecated
   public static XmlSyntaxError
   createFatalError(Ruby runtime, SAXParseException e)
   {

--- a/ext/java/nokogiri/XmlText.java
+++ b/ext/java/nokogiri/XmlText.java
@@ -47,6 +47,7 @@ public class XmlText extends XmlNode
   init(ThreadContext context, IRubyObject[] args)
   {
     if (args.length < 2) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw context.runtime.newArgumentError(args.length, 2);
     }
 
@@ -55,6 +56,7 @@ public class XmlText extends XmlNode
 
     if (!(rbDocument instanceof XmlNode)) {
       String msg = "expected second parameter to be a Nokogiri::XML::Document, received " + rbDocument.getMetaClass();
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
       throw context.runtime.newTypeError(msg);
     }
     if (!(rbDocument instanceof XmlDocument)) {

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -17,7 +17,6 @@ import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.SafePropertyAccessor;
@@ -121,7 +120,6 @@ public class XmlXpathContext extends RubyObject
 
       while (xpathFunctionCalls.find()) {
         namespacedQuery.append(query.subSequence(jchar, xpathFunctionCalls.start()));
-        jchar = xpathFunctionCalls.start();
 
         if (methodNames.contains(xpathFunctionCalls.group())) {
           namespacedQuery.append(NokogiriNamespaceContext.NOKOGIRI_PREFIX);
@@ -198,7 +196,7 @@ public class XmlXpathContext extends RubyObject
       return tryGetNodeSet(context, expr, fnResolver);
     } catch (TransformerException | RuntimeException ex) {
       throw XmlSyntaxError.createXMLXPathSyntaxError(context.runtime,
-          (expr + ": " + ex.toString()),
+          (expr + ": " + ex),
           ex).toThrowable();
     }
   }

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -741,7 +741,7 @@ public class NokogiriHelpers
     if (ruby_encoding == null) { return str; }
     Charset encoding = Charset.forName(ruby_encoding);
     if (Charset.forName(parsed_encoding).compareTo(encoding) == 0) { return str; }
-    if (str.isEmpty()) { return str; } // no need to convert
+    if (str.length() == 0) { return str; } // no need to convert
     return NokogiriHelpers.nkf(context, encoding, str);
   }
 

--- a/ext/java/nokogiri/internals/NokogiriHelpers.java
+++ b/ext/java/nokogiri/internals/NokogiriHelpers.java
@@ -40,6 +40,8 @@ import nokogiri.XmlProcessingInstruction;
 import nokogiri.XmlText;
 import nokogiri.XmlXpathContext;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * A class for various utility methods.
  *
@@ -59,6 +61,8 @@ public class NokogiriHelpers
     return (XmlNode) node.getUserData(CACHED_NODE);
   }
 
+  // unused
+  @Deprecated
   public static void
   clearCachedNode(Node node)
   {
@@ -221,7 +225,7 @@ public class NokogiriHelpers
   public static IRubyObject
   nonEmptyStringOrNil(Ruby runtime, String s)
   {
-    if (s == null || s.length() == 0) { return runtime.getNil(); }
+    if (s == null || s.isEmpty()) { return runtime.getNil(); }
     return RubyString.newString(runtime, s);
   }
 
@@ -287,7 +291,7 @@ public class NokogiriHelpers
 
     Node cur, tmp, next;
 
-    String buffer = "";
+    StringBuilder buffer = new StringBuilder();
 
     cur = node;
 
@@ -295,10 +299,10 @@ public class NokogiriHelpers
       String name = "";
       String sep = "?";
       int occur = 0;
-      boolean generic = false;
+      boolean generic;
 
       if (cur.getNodeType() == Node.DOCUMENT_NODE) {
-        if (buffer.startsWith("/")) { break; }
+        if (buffer.toString().startsWith("/")) { break; }
 
         sep = "/";
         next = null;
@@ -471,18 +475,20 @@ public class NokogiriHelpers
       }
 
       if (occur == 0) {
-        buffer = sep + name + buffer;
+        buffer.insert(0, sep + name);
       } else {
-        buffer = sep + name + "[" + occur + "]" + buffer;
+        buffer.insert(0, sep + name + "[" + occur + "]");
       }
 
       cur = next;
 
     } while (cur != null);
 
-    return buffer;
+    return buffer.toString();
   }
 
+  // unused
+  @Deprecated
   static boolean
   compareTwoNodes(Node m, Node n)
   {
@@ -494,7 +500,7 @@ public class NokogiriHelpers
   nodesAreEqual(Object a, Object b)
   {
     return (((a == null) && (b == null)) ||
-            ((a != null) && (b != null) && (b.equals(a))));
+            ((b != null) && (b.equals(a))));
   }
 
   private static boolean
@@ -505,7 +511,7 @@ public class NokogiriHelpers
 
   private static final Pattern encoded_pattern = Pattern.compile("&amp;|&gt;|&lt;|&#13;");
   private static final String[] encoded = {"&amp;", "&gt;", "&lt;", "&#13;"};
-  private static final Pattern decoded_pattern = Pattern.compile("&|>|<|\r");
+  private static final Pattern decoded_pattern = Pattern.compile("[&><\r]");
   private static final String[] decoded = {"&", ">", "<", "\r"};
 
   private static StringBuffer
@@ -555,6 +561,8 @@ public class NokogiriHelpers
     return (nodeName.startsWith("xmlns"));
   }
 
+  // unused
+  @Deprecated
   public static boolean
   isNonDefaultNamespace(Node node)
   {
@@ -591,6 +599,8 @@ public class NokogiriHelpers
     return str.isEmpty() || isBlank((CharSequence) str);
   }
 
+  // unused
+  @Deprecated
   public static boolean
   isNullOrEmpty(String str)
   {
@@ -649,8 +659,9 @@ public class NokogiriHelpers
   nodeArrayToRubyArray(Ruby ruby, Node[] nodes)
   {
     RubyArray<?> n = RubyArray.newArray(ruby, nodes.length);
-    for (int i = 0; i < nodes.length; i++) {
-      n.append(NokogiriHelpers.getCachedNodeOrCreate(ruby, nodes[i]));
+    for (Node node : nodes) {
+      // TODO: switch to common undeprecated API when 9.4 adds 10 methods
+      n.append(NokogiriHelpers.getCachedNodeOrCreate(ruby, node));
     }
     return n;
   }
@@ -690,7 +701,7 @@ public class NokogiriHelpers
   private static String
   resolveSystemId(String baseName, String systemId)
   {
-    if (baseName == null || baseName.length() < 1) { return null; }
+    if (baseName == null || baseName.isEmpty()) { return null; }
     String parentName;
     baseName = baseName.replace("%20", " ");
     File base = new File(baseName);
@@ -703,15 +714,13 @@ public class NokogiriHelpers
     return null;
   }
 
-  private static final Charset UTF8 = Charset.forName("UTF-8");
-
   public static boolean
   isUTF8(String encoding)
   {
     if (encoding == null) { return true; } // no need to convert encoding
 
     if ("UTF-8".equals(encoding)) { return true; }
-    return UTF8.aliases().contains(encoding);
+    return UTF_8.aliases().contains(encoding);
   }
 
   public static ByteBuffer
@@ -720,6 +729,8 @@ public class NokogiriHelpers
     return output_charset.encode(CharBuffer.wrap(input_string)); // does replace implicitly on un-mappable characters
   }
 
+  // unused
+  @Deprecated
   public static CharSequence
   convertEncodingByNKFIfNecessary(ThreadContext context, XmlDocument doc, CharSequence str)
   {
@@ -730,7 +741,7 @@ public class NokogiriHelpers
     if (ruby_encoding == null) { return str; }
     Charset encoding = Charset.forName(ruby_encoding);
     if (Charset.forName(parsed_encoding).compareTo(encoding) == 0) { return str; }
-    if (str.length() == 0) { return str; } // no need to convert
+    if (str.isEmpty()) { return str; } // no need to convert
     return NokogiriHelpers.nkf(context, encoding, str);
   }
 
@@ -766,15 +777,8 @@ public class NokogiriHelpers
       RubyString r_str =
         (RubyString)nkf_method.invoke(null, context, null, runtime.newString(opt), runtime.newString(str.toString()));
       return NokogiriHelpers.rubyStringToString(r_str);
-    } catch (SecurityException e) {
-      return str;
-    } catch (NoSuchMethodException e) {
-      return str;
-    } catch (IllegalArgumentException e) {
-      return str;
-    } catch (IllegalAccessException e) {
-      return str;
-    } catch (InvocationTargetException e) {
+    } catch (SecurityException | NoSuchMethodException | IllegalArgumentException | IllegalAccessException |
+             InvocationTargetException e) {
       return str;
     }
   }


### PR DESCRIPTION
This PR will do some cleanup of the JRuby extension.

The first pass will be improvements recommended by IntelliJ plus some TODO comments for deprecated methods in JRuby 10.

Deprecated JRuby calls have replacements in 10 that will soon be backported to JRuby 9.4. These calls should not be updated to use the new API until it has been in the wild in a 9.4 release for at least a year.

Additional passes will update style to match modern JRuby and Java recommendations and include some minor performance improvements.