### PR TITLE
dep: update libxslt to 1.1.43 (main branch)

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -5,9 +5,9 @@ libxml2:
   # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.6.sha256sum
 
 libxslt:
-  version: "1.1.42"
-  sha256: "85ca62cac0d41fc77d3f6033da9df6fd73d20ea2fc18b0a3609ffb4110e1baeb"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.42.sha256sum
+  version: "1.1.43"
+  sha256: "5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.sha256sum
 
 zlib:
   version: "1.3.1"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Forward-port #3467 to the `main` branch.

https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.43
