### PR TITLE
doc: Nokogiri::XML::Node.traverse is recursively called on children first

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -1334,7 +1334,7 @@ module Nokogiri
       end
 
       ####
-      # Yields self and all children to +block+ recursively.
+      # Yields all children to +block+ recursively, then yields self.
       def traverse(&block)
         children.each { |j| j.traverse(&block) }
         yield(self)


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

The documentation of [traverse](https://nokogiri.org/rdoc/Nokogiri/XML/Node.html#method-i-traverse) says "Yields self and all children to block recursively". I thought that means *first yield self, then recurse on children*. But actually it's the other way around: *first recurse on children, then yield self*. This PR changes the RDoc comment to clarify that.

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

not necessary for this PR

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

no

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
