### PR TITLE
feat: Implement Document#parent, which always returns nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 ### Changed
 
 * The constant `Struct::HTMLElementDescription` is no longer defined. (#3432, #3433) @viralpraxis
+* `Document` objects now respond to `#parent`, which will always return `nil`. Previously, the method was `undef`ed from its parent class `Node`. #3466
 
 
 ### Fixed

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -322,6 +322,13 @@ module Nokogiri
         self
       end
 
+      # call-seq: parent => nil
+      #
+      # For a Document, parent always returns +nil+
+      def parent
+        nil
+      end
+
       # :call-seq:
       #   collect_namespaces() → Hash<String(Namespace#prefix) ⇒ String(Namespace#href)>
       #
@@ -430,7 +437,7 @@ module Nokogiri
         DocumentFragment.new(self, tags, root)
       end
 
-      undef_method :swap, :parent, :namespace, :default_namespace=
+      undef_method :swap, :namespace, :default_namespace=
       undef_method :add_namespace_definition, :attributes
       undef_method :namespace_definitions, :line, :add_namespace
 

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -711,9 +711,8 @@ module Nokogiri
 
         def test_document_parent
           xml = Nokogiri::XML(File.read(XML_FILE), XML_FILE)
-          assert_raises(NoMethodError) do
-            xml.parent
-          end
+
+          assert_nil(xml.parent)
         end
 
         def test_document_name


### PR DESCRIPTION

**What problem is this PR intended to solve?**

We've `undef`ed the `parent` method in `Document` since ffbfc734 in 2009. There's no good reason to do so, and restoring the method so it returns `nil` makes the Document object quack more like the Node that it is.

Closes #3466

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

N/A
