### PR TITLE
fix(jruby): Node#attribute in HTML documents

### DIFF
--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -678,7 +678,7 @@ public class XmlNode extends RubyObject
       Node attribute = attributes.item(j);
       String localName = attribute.getLocalName();
       if (localName == null) {
-        continue;
+        localName = attribute.getNodeName();
       }
       if (localName.equals(name)) {
         return getCachedNodeOrCreate(context.runtime, attribute);

--- a/test/html4/test_node.rb
+++ b/test/html4/test_node.rb
@@ -23,7 +23,15 @@ module Nokogiri
 
       def test_attr
         node = @html.at("div.baz")
-        assert_equal(node["class"], node.attr("class"))
+        assert_equal("baz", node["class"])
+        assert_equal("baz", node.attr("class"))
+      end
+
+      def test_attribute
+        # https://github.com/sparklemotion/nokogiri/issues/3487
+        node = @html.at("div.baz")
+        refute_nil(node.attribute("class"))
+        assert_equal("baz", node.attribute("class").value)
       end
 
       def test_get_attribute

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -129,6 +129,23 @@ module Nokogiri
           end
         end
 
+        it "#attr on XML gets attribute from first node" do
+          doc = Nokogiri::XML("<root><child name='ruby' /><child name='python' /></root>")
+          children = doc.css("child")
+
+          refute_nil(children.attr("name"))
+          assert_equal(children.first.attribute("name"), children.attr("name"))
+        end
+
+        it "#attr on HTML gets attribute from first node" do
+          # https://github.com/sparklemotion/nokogiri/issues/3487
+          doc = Nokogiri::HTML("<root><child name='ruby' /><child name='python' /></root>")
+          children = doc.css("child")
+
+          refute_nil(children.attr("name"))
+          assert_equal(children.first.attribute("name"), children.attr("name"))
+        end
+
         it "#attribute with no args gets attribute from first node" do
           list.first["foo"] = "bar"
           assert_equal(list.first.attribute("foo"), list.attribute("foo"))


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fix Node#attribute in HTML documents and anything that depends on that, like NodeSet#attr.

Fixes #3487

**Have you included adequate test coverage?**

Yes


**Does this change affect the behavior of either the C or the Java implementations?**

Fixes JRuby to behave like CRuby.
