### PR TITLE
dep(dev): drop Rubocop from JRuby deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,12 @@ group :development do
   gem "simplecov", "0.22.0"
 
   # rubocop
-  gem "standard", "1.47.0"
-  gem "rubocop-minitest", "0.37.1"
-  gem "rubocop-packaging", "0.6.0"
-  gem "rubocop-rake", "0.7.1"
+  unless RUBY_PLATFORM == "java"
+    gem "standard", "1.47.0"
+    gem "rubocop-minitest", "0.37.1"
+    gem "rubocop-packaging", "0.6.0"
+    gem "rubocop-rake", "0.7.1"
+  end
 end
 
 # If Psych doesn't build, you can disable this group locally by running


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Drop Rubocop from JRuby deps, because prism won't build on the installation VMs without installing more packages, which I don't want to to do.

e.g. https://github.com/sparklemotion/nokogiri/actions/runs/14078266200/job/39443801657#step:4:236
