### PR TITLE
dep: bump libxml2 to 2.13.7 (v1.18.x backport)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,12 @@ group :development do
   gem "simplecov", "= 0.21.2"
 
   # rubocop
-  gem "standard", "1.43.0"
-  gem "rubocop-minitest", "0.36.0"
-  gem "rubocop-packaging", "0.5.2"
-  gem "rubocop-rake", "0.6.0"
+  unless RUBY_PLATFORM == "java"
+    gem "standard", "1.43.0"
+    gem "rubocop-minitest", "0.36.0"
+    gem "rubocop-packaging", "0.5.2"
+    gem "rubocop-rake", "0.6.0"
+  end
 end
 
 # If Psych doesn't build, you can disable this group locally by running

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.13.6"
-  sha256: "f453480307524968f7a04ec65e64f2a83a825973bcd260a2e7691be82ae70c96"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.6.sha256sum
+  version: "2.13.7"
+  sha256: "14796d24402108e99d8de4e974d539bed62e23af8c4233317274ce073ceff93b"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.7.sha256sum
 
 libxslt:
   version: "1.1.43"


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.7

This is a bugfix release

(cherry picked from commit f51011704f6ef3d55c7fc57ff271c47b96bb38a5)

Backport of #3494