### PR TITLE
[skip ci] New doc about parsing XML

### DIFF
--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -1,19 +1,65 @@
 # Parsing
 
-This page shows how Nokogiri parses an XML string into Nokogiri objects.
+This page shows how \Nokogiri parses an XML string into \Nokogiri objects.
 The string has text consisting of character data and markup.
-For Nokogiri parsing, the string is given either by a String object
-or by an IO object (which is read as a string).
+For a \Nokogiri parsing method, the string is passed
+either as a [String](https://docs.ruby-lang.org/en/master/String.html) object
+or as an [IO](https://docs.ruby-lang.org/en/master/IO.html) object
+from which the string is to be read.
 
-On this page, each example uses method Nokogiri::XML.parse
-to parse a string into a tree of Nokogiri objects.
-The topmost object is a Nokogiri::XML::Document object,
-which we will usually refer to as a document;
-the document may have other objects as children.
+On this page, each example uses either:
+
+- Method Nokogiri::XML::parse (shorthand for Nokogiri::XML::Document.parse)
+  to parse a string into a tree of \Nokogiri objects.
+  The topmost object is a Nokogiri::XML::Document object,
+  which we will usually refer to as a document;
+  the document may have other objects as children.
+
+- Method Nokogiri::XML::DocumentFragment.parse
+  to parse a string into a tree of \Nokogiri objects.
+  The topmost object is a Nokogiri::XML::DocumentFragment object,
+  which we will usually refer to as a fragment;
+  the fragment may have other objects as children.
 
 ## Text
 
+The string to be parsed is text, consisting of character data and markup.
+
+## Character Data
+
+All text that is not markup it character data.
+
 ## Markup
+
+### Comments
+
+\Nokogiri parses a comment into a Nokogiri::XML::Comment object.
+
+A comment may be in the document itself or in a tag:
+
+```
+xml = '<!-- Comment. --><root><!-- Another comment. --></root>'
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document:0xa04c0 {
+  name = "document",
+  children = [
+    #(Comment " Comment. "),
+    #(Element:0xa0560 {
+      name = "root",
+      children = [ #(Comment " Another comment. ")]
+      })]
+  })
+```
+
+### Processing Instructions
+
+### CDATA Sections
+
+### Prolog (XML Declaration)
+
+### Document Type Declaration
 
 ### Tags
 
@@ -110,7 +156,7 @@ doc
   })
 ```
 
-### Tag Attributes
+#### Tag Attributes
 
 Nokogiri parses a tag attribute into a Nokogiri::XML::Attr object.
 
@@ -135,41 +181,18 @@ doc
   })
 ```
 
-### Comments
+#### Element Type Declarations
 
-Nokogiri parses a comment into a Nokogiri::XML::Comment object.
+#### Attribute-List Declarations
 
-A comment may be in a document or in a tag:
-
-```
-xml = '<!-- Comment. --><root><!-- Another comment. --></root>'
-doc = Nokogiri::XML.parse(xml)
-doc
-# =>
-#(Document:0xa04c0 {
-  name = "document",
-  children = [
-    #(Comment " Comment. "),
-    #(Element:0xa0560 {
-      name = "root",
-      children = [ #(Comment " Another comment. ")]
-      })]
-  })
-```
-
-
-### CDATA Sections
-
-### DocTypes
-
-### Processing Instructions
-
-### XML Declarations
-
-### Text Declarations
-
-### Entity References
+#### Element Type Declarations
 
 ### Character References
 
+### Entity References
 
+#### Entity Declarations
+
+#### Text Declaration
+
+## Document Fragments

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -1,4 +1,4 @@
-# Parsing Strings
+# Parsing
 
 This page shows how Nokogiri parses an XML string into Nokogiri objects.
 The string has text consisting of character data and markup.

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -119,7 +119,7 @@ doc
 
 ### Tags
 
-Nokogiri parses a tag into a Nokogiri::XML::Element object.
+\Nokogiri parses a tag into a Nokogiri::XML::Element object.
 
 In this example, a single tag is parsed into a document whose only child
 is the root element parsed from the tag:
@@ -214,7 +214,7 @@ doc
 
 ### Tag Attributes
 
-Nokogiri parses a tag attribute into a Nokogiri::XML::Attr object.
+\Nokogiri parses a tag attribute into a Nokogiri::XML::Attr object:
 
 ```
 xml = '<root foo="0" bar="1"/>'
@@ -267,7 +267,7 @@ doc
 
 ### Attribute-List Declarations
 
-Nokogiri parses an attribute-list declaration into a Nokogiri::XML::AttributeDecl object.
+\Nokogiri parses an attribute-list declaration into a Nokogiri::XML::AttributeDecl object:
 
 ```
 xml = <<DOCTYPE
@@ -293,7 +293,7 @@ doc
 
 ### Conditional Sections
 
-Nokogiri parses a conditional section into a Nokogiri::XML::EntityDecl object.
+\Nokogiri parses a conditional section into a Nokogiri::XML::EntityDecl object:
 
 ```
 xml = <<DOCTYPE
@@ -316,6 +316,8 @@ doc
 
 ### Character References
 
+\Nokogiri parses a character reference (such as <tt>&#9792;</tt>)
+and replaces it with a character such as (<tt>'♀'</tt>):
 
 ```
 xml = <<ELE
@@ -355,6 +357,8 @@ doc
 
 ### Entity References
 
+\Nokogiri parses an entity reference (such as <tt>&lt;</tt>)
+and replaces it with text such as (<tt>'<'</tt>):
 
 ```
 xml = '<root>An entity reference is needed for the less-than character (&lt;).</root>'
@@ -373,6 +377,7 @@ doc
 
 ### Entity Declarations
 
+\Nokogiri parses an entity declaration into a Nokogiri::XML::EntityDecl object:
 
 ```
 xml = <<DTD

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -427,4 +427,78 @@ doc = Nokogiri::XML.parse(xml)
 doc.encoding # => "KOI8-R"
 ```
 
-## Document Fragment
+## Document Fragments
+
+When an XML string has more than one top-level tag,
+\Nokogiri *document parsing* captures only the first top-level tag
+(which becomes the root element)
+and ignores other top-level tags (and their children);
+this may not be the desired result:
+
+```
+xml = <<FRAGMENT
+<top0>
+  <ele0/>
+  <ele1/>
+</top0>
+<top1/>
+<top2/>
+FRAGMENT
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document: {
+  name = "document",
+  children = [
+    #(Element: {
+      name = "top0",
+      children = [
+        #(Text "\n  "),
+        #(Element: { name = "ele0" }),
+        #(Text "\n  "),
+        #(Element: { name = "ele1" }),
+        #(Text "\n")]
+      })]
+  })```
+
+To capture all top-level tags, use \Nokogiri *fragment parsing*
+via method Nokogiri::XML::DocumentFragment.parse:
+
+```
+xml = <<FRAGMENT
+<top0>
+  <ele0/>
+  <ele1/>
+</top0>
+<top1/>
+<top2/>
+FRAGMENT
+fragment = Nokogiri::XML::DocumentFragment.parse(xml)
+fragment
+# =>
+#(DocumentFragment: {
+  name = "#document-fragment",
+  children = [
+    #(Element: {
+      name = "top0",
+      children = [
+        #(Text "\n  "),
+        #(Element: { name = "ele0" }),
+        #(Text "\n  "),
+        #(Element: { name = "ele1" }),
+        #(Text "\n")]
+      }),
+    #(Text "\n"),
+    #(Element: { name = "top1" }),
+    #(Text "\n"),
+    #(Element: { name = "top2" }),
+    #(Text "\n")]
+  })
+```
+
+Note that:
+
+- The returned object is a Nokogiri::XML::DocumentFragment object
+  (not a Nokigiri::XML::Document object).
+- The fragment has three children of class Nokogiri::XML::Element
+  (which in a document is not allowed).

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -218,7 +218,7 @@ doc
   })
 ```
 
-#### Tag Attributes
+### Tag Attributes
 
 Nokogiri parses a tag attribute into a Nokogiri::XML::Attr object.
 
@@ -301,12 +301,35 @@ doc
 
 ### Conditional Sections
 
+```
+xml = <<DOCTYPE
+<!DOCTYPE note [
+<!ENTITY % draft 'INCLUDE' >
+]>
+DOCTYPE
+# => "<!DOCTYPE note [\n<!ENTITY % draft 'INCLUDE' >\n]>\n"
+doc = Nokogiri::XML.parse(xml)
+# =>
+#(Document:0x4f8d0 {
+...
+doc
+# =>
+#(Document:0x4f8d0 {
+  name = "document",
+  children = [
+    #(DTD:0x4f948 {
+      name = "note",
+      children = [ #(EntityDecl:0x4f9c0 { "<!ENTITY % draft \"INCLUDE\">\n" })]
+      })]
+  })
+```
+
 ### Character References
 
 ### Entity References
 
-#### Entity Declarations
+### Entity Declarations
 
-#### Text Declaration
+### Text Declaration
 
 ## Document Fragments

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -332,7 +332,7 @@ doc
 ### Character References
 
 \Nokogiri parses an [XML character reference](https://www.w3.org/TR/REC-xml/#sec-references)
-(such as <tt>&#9792;</tt>)
+(such as <tt>&amp;9792;</tt>)
 and replaces it with a character such as (<tt>'♀'</tt>):
 
 ```
@@ -374,7 +374,7 @@ doc
 ### Entity References
 
 \Nokogiri parses an [XML entity reference](https://www.w3.org/TR/REC-xml/#sec-references)
-(such as <tt>&lt;</tt>)
+(such as <tt>&amp;lt;</tt>)
 and replaces it with text such as (<tt>'<'</tt>):
 
 ```

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -77,9 +77,51 @@ doc
 
 ### CDATA Sections
 
+\Nokogiri parses a CDATA section into a Nokogiri::XML::CDATA object:
+
+```
+xml = '<root><![CDATA[<greeting>Hello, world!</greeting>]]></root>'
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document:0x8dd8 {
+  name = "document",
+  children = [
+    #(Element:0x8e50 {
+      name = "root",
+      children = [
+        #(CDATA "<greeting>Hello, world!</greeting>")]
+      })]
+  })
+```
+
 ### Prolog (XML Declaration)
 
+\Nokogiri parses an XML declaration into values put onto the parsed document:
+
+```
+xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+doc = Nokogiri::XML.parse(xml)
+doc
+# => #(Document:0x17300 { name = "document" })
+doc.version  # => "1.0"
+doc.encoding # => "UTF-8"
+```
+
 ### Document Type Declaration
+
+\Nokogiri parses a document type declaration into a Nokogiri::XML::DTD object:
+
+```
+xml = '<!DOCTYPE greeting SYSTEM "hello.dtd">'
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document:0x32a38 {
+  name = "document",
+  children = [ #(DTD:0x32ab0 { name = "greeting" })]
+  })
+  ```
 
 ### Tags
 
@@ -201,11 +243,63 @@ doc
   })
 ```
 
-#### Element Type Declarations
+### Element Type Declarations
 
-#### Attribute-List Declarations
+\Nokogiri parses an element type declaration into a Nokogiri::XML::ElementDecl object:
 
-#### Element Type Declarations
+```
+xml = <<DOCTYPE
+<!DOCTYPE note [
+<!ELEMENT note (to,from,heading,body)>
+<!ELEMENT to (#PCDATA)>
+<!ELEMENT from (#PCDATA)>
+<!ELEMENT heading (#PCDATA)>
+<!ELEMENT body (#PCDATA)>
+]>
+DOCTYPE
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document:0x2a330 {
+  name = "document",
+  children = [
+    #(DTD:0x2a3a8 {
+      name = "note",
+      children = [
+        #(ElementDecl:0x2a420 { "<!ELEMENT note (to , from , heading , body)>\n" }),
+        #(ElementDecl:0x2a460 { "<!ELEMENT to (#PCDATA)>\n" }),
+        #(ElementDecl:0x2a4a0 { "<!ELEMENT from (#PCDATA)>\n" }),
+        #(ElementDecl:0x2a4e0 { "<!ELEMENT heading (#PCDATA)>\n" }),
+        #(ElementDecl:0x2a520 { "<!ELEMENT body (#PCDATA)>\n" })]
+      })]
+  })
+  ```
+
+### Attribute-List Declarations
+
+```
+xml = <<DOCTYPE
+<!DOCTYPE note [
+<!ELEMENT payment (#PCDATA)>
+<!ATTLIST payment type CDATA "check">
+]>
+DOCTYPE
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document:0x4a430 {
+  name = "document",
+  children = [
+    #(DTD:0x4a4a8 {
+      name = "note",
+      children = [
+        #(ElementDecl:0x4a520 { "<!ELEMENT payment (#PCDATA)>\n" }),
+        #(AttributeDecl:0x4a560 { "<!ATTLIST payment type CDATA \"check\">\n" })]
+      })]
+  })
+```
+
+### Conditional Sections
 
 ### Character References
 

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -7,6 +7,10 @@ either as a [String](https://docs.ruby-lang.org/en/master/String.html) object
 or as an [IO](https://docs.ruby-lang.org/en/master/IO.html) object
 from which the string is to be read.
 
+Most of the sections below link to a relevant section in the W3C document
+[Extensible Markup Language (XML) 1.0 (Fifth Edition)](https://www.w3.org/TR/REC-xml/).
+
+
 On this page, each example uses either:
 
 - Method Nokogiri::XML::parse (shorthand for Nokogiri::XML::Document.parse)
@@ -23,7 +27,8 @@ On this page, each example uses either:
 
 ## Text
 
-The string to be parsed is text, consisting of character data and markup.
+The string to be parsed is text, consisting of
+[character data and markup](https://www.w3.org/TR/REC-xml/#syntax).
 
 ## Character Data
 
@@ -33,7 +38,8 @@ All text that is not markup it character data.
 
 ### Comments
 
-\Nokogiri parses a comment into a Nokogiri::XML::Comment object.
+\Nokogiri parses an [XML comment](https://www.w3.org/TR/REC-xml/#sec-comments)
+into a Nokogiri::XML::Comment object.
 
 A comment may be in the document itself or in a tag:
 
@@ -55,7 +61,8 @@ doc
 
 ### Processing Instructions
 
-\Nokogiri parses a processing instruction into a Nokogiri::XML::ProcessingInstruction object:
+\Nokogiri parses an [XML processing instruction](https://www.w3.org/TR/REC-xml/#sec-pi)
+into a Nokogiri::XML::ProcessingInstruction object:
 
 ```
 xml = '<?xml-stylesheet type="text/xsl" href="style.xsl"?>'
@@ -73,7 +80,8 @@ doc
 
 ### CDATA Sections
 
-\Nokogiri parses a CDATA section into a Nokogiri::XML::CDATA object:
+\Nokogiri parses an [XML CDATA section](https://www.w3.org/TR/REC-xml/#sec-cdata-sect)
+into a Nokogiri::XML::CDATA object:
 
 ```
 xml = '<root><![CDATA[<greeting>Hello, world!</greeting>]]></root>'
@@ -93,7 +101,8 @@ doc
 
 ### Prolog (XML Declaration)
 
-\Nokogiri parses an XML declaration into values put onto the parsed document:
+\Nokogiri parses an [XML declaration](https://www.w3.org/TR/REC-xml/#sec-prolog-dtd)
+into values put onto the parsed document:
 
 ```
 xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
@@ -104,7 +113,8 @@ doc.encoding # => "UTF-8"
 
 ### Document Type Declaration
 
-\Nokogiri parses a document type declaration into a Nokogiri::XML::DTD object:
+\Nokogiri parses an [XML document type declaration](https://www.w3.org/TR/REC-xml/#sec-prolog-dtd)
+into a Nokogiri::XML::DTD object:
 
 ```
 xml = '<!DOCTYPE greeting SYSTEM "hello.dtd">'
@@ -119,7 +129,8 @@ doc
 
 ### Tags
 
-\Nokogiri parses a tag into a Nokogiri::XML::Element object.
+\Nokogiri parses an [XML tag](https://www.w3.org/TR/REC-xml/#sec-starttags)
+into a Nokogiri::XML::Element object.
 
 In this example, a single tag is parsed into a document whose only child
 is the root element parsed from the tag:
@@ -214,7 +225,8 @@ doc
 
 ### Tag Attributes
 
-\Nokogiri parses a tag attribute into a Nokogiri::XML::Attr object:
+\Nokogiri parses an [XML tag attribute](https://www.w3.org/TR/REC-xml/#NT-Attribute)
+into a Nokogiri::XML::Attr object:
 
 ```
 xml = '<root foo="0" bar="1"/>'
@@ -235,7 +247,8 @@ doc
 
 ### Element Type Declarations
 
-\Nokogiri parses an element type declaration into a Nokogiri::XML::ElementDecl object:
+\Nokogiri parses an [XML element type declaration](https://www.w3.org/TR/REC-xml/#elemdecls)
+into a Nokogiri::XML::ElementDecl object:
 
 ```
 xml = <<DOCTYPE
@@ -267,7 +280,8 @@ doc
 
 ### Attribute-List Declarations
 
-\Nokogiri parses an attribute-list declaration into a Nokogiri::XML::AttributeDecl object:
+\Nokogiri parses an [XML attribute-list declaration](https://www.w3.org/TR/REC-xml/#attdecls)
+into a Nokogiri::XML::AttributeDecl object:
 
 ```
 xml = <<DOCTYPE
@@ -293,7 +307,8 @@ doc
 
 ### Conditional Sections
 
-\Nokogiri parses a conditional section into a Nokogiri::XML::EntityDecl object:
+\Nokogiri parses an [XML conditional section](https://www.w3.org/TR/REC-xml/#sec-condition-sect)
+into a Nokogiri::XML::EntityDecl object:
 
 ```
 xml = <<DOCTYPE
@@ -316,7 +331,8 @@ doc
 
 ### Character References
 
-\Nokogiri parses a character reference (such as <tt>&#9792;</tt>)
+\Nokogiri parses an [XML character reference](https://www.w3.org/TR/REC-xml/#sec-references)
+(such as <tt>&#9792;</tt>)
 and replaces it with a character such as (<tt>'♀'</tt>):
 
 ```
@@ -357,7 +373,8 @@ doc
 
 ### Entity References
 
-\Nokogiri parses an entity reference (such as <tt>&lt;</tt>)
+\Nokogiri parses an [XML entity reference](https://www.w3.org/TR/REC-xml/#sec-references)
+(such as <tt>&lt;</tt>)
 and replaces it with text such as (<tt>'<'</tt>):
 
 ```
@@ -377,7 +394,8 @@ doc
 
 ### Entity Declarations
 
-\Nokogiri parses an entity declaration into a Nokogiri::XML::EntityDecl object:
+\Nokogiri parses an [XML entity declaration](https://www.w3.org/TR/REC-xml/#sec-entity-decl)
+into a Nokogiri::XML::EntityDecl object:
 
 ```
 xml = <<DTD
@@ -398,9 +416,10 @@ doc
   })
 ```
 
-### Text Declarations
+### Text Declaration
 
-\Nokogiri parses a text declaration into a value put onto the parsed document:
+\Nokogiri parses an [XML text declaration](https://www.w3.org/TR/REC-xml/#sec-TextDecl)
+into a value put onto the parsed document:
 
 ```
 xml = '<?xml encoding="KOI8-R"?>'
@@ -408,4 +427,4 @@ doc = Nokogiri::XML.parse(xml)
 doc.encoding # => "KOI8-R"
 ```
 
-## Document Fragments
+## Document Fragment

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -367,30 +367,16 @@ doc
 
 
 ```
-xml = <<XML
-<!DOCTYPE note [
-  <!ENTITY company "Example Corp">
-]>
-<root>&company;</root>
-XML
-# => "<!DOCTYPE note [\n  <!ENTITY company \"Example Corp\">\n]>\n<root>&company;</root>\n"
-
+xml = '<root>An entity reference is needed for the less-than character (&lt;).</root>'
 doc = Nokogiri::XML.parse(xml)
-# =>
-#(Document:0x5d890 {
-...
 doc
 # =>
-#(Document:0x5d890 {
+#(Document:0x78298 {
   name = "document",
   children = [
-    #(DTD:0x5d908 {
-      name = "note",
-      children = [ #(EntityDecl:0x5d980 { "<!ENTITY company \"Example Corp\">\n" })]
-      }),
-    #(Element:0x5d9e0 {
+    #(Element:0x78310 {
       name = "root",
-      children = [ #(EntityReference:0x5da58 { "company" })]
+      children = [ #(Text "An entity reference is needed for the less-than character (<).")]
       })]
   })
 ```
@@ -417,7 +403,14 @@ doc
   })
 ```
 
+### Text Declarations
 
-### Text Declaration
+\Nokogiri parses a text declaration into a value put onto the parsed document:
+
+```
+xml = '<?xml encoding="KOI8-R"?>'
+doc = Nokogiri::XML.parse(xml)
+doc.encoding # => "KOI8-R"
+```
 
 ## Document Fragments

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -326,9 +326,97 @@ doc
 
 ### Character References
 
+
+```
+xml = <<ELE
+<root>
+  <name>
+    <vorname>Marie</vorname>
+    <nachname>M&#252;ller</nachname>
+    <geschlecht>&#9792;</geschlecht>
+  </name>
+</root>
+ELE
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document:0x513f0 {
+  name = "document",
+  children = [
+    #(Element:0x51468 {
+      name = "root",
+      children = [
+        #(Text "\n  "),
+        #(Element:0x51508 {
+          name = "name",
+          children = [
+            #(Text "\n    "),
+            #(Element:0x515a8 { name = "vorname", children = [ #(Text "Marie")] }),
+            #(Text "\n    "),
+            #(Element:0x51690 { name = "nachname", children = [ #(Text "Müller")] }),
+            #(Text "\n    "),
+            #(Element:0x51778 { name = "geschlecht", children = [ #(Text "♀")] }),
+            #(Text "\n  ")]
+          }),
+        #(Text "\n")]
+      })]
+  })
+```
+
 ### Entity References
 
+
+```
+xml = <<XML
+<!DOCTYPE note [
+  <!ENTITY company "Example Corp">
+]>
+<root>&company;</root>
+XML
+# => "<!DOCTYPE note [\n  <!ENTITY company \"Example Corp\">\n]>\n<root>&company;</root>\n"
+
+doc = Nokogiri::XML.parse(xml)
+# =>
+#(Document:0x5d890 {
+...
+doc
+# =>
+#(Document:0x5d890 {
+  name = "document",
+  children = [
+    #(DTD:0x5d908 {
+      name = "note",
+      children = [ #(EntityDecl:0x5d980 { "<!ENTITY company \"Example Corp\">\n" })]
+      }),
+    #(Element:0x5d9e0 {
+      name = "root",
+      children = [ #(EntityReference:0x5da58 { "company" })]
+      })]
+  })
+```
+
 ### Entity Declarations
+
+
+```
+xml = <<DTD
+<!DOCTYPE note [
+  <!ENTITY company "Example Corp">
+]>
+DTD
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document:0x53228 {
+  name = "document",
+  children = [
+    #(DTD:0x532a0 {
+      name = "note",
+      children = [ #(EntityDecl:0x53318 { "<!ENTITY company \"Example Corp\">\n" })]
+      })]
+  })
+```
+
 
 ### Text Declaration
 

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -416,17 +416,6 @@ doc
   })
 ```
 
-### Text Declaration
-
-\Nokogiri parses an [XML text declaration](https://www.w3.org/TR/REC-xml/#sec-TextDecl)
-into a value put onto the parsed document:
-
-```
-xml = '<?xml encoding="KOI8-R"?>'
-doc = Nokogiri::XML.parse(xml)
-doc.encoding # => "KOI8-R"
-```
-
 ## Document Fragments
 
 When an XML string has more than one top-level tag,

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -16,14 +16,18 @@ On this page, each example uses either:
 - Method Nokogiri::XML::parse (shorthand for Nokogiri::XML::Document.parse)
   to parse a string into a tree of \Nokogiri objects.
   The topmost object is a Nokogiri::XML::Document object,
-  which we will usually refer to as a document;
-  the document may have other objects as children.
+  which we will usually refer to as a document.
+
+  A document may be childless (i.e., it may have no immediate child object),
+  or it may have a single immediate child Nokogiri::XML::Element object -- its root.
 
 - Method Nokogiri::XML::DocumentFragment.parse
   to parse a string into a tree of \Nokogiri objects.
   The topmost object is a Nokogiri::XML::DocumentFragment object,
   which we will usually refer to as a fragment;
   the fragment may have other objects as children.
+
+  A document fragment may have multiple immediate child objects of various types.
 
 ## Text
 

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -55,6 +55,26 @@ doc
 
 ### Processing Instructions
 
+\Nokogiri parses a processing instruction into a Nokogiri::XML::ProcessingInstruction object:
+
+```
+xml = '<?xml-stylesheet type="text/xsl" href="style.xsl"?>'
+# => "<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>"
+doc = Nokogiri::XML.parse(xml)
+# =>
+#(Document:0x4da8 {
+...
+doc
+# =>
+#(Document:0x4da8 {
+  name = "document",
+  children = [
+    #(ProcessingInstruction:0x4e20 {
+      name = "xml-stylesheet"
+      })]
+  })
+```
+
 ### CDATA Sections
 
 ### Prolog (XML Declaration)

--- a/doc/xml/parsing.md
+++ b/doc/xml/parsing.md
@@ -42,11 +42,11 @@ xml = '<!-- Comment. --><root><!-- Another comment. --></root>'
 doc = Nokogiri::XML.parse(xml)
 doc
 # =>
-#(Document:0xa04c0 {
+#(Document: {
   name = "document",
   children = [
     #(Comment " Comment. "),
-    #(Element:0xa0560 {
+    #(Element: {
       name = "root",
       children = [ #(Comment " Another comment. ")]
       })]
@@ -59,17 +59,13 @@ doc
 
 ```
 xml = '<?xml-stylesheet type="text/xsl" href="style.xsl"?>'
-# => "<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>"
 doc = Nokogiri::XML.parse(xml)
-# =>
-#(Document:0x4da8 {
-...
 doc
 # =>
-#(Document:0x4da8 {
+#(Document: {
   name = "document",
   children = [
-    #(ProcessingInstruction:0x4e20 {
+    #(ProcessingInstruction: {
       name = "xml-stylesheet"
       })]
   })
@@ -84,10 +80,10 @@ xml = '<root><![CDATA[<greeting>Hello, world!</greeting>]]></root>'
 doc = Nokogiri::XML.parse(xml)
 doc
 # =>
-#(Document:0x8dd8 {
+#(Document: {
   name = "document",
   children = [
-    #(Element:0x8e50 {
+    #(Element: {
       name = "root",
       children = [
         #(CDATA "<greeting>Hello, world!</greeting>")]
@@ -102,8 +98,6 @@ doc
 ```
 xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
 doc = Nokogiri::XML.parse(xml)
-doc
-# => #(Document:0x17300 { name = "document" })
 doc.version  # => "1.0"
 doc.encoding # => "UTF-8"
 ```
@@ -117,9 +111,9 @@ xml = '<!DOCTYPE greeting SYSTEM "hello.dtd">'
 doc = Nokogiri::XML.parse(xml)
 doc
 # =>
-#(Document:0x32a38 {
+#(Document: {
   name = "document",
-  children = [ #(DTD:0x32ab0 { name = "greeting" })]
+  children = [ #(DTD: { name = "greeting" })]
   })
   ```
 
@@ -224,21 +218,17 @@ Nokogiri parses a tag attribute into a Nokogiri::XML::Attr object.
 
 ```
 xml = '<root foo="0" bar="1"/>'
-# => "<root foo=\"0\" bar=\"1\"/>"
 doc = Nokogiri::XML.parse(xml)
-# =>
-#(Document:0xa5d30 {
-...
 doc
 # =>
-#(Document:0xa5d30 {
+#(Document: {
   name = "document",
   children = [
-    #(Element:0xa5da8 {
+    #(Element: {
       name = "root",
       attribute_nodes = [
-        #(Attr:0xa5e20 { name = "foo", value = "0" }),
-        #(Attr:0xa5ec8 { name = "bar", value = "1" })]
+        #(Attr: { name = "foo", value = "0" }),
+        #(Attr: { name = "bar", value = "1" })]
       })]
   })
 ```
@@ -260,22 +250,24 @@ DOCTYPE
 doc = Nokogiri::XML.parse(xml)
 doc
 # =>
-#(Document:0x2a330 {
+#(Document: {
   name = "document",
   children = [
-    #(DTD:0x2a3a8 {
+    #(DTD: {
       name = "note",
       children = [
-        #(ElementDecl:0x2a420 { "<!ELEMENT note (to , from , heading , body)>\n" }),
-        #(ElementDecl:0x2a460 { "<!ELEMENT to (#PCDATA)>\n" }),
-        #(ElementDecl:0x2a4a0 { "<!ELEMENT from (#PCDATA)>\n" }),
-        #(ElementDecl:0x2a4e0 { "<!ELEMENT heading (#PCDATA)>\n" }),
-        #(ElementDecl:0x2a520 { "<!ELEMENT body (#PCDATA)>\n" })]
+        #(ElementDecl: { "<!ELEMENT note (to , from , heading , body)>\n" }),
+        #(ElementDecl: { "<!ELEMENT to (#PCDATA)>\n" }),
+        #(ElementDecl: { "<!ELEMENT from (#PCDATA)>\n" }),
+        #(ElementDecl: { "<!ELEMENT heading (#PCDATA)>\n" }),
+        #(ElementDecl: { "<!ELEMENT body (#PCDATA)>\n" })]
       })]
   })
   ```
 
 ### Attribute-List Declarations
+
+Nokogiri parses an attribute-list declaration into a Nokogiri::XML::AttributeDecl object.
 
 ```
 xml = <<DOCTYPE
@@ -287,19 +279,21 @@ DOCTYPE
 doc = Nokogiri::XML.parse(xml)
 doc
 # =>
-#(Document:0x4a430 {
+#(Document: {
   name = "document",
   children = [
-    #(DTD:0x4a4a8 {
+    #(DTD: {
       name = "note",
       children = [
-        #(ElementDecl:0x4a520 { "<!ELEMENT payment (#PCDATA)>\n" }),
-        #(AttributeDecl:0x4a560 { "<!ATTLIST payment type CDATA \"check\">\n" })]
+        #(ElementDecl: { "<!ELEMENT payment (#PCDATA)>\n" }),
+        #(AttributeDecl: { "<!ATTLIST payment type CDATA \"check\">\n" })]
       })]
   })
 ```
 
 ### Conditional Sections
+
+Nokogiri parses a conditional section into a Nokogiri::XML::EntityDecl object.
 
 ```
 xml = <<DOCTYPE
@@ -307,19 +301,15 @@ xml = <<DOCTYPE
 <!ENTITY % draft 'INCLUDE' >
 ]>
 DOCTYPE
-# => "<!DOCTYPE note [\n<!ENTITY % draft 'INCLUDE' >\n]>\n"
 doc = Nokogiri::XML.parse(xml)
-# =>
-#(Document:0x4f8d0 {
-...
 doc
 # =>
-#(Document:0x4f8d0 {
+#(Document: {
   name = "document",
   children = [
-    #(DTD:0x4f948 {
+    #(DTD: {
       name = "note",
-      children = [ #(EntityDecl:0x4f9c0 { "<!ENTITY % draft \"INCLUDE\">\n" })]
+      children = [ #(EntityDecl: { "<!ENTITY % draft \"INCLUDE\">\n" })]
       })]
   })
 ```
@@ -340,22 +330,22 @@ ELE
 doc = Nokogiri::XML.parse(xml)
 doc
 # =>
-#(Document:0x513f0 {
+#(Document: {
   name = "document",
   children = [
-    #(Element:0x51468 {
+    #(Element: {
       name = "root",
       children = [
         #(Text "\n  "),
-        #(Element:0x51508 {
+        #(Element: {
           name = "name",
           children = [
             #(Text "\n    "),
-            #(Element:0x515a8 { name = "vorname", children = [ #(Text "Marie")] }),
+            #(Element: { name = "vorname", children = [ #(Text "Marie")] }),
             #(Text "\n    "),
-            #(Element:0x51690 { name = "nachname", children = [ #(Text "Müller")] }),
+            #(Element: { name = "nachname", children = [ #(Text "Müller")] }),
             #(Text "\n    "),
-            #(Element:0x51778 { name = "geschlecht", children = [ #(Text "♀")] }),
+            #(Element: { name = "geschlecht", children = [ #(Text "♀")] }),
             #(Text "\n  ")]
           }),
         #(Text "\n")]
@@ -371,10 +361,10 @@ xml = '<root>An entity reference is needed for the less-than character (&lt;).</
 doc = Nokogiri::XML.parse(xml)
 doc
 # =>
-#(Document:0x78298 {
+#(Document: {
   name = "document",
   children = [
-    #(Element:0x78310 {
+    #(Element: {
       name = "root",
       children = [ #(Text "An entity reference is needed for the less-than character (<).")]
       })]
@@ -393,12 +383,12 @@ DTD
 doc = Nokogiri::XML.parse(xml)
 doc
 # =>
-#(Document:0x53228 {
+#(Document: {
   name = "document",
   children = [
-    #(DTD:0x532a0 {
+    #(DTD: {
       name = "note",
-      children = [ #(EntityDecl:0x53318 { "<!ENTITY company \"Example Corp\">\n" })]
+      children = [ #(EntityDecl: { "<!ENTITY company \"Example Corp\">\n" })]
       })]
   })
 ```

--- a/doc/xml/parsing/parsing_strings.md
+++ b/doc/xml/parsing/parsing_strings.md
@@ -111,6 +111,27 @@ doc
 
 ### Comments
 
+Nokogiri parses a comment into a Nokogiri::XML::Comment object.
+
+A comment may be in a document or in a tag:
+
+```
+xml = '<!-- Comment. --><root><!-- Another comment. --></root>'
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document:0xa04c0 {
+  name = "document",
+  children = [
+    #(Comment " Comment. "),
+    #(Element:0xa0560 {
+      name = "root",
+      children = [ #(Comment " Another comment. ")]
+      })]
+  })
+```
+
+
 ### CDATA Sections
 
 ### DocTypes

--- a/doc/xml/parsing/parsing_strings.md
+++ b/doc/xml/parsing/parsing_strings.md
@@ -1,0 +1,128 @@
+# Parsing Strings
+
+This page shows how Nokogiri parses an XML string into Nokogiri objects.
+The string has text consisting of character data and markup.
+For Nokogiri parsing, the string is given either by a String object
+or by an IO object (which is read as a string).
+
+On this page, each example uses method Nokogiri::XML.parse
+to parse a string into a tree of Nokogiri objects.
+The topmost object is a Nokogiri::XML::Document object,
+which we will usually refer to as a document;
+the document may have other objects as children.
+
+## Text
+
+## Markup
+
+### Tags
+
+Nokogiri parses a tag into a Nokogiri::XML::Element object.
+
+In this example, a single tag is parsed into a document whose only child
+is the root element parsed from the tag:
+
+```
+xml = '<root/>'
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document: {
+  name = "document",
+  children = [ #(Element: { name = "root" })]
+  })
+```
+
+A tag may have nested tags:
+
+```
+xml = '<root><foo><goo/><moo/></foo><bar><car/><far/></bar></root>'
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document: {
+  name = "document",
+  children = [
+    #(Element: {
+      name = "root",
+      children = [
+        #(Element: {
+          name = "foo",
+          children = [
+            #(Element: { name = "goo" }),
+            #(Element: { name = "moo" })]
+          }),
+        #(Element: {
+          name = "bar",
+          children = [
+            #(Element: { name = "car" }),
+            #(Element: { name = "far" })]
+          })]
+      })]
+  })
+```
+
+A tag may have nested text:
+
+```
+xml = '<root>One<foo>Two</foo>Three<bar>Four</bar>Five</root>'
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document: {
+  name = "document",
+  children = [
+    #(Element: {
+      name = "root",
+      children = [
+        #(Text "One"),
+        #(Element: {
+          name = "foo",
+          children = [ #(Text "Two")]
+          }),
+        #(Text "Three"),
+        #(Element: {
+          name = "bar",
+          children = [ #(Text "Four")]
+          }),
+        #(Text "Five")]
+      })]
+  })  ```
+
+A tag may have nested markup of other types (such as comments):
+
+```
+xml = '<root><foo/><!-- Comment text. --><bar/></root>'
+doc = Nokogiri::XML.parse(xml)
+doc
+# =>
+#(Document: {
+  name = "document",
+  children = [
+    #(Element: {
+      name = "root",
+      children = [
+        #(Element: { name = "foo" }),
+        #(Comment " Comment text. "),
+        #(Element: { name = "bar" })]
+      })]
+  })
+```
+
+### Comments
+
+### CDATA Sections
+
+### DocTypes
+
+### Processing Instructions
+
+### XML Declarations
+
+### Text Declarations
+
+### Entity References
+
+### Character References
+
+

--- a/doc/xml/parsing/parsing_strings.md
+++ b/doc/xml/parsing/parsing_strings.md
@@ -87,7 +87,8 @@ doc
           }),
         #(Text "Five")]
       })]
-  })  ```
+  })
+```
 
 A tag may have nested markup of other types (such as comments):
 
@@ -105,6 +106,31 @@ doc
         #(Element: { name = "foo" }),
         #(Comment " Comment text. "),
         #(Element: { name = "bar" })]
+      })]
+  })
+```
+
+### Tag Attributes
+
+Nokogiri parses a tag attribute into a Nokogiri::XML::Attr object.
+
+```
+xml = '<root foo="0" bar="1"/>'
+# => "<root foo=\"0\" bar=\"1\"/>"
+doc = Nokogiri::XML.parse(xml)
+# =>
+#(Document:0xa5d30 {
+...
+doc
+# =>
+#(Document:0xa5d30 {
+  name = "document",
+  children = [
+    #(Element:0xa5da8 {
+      name = "root",
+      attribute_nodes = [
+        #(Attr:0xa5e20 { name = "foo", value = "0" }),
+        #(Attr:0xa5ec8 { name = "bar", value = "1" })]
       })]
   })
 ```

--- a/rakelib/rdoc.rake
+++ b/rakelib/rdoc.rake
@@ -5,7 +5,7 @@ begin
 
   def rdoc_nokogiri_common_options(rdoc)
     rdoc.rdoc_files
-      .include("*.md", "lib/**/*.rb", "ext/**/*.c", "doc/*md")
+      .include("*.md", "lib/**/*.rb", "ext/**/*.c", "doc/**/*md")
       .exclude("CHANGELOG.md", "ROADMAP.md", "ext/nokogiri/test_global_handlers.c")
     rdoc.options << "--embed-mixins"
     rdoc.options << "--main=README.md"


### PR DESCRIPTION
This new doc file aims to show how various XML text and markup are parsed into specific Nokogiri::XML::* instances.

This can be linked from the parsing methods and the parsed classes.
