### PR TITLE
[skip ci] Doc for XML::Node#<<

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -336,7 +336,7 @@ module Nokogiri
       #   # Move the node.
       #   dst_parent_node << src_node
       #   # After the move.
-      #  src_parent_node.children.map {|child| child.name }  # => ["BAR"]
+      #   src_parent_node.children.map {|child| child.name } # => ["BAR"]
       #   dst_parent_node.children.map {|child| child.name } # => ["foo", "bar", "FOO"]
       #   src_node.parent.name                               # => "parent"
       #

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -320,7 +320,7 @@ module Nokogiri
       # - +self+, to support method chaining.
       #
       # When +object+ is a Node,
-      # moves it to become the last child of +self+.
+      # moves it to become the last child of +self+:
       #
       #   src_xml = '<src_root><src_parent><src_child/></src_parent></src_root>'
       #   src_doc = Nokogiri::XML::Document.parse(src_xml)
@@ -341,7 +341,7 @@ module Nokogiri
       #   node_to_move.parent.name                           # => "dst_root"
       #
       # When +object+ is a NodeSet,
-      # appends each of its nodes to the children of +self+.
+      # appends each of its nodes to the children of +self+:
       #
       #   src_xml = '<src_root><foo/><bar/></src_root>'
       #   src_doc = Nokogiri::XML::Document.parse(src_xml)
@@ -362,7 +362,7 @@ module Nokogiri
       #
       # When +object+ is a DocumentFragment,
       # creates a NodeSet object from the DocumentFragment;
-      # appends each of its nodes to the children of +self+.
+      # appends each of its nodes to the children of +self+:
       #
       #   src_xml = '<foo/><bar/>'
       #   src_frag = Nokogiri::XML::DocumentFragment.parse(src_xml)
@@ -382,7 +382,7 @@ module Nokogiri
       #
       # When +object+ is a String,
       # creates a NodeSet object from the string;
-      # appends each of its nodes to the children of +self+.
+      # appends each of its nodes to the children of +self+:
       #
       #   src_xml = '<foo/><bar/>'
       #   dst_xml = '<dst_root><baz/></dst_root>'

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -301,15 +301,108 @@ module Nokogiri
         self
       end
 
-      ###
-      # Add +node_or_tags+ as a child of this Node.
+      # :call-seq:
+      #   self << object -> self
       #
-      # +node_or_tags+ can be a Nokogiri::XML::Node, a ::DocumentFragment, a ::NodeSet, or a String
-      # containing markup.
+      # Appends specified Nodes to the children of +self+;
+      # each appended Node has +self+ as its #parent value,
+      # and <tt>self.document</tt> as its #document value.
       #
-      # Returns +self+, to support chaining of calls (e.g., root << child1 << child2)
+      # [Arguments]
       #
-      # Also see related method +add_child+.
+      # - +object+ (Node | NodeSet | DocumentFragment | String):
+      #   Specifies the Node objects to be appended;
+      #   the Nodes may be in the same Document or DocumentFragment as +self+,
+      #   or in a different one.
+      #
+      # [Returns]
+      #
+      # - +self+, to support method chaining.
+      #
+      # When +object+ is a Node,
+      # moves it to become the last child of +self+;
+      # returns +object+:
+      #
+      #   src_xml = '<src_root><src_parent><src_child/></src_parent></src_root>'
+      #   src_doc = Nokogiri::XML::Document.parse(src_xml)
+      #   src_parent_node = src_doc.at_xpath('//src_parent')
+      #   dst_xml = '<dst_root><dst_parent><dst_child/></dst_parent></dst_root>'
+      #   dst_doc = Nokogiri::XML::Document.parse(dst_xml)
+      #   dst_parent_node = dst_doc.root
+      #   node_to_move = src_doc.at_xpath('//src_child')
+      #   # Before.
+      #   src_parent_node.children.map {|child| child.name } # => ["src_child"]
+      #   dst_parent_node.children.map {|child| child.name } # => ["dst_parent"]
+      #   node_to_move.parent.name                           # => "src_parent"
+      #   # Move the node.
+      #   dst_parent_node << node_to_move
+      #   # After.
+      #   src_parent_node.children.map {|child| child.name } # => []
+      #   dst_parent_node.children.map {|child| child.name } # => ["dst_parent", "src_child"]
+      #   node_to_move.parent.name                           # => "dst_root"
+      #
+      # When +object+ is a NodeSet,
+      # appends each of its nodes to the children of +self+;
+      # returns +object+:
+      #
+      #   src_xml = '<src_root><foo/><bar/></src_root>'
+      #   src_doc = Nokogiri::XML::Document.parse(src_xml)
+      #   nodeset_to_move = src_doc.root.children
+      #   nodeset_to_move.class                          # => Nokogiri::XML::NodeSet
+      #   dst_doc = Nokogiri::XML::Document.parse('<dst_root><baz/></dst_root>')
+      #   dst_node = dst_doc.root
+      #   # Before.
+      #   nodeset_to_move.map {|node| node.name }        # => ["foo", "bar"]
+      #   nodeset_to_move.map {|node| node.parent.name } # => ["src_root", "src_root"]
+      #   dst_node.children.map {|child| child.name }    # => ["baz"]
+      #   # Move the nodeset.
+      #   dst_node << nodeset_to_move
+      #   # After.
+      #   nodeset_to_move.map {|node| node.name }        # => ["foo", "bar"]
+      #   nodeset_to_move.map {|node| node.parent.name } # => ["dst_root", "dst_root"]
+      #   dst_node.children.map {|child| child.name }    # => ["baz", "foo", "bar"]
+      #
+      # When +object+ is a DocumentFragment,
+      # creates a NodeSet object from the DocumentFragment;
+      # appends each of its nodes to the children of +self+;
+      # returns the NodeSet:
+      #
+      #   src_xml = '<foo/><bar/>'
+      #   src_frag = Nokogiri::XML::DocumentFragment.parse(src_xml)
+      #   dst_xml = '<dst_root><baz/></dst_root>'
+      #   dst_doc = Nokogiri::XML::Document.parse(dst_xml)
+      #   dst_node = dst_doc.root
+      #   # Before.
+      #   src_frag.children.map {|child| child.name }        # => ["foo", "bar"]
+      #   src_frag.children.map {|child| child.parent.name } # => ["#document-fragment", "#document-fragment"]
+      #   dst_node.children.map {|child| child.name }        # => ["baz"]
+      #   # Move the fragment.
+      #   dst_node << src_frag
+      #   # After.
+      #   src_frag.children.map {|child| child.name }        # => []
+      #   dst_node.children.map {|child| child.name }        # => ["baz", "foo", "bar"]
+      #   dst_node.children.map {|child| child.parent.name } # => ["dst_root", "dst_root", "dst_root"]
+      #
+      # When +object+ is a String,
+      # creates a NodeSet object from the string;
+      # appends each of its nodes to the children of +self+;
+      # returns the NodeSet:
+      #
+      #   src_xml = '<foo/><bar/>'
+      #   dst_xml = '<dst_root><baz/></dst_root>'
+      #   dst_doc = Nokogiri::XML::Document.parse(dst_xml)
+      #   dst_node = dst_doc.root
+      #   # Before.
+      #   dst_node.children.map {|child| child.name }        # => ["baz"]
+      #   dst_node.children.map {|child| child.parent.name } # => ["dst_root"]
+      #   # Add the NodeSet created from src_xml.
+      #   dst_node << src_xml
+      #   # After.
+      #   dst_node.children.map {|child| child.name }        # => ["baz", "foo", "bar"]
+      #   dst_node.children.map {|child| child.parent.name } # => ["dst_root", "dst_root", "dst_root"]
+      #
+      # Related: #add_child, #after, #before, #children=, #prepend_child.
+      #
       def <<(node_or_tags)
         add_child(node_or_tags)
         self

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -320,8 +320,7 @@ module Nokogiri
       # - +self+, to support method chaining.
       #
       # When +object+ is a Node,
-      # moves it to become the last child of +self+;
-      # returns +object+:
+      # moves it to become the last child of +self+.
       #
       #   src_xml = '<src_root><src_parent><src_child/></src_parent></src_root>'
       #   src_doc = Nokogiri::XML::Document.parse(src_xml)
@@ -342,8 +341,7 @@ module Nokogiri
       #   node_to_move.parent.name                           # => "dst_root"
       #
       # When +object+ is a NodeSet,
-      # appends each of its nodes to the children of +self+;
-      # returns +object+:
+      # appends each of its nodes to the children of +self+.
       #
       #   src_xml = '<src_root><foo/><bar/></src_root>'
       #   src_doc = Nokogiri::XML::Document.parse(src_xml)
@@ -364,8 +362,7 @@ module Nokogiri
       #
       # When +object+ is a DocumentFragment,
       # creates a NodeSet object from the DocumentFragment;
-      # appends each of its nodes to the children of +self+;
-      # returns the NodeSet:
+      # appends each of its nodes to the children of +self+.
       #
       #   src_xml = '<foo/><bar/>'
       #   src_frag = Nokogiri::XML::DocumentFragment.parse(src_xml)
@@ -385,8 +382,7 @@ module Nokogiri
       #
       # When +object+ is a String,
       # creates a NodeSet object from the string;
-      # appends each of its nodes to the children of +self+;
-      # returns the NodeSet:
+      # appends each of its nodes to the children of +self+.
       #
       #   src_xml = '<foo/><bar/>'
       #   dst_xml = '<dst_root><baz/></dst_root>'


### PR DESCRIPTION
Is the `'|'` notation in `Arguments` correct here?  If so, I'll change `#add_child` in a separate PR.