### PR TITLE
dep: libxml2 to v2.13.8

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.13.7"
-  sha256: "14796d24402108e99d8de4e974d539bed62e23af8c4233317274ce073ceff93b"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.7.sha256sum
+  version: "2.13.8"
+  sha256: "277294cb33119ab71b2bc81f2f445e9bc9435b893ad15bb2cd2b0e859a0ee84a"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.8.sha256sum
 
 libxslt:
   version: "1.1.43"


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Update libxml2 to v2.13.8

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.8

Note that the release notes reference:

- [CVE-2025-32415] schemas: Fix heap buffer overflow in
xmlSchemaIDCFillNodeTables
- [CVE-2025-32414] python: Read at most len/4 characters. (Maks Verver)

so this will need a security release.