### PR TITLE
dep: libxml2 to v2.13.8 (branch `main`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] Update to rake-compiler-dock v1.9.1 for building precompiled native gems. (#3404, #3418) @flavorjones
 
 
+## v1.18.8 / 2025-04-21
+
+### Security
+
+* [CRuby] Vendored libxml2 is updated to [v2.13.8](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.8) to address CVE-2025-32414 and CVE-2025-32415. See [GHSA-5w6v-399v-w3cc](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5w6v-399v-w3cc) for more information.
+
+
 ## v1.18.7 / 2025-03-31
 
 ### Dependencies

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.13.7"
-  sha256: "14796d24402108e99d8de4e974d539bed62e23af8c4233317274ce073ceff93b"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.7.sha256sum
+  version: "2.13.8"
+  sha256: "277294cb33119ab71b2bc81f2f445e9bc9435b893ad15bb2cd2b0e859a0ee84a"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.8.sha256sum
 
 libxslt:
   version: "1.1.43"


### PR DESCRIPTION
**What problem is this PR intended to solve?**

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.8

(cherry picked from commit 6457fe639359edda9f8817994bc4935abae3e81e and 9187f4af)

Forward port of #3509 to `main`