### PR TITLE
style(rubocop): SpaceInsideHashLiteralBraces, RedundantParentheses

### DIFF
--- a/lib/nokogiri/html4/encoding_reader.rb
+++ b/lib/nokogiri/html4/encoding_reader.rb
@@ -108,7 +108,7 @@ module Nokogiri
 
         ret = @firstchunk.slice!(0, len)
         if (len -= ret.length) > 0
-          (rest = @io.read(len)) && ret << (rest)
+          (rest = @io.read(len)) && ret << rest
         end
         if ret.empty?
           nil

--- a/test/html4/sax/test_push_parser.rb
+++ b/test/html4/sax/test_push_parser.rb
@@ -7,7 +7,7 @@ describe Nokogiri::HTML4::SAX::PushParser do
   let(:parser) { Nokogiri::HTML4::SAX::PushParser.new(Nokogiri::SAX::TestCase::Doc.new) }
 
   it :test_end_document_called do
-    parser << (<<~HTML)
+    parser << <<~HTML
       <p id="asdfasdf">
         <!-- This is a comment -->
         Paragraph 1
@@ -19,7 +19,7 @@ describe Nokogiri::HTML4::SAX::PushParser do
   end
 
   it :test_start_element do
-    parser << (<<~HTML)
+    parser << <<~HTML
       <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
       <html><head><body><p id="asdfasdf">
     HTML
@@ -29,7 +29,7 @@ describe Nokogiri::HTML4::SAX::PushParser do
       parser.document.start_elements,
     )
 
-    parser << (<<~HTML)
+    parser << <<~HTML
       <!-- This is a comment -->
       Paragraph 1
       </p></body></html>
@@ -39,11 +39,11 @@ describe Nokogiri::HTML4::SAX::PushParser do
   end
 
   it :test_chevron_partial_html do
-    parser << (<<~HTML)
+    parser << <<~HTML
       <p id="asdfasdf">
     HTML
 
-    parser << (<<-HTML)
+    parser << <<~HTML
         <!-- This is a comment -->
         Paragraph 1
       </p>
@@ -53,7 +53,7 @@ describe Nokogiri::HTML4::SAX::PushParser do
   end
 
   it :test_chevron do
-    parser << (<<~HTML)
+    parser << <<~HTML
       <p id="asdfasdf">
         <!-- This is a comment -->
         Paragraph 1

--- a/test/html4/test_comments.rb
+++ b/test/html4/test_comments.rb
@@ -250,7 +250,7 @@ module Nokogiri
                 {
                   name: "div", children: [
                     { name: "comment", content: "[if foo]" },
-                    { name: "div", attributes: [{name: "id", value: "do-i-exist"}] },
+                    { name: "div", attributes: [{ name: "id", value: "do-i-exist" }] },
                     { name: "comment", content: "[endif]" },
                   ]
                 }

--- a/test/html4/test_document_fragment.rb
+++ b/test/html4/test_document_fragment.rb
@@ -193,9 +193,9 @@ module Nokogiri
             assert_pattern do
               fragment => [
                 { name: "div", attributes: [
-                    { name: "<", value: ""},
-                    { name: "div", value: ""},
-                  ]}
+                    { name: "<", value: "" },
+                    { name: "div", value: "" },
+                  ] }
               ]
             end
           else

--- a/test/test_pattern_matching.rb
+++ b/test/test_pattern_matching.rb
@@ -258,14 +258,14 @@ describe "experimental pattern matching" do
 
         it "finds node contents" do
           assert_pattern do
-            doc => { root: { children: [*, { children: [*, {name: "grandchild1", content: }, *] }, *] } }
+            doc => { root: { children: [*, { children: [*, { name: "grandchild1", content: }, *] }, *] } }
             assert_equal("hello & goodbye", content)
           end
         end
 
         it "finds node contents by attribute" do
           assert_pattern do
-            doc => { root: { children: [*, { children: [*, {attributes: [*, {name: "size", value: "small"}, *], content: }, *] }, *] } }
+            doc => { root: { children: [*, { children: [*, { attributes: [*, { name: "size", value: "small" }, *], content: }, *] }, *] } }
             assert_equal("hello & goodbye", content)
           end
         end
@@ -274,13 +274,13 @@ describe "experimental pattern matching" do
       describe "Fragment" do
         it "finds nodes" do
           assert_pattern do
-            frag => [{name: "child1"}, {name: "child2"}, {name: "child3"}, {content: "\n"}]
+            frag => [{ name: "child1" }, { name: "child2" }, { name: "child3" }, { content: "\n" }]
           end
         end
 
         it "finds attributes" do
           assert_pattern do
-            frag => [*, {name: "child2", attributes: }, *]
+            frag => [*, { name: "child2", attributes: }, *]
             assert_equal("foo", attributes.first.name)
           end
         end
@@ -289,7 +289,7 @@ describe "experimental pattern matching" do
       describe "Node" do
         it "finds nodes" do
           assert_pattern do
-            doc.root => { elements: [{name: "child1"}, {name: "child2"}, {name: "child3"}] }
+            doc.root => { elements: [{ name: "child1" }, { name: "child2" }, { name: "child3" }] }
           end
         end
       end

--- a/test/xml/node/test_save_options.rb
+++ b/test/xml/node/test_save_options.rb
@@ -19,9 +19,9 @@ module Nokogiri
 
         def test_default_xml_save_options
           if Nokogiri.jruby?
-            assert_equal(0, (SaveOptions::DEFAULT_XML & SaveOptions::FORMAT))
+            assert_equal(0, SaveOptions::DEFAULT_XML & SaveOptions::FORMAT)
           else
-            assert_equal(SaveOptions::FORMAT, (SaveOptions::DEFAULT_XML & SaveOptions::FORMAT))
+            assert_equal(SaveOptions::FORMAT, SaveOptions::DEFAULT_XML & SaveOptions::FORMAT)
           end
         end
       end

--- a/test/xml/sax/test_push_parser.rb
+++ b/test/xml/sax/test_push_parser.rb
@@ -88,7 +88,7 @@ describe Nokogiri::XML::SAX::PushParser do
   end
 
   it :test_end_document_called do
-    parser << (<<~XML)
+    parser << <<~XML
       <p id="asdfasdf">
         <!-- This is a comment -->
         Paragraph 1
@@ -100,14 +100,14 @@ describe Nokogiri::XML::SAX::PushParser do
   end
 
   it :test_start_element do
-    parser << (<<~XML)
+    parser << <<~XML
       <p id="asdfasdf">
     XML
 
     assert_equal [["p", [["id", "asdfasdf"]]]],
       parser.document.start_elements
 
-    parser << (<<~XML)
+    parser << <<~XML
         <!-- This is a comment -->
         Paragraph 1
       </p>
@@ -117,14 +117,14 @@ describe Nokogiri::XML::SAX::PushParser do
   end
 
   it :test_start_element_with_namespaces do
-    parser << (<<~XML)
+    parser << <<~XML
       <p xmlns:foo="http://foo.example.com/">
     XML
 
     assert_equal [["p", [["xmlns:foo", "http://foo.example.com/"]]]],
       parser.document.start_elements
 
-    parser << (<<~XML)
+    parser << <<~XML
         <!-- This is a comment -->
         Paragraph 1
       </p>
@@ -134,7 +134,7 @@ describe Nokogiri::XML::SAX::PushParser do
   end
 
   it :test_start_element_ns do
-    parser << (<<~XML)
+    parser << <<~XML
       <stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams' version='1.0' size='large'></stream:stream>
     XML
 
@@ -152,7 +152,7 @@ describe Nokogiri::XML::SAX::PushParser do
   end
 
   it :test_end_element_ns do
-    parser << (<<~XML)
+    parser << <<~XML
       <stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams' version='1.0'></stream:stream>
     XML
 
@@ -162,11 +162,11 @@ describe Nokogiri::XML::SAX::PushParser do
   end
 
   it :test_chevron_partial_xml do
-    parser << (<<~XML)
+    parser << <<~XML
       <p id="asdfasdf">
     XML
 
-    parser << (<<~XML)
+    parser << <<~XML
         <!-- This is a comment -->
         Paragraph 1
       </p>
@@ -176,7 +176,7 @@ describe Nokogiri::XML::SAX::PushParser do
   end
 
   it :test_chevron do
-    parser << (<<~XML)
+    parser << <<~XML
       <p id="asdfasdf">
         <!-- This is a comment -->
         Paragraph 1
@@ -192,7 +192,7 @@ describe Nokogiri::XML::SAX::PushParser do
 
   it :test_recover do
     parser.options |= Nokogiri::XML::ParseOptions::RECOVER
-    parser << (<<~XML)
+    parser << <<~XML
       <p>
         Foo
         <bar>
@@ -248,7 +248,7 @@ describe Nokogiri::XML::SAX::PushParser do
 
   it :test_untouched_entities do
     skip_unless_libxml2("entities are always replaced in pure Java version")
-    parser << (<<~XML)
+    parser << <<~XML
       <p id="asdf&amp;asdf">
         <!-- This is a comment -->
         Paragraph 1 &amp; 2
@@ -261,7 +261,7 @@ describe Nokogiri::XML::SAX::PushParser do
 
   it :test_replaced_entities do
     parser.replace_entities = true
-    parser << (<<~XML)
+    parser << <<~XML
       <p id="asdf&amp;asdf">
         <!-- This is a comment -->
         Paragraph 1 &amp; 2

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -109,7 +109,7 @@ module Nokogiri
             assert_empty(doc.errors)
             assert_pattern do
               nodeset => [
-                { name: "div", attributes: [{name: "<", value: ""}, { name: "div", value: ""}] },
+                { name: "div", attributes: [{ name: "<", value: "" }, { name: "div", value: "" }] },
               ]
             end
           else
@@ -131,7 +131,7 @@ module Nokogiri
             assert_empty(doc.errors)
             assert_pattern do
               nodeset => [
-                { name: "div", attributes: [{name: "<", value: ""}, { name: "div", value: ""}] },
+                { name: "div", attributes: [{ name: "<", value: "" }, { name: "div", value: "" }] },
               ]
             end
           else
@@ -461,7 +461,7 @@ module Nokogiri
 
         def test_spaceship
           nodes = xml.xpath("//employee")
-          assert_equal(-1, (nodes.first <=> nodes.last))
+          assert_equal(-1, nodes.first <=> nodes.last)
           list = [nodes.first, nodes.last].sort
           assert_equal(nodes.first, list.first)
           assert_equal(nodes.last, list.last)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

The update to standard/rubocop requires some changes. Not sure why these weren't caught in the dependabot PR?
