### PR TITLE
gumbo: Make sure to use the char* pointer as the hashmap item

### DIFF
--- a/gumbo-parser/src/string_set.c
+++ b/gumbo-parser/src/string_set.c
@@ -8,12 +8,12 @@
 
 static int
 string_compare(const void *a, const void *b, void *udata) {
-  return strcmp((const char *)a, (const char *)b);
+  return strcmp(*(const char **)a, *(const char **)b);
 }
 
 static uint64_t
 string_hash(const void *item, uint64_t seed0, uint64_t seed1) {
-  const char *str = (const char *)item;
+  const char *str = *(const char **)item;
   return hashmap_xxhash3(str, strlen(str), seed0, seed1);
 }
 
@@ -31,11 +31,11 @@ void gumbo_string_set_free(GumboStringSet *set)
 void
 gumbo_string_set_insert(GumboStringSet *set, const char *str)
 {
-  hashmap_set(set, str);
+  hashmap_set(set, &str);
 }
 
 int
 gumbo_string_set_contains(GumboStringSet *set, const char *str)
 {
-  return hashmap_get(set, str) == NULL ? 0 : 1;
+  return hashmap_get(set, &str) == NULL ? 0 : 1;
 }


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Previously we were passing a character string of variable length, but always copying 8 bytes into the item. It's not really a problem if the length of the string is less than 8, but it's more serious if the length is longer than 8.

Fixes https://github.com/sparklemotion/nokogiri/issues/3500
Fixes https://github.com/sparklemotion/nokogiri/issues/3508


**Have you included adequate test coverage?**

I've added test coverage that will fail under valgrind.


**Does this change affect the behavior of either the C or the Java implementations?**

The issue is only with the C (gumbo) implementation.