### PR TITLE
CI: Remove ruby-3.1 from test matrix on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     outputs:
       # these are usually the same, but are different once we get to ruby release candidates
       setup_ruby: "['3.1', '3.2', '3.3', '3.4']"
-      setup_ruby_win: "['3.1', '3.2', '3.3', '3.4']"
+      setup_ruby_win: "['3.2', '3.3', '3.4']"
       image_tag: "['3.1', '3.2', '3.3', '3.4']"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Ruby-3.1 is not compatible to gcc-15 and patches will not be backported since it's EOL now. Unfortunately MSYS2 is a rolling release with no option for an older gcc. Althought setup-ruby installs an older gcc-14.2 package by default, it fails to install further packages per pacman due to dependencies:

```sh
  $ pacman.exe -Sy --noconfirm --noprogressbar --needed --disable-download-timeout  mingw-w64-ucrt-x86_64-libxml2 mingw-w64-ucrt-x86_64-libxslt
  resolving dependencies...
  looking for conflicting packages...
  error: failed to prepare transaction (could not satisfy dependencies)
  :: installing mingw-w64-ucrt-x86_64-gcc-libs (15.1.0-8) breaks dependency 'mingw-w64-ucrt-x86_64-gcc-libs=14.2.0-3' required by mingw-w64-ucrt-x86_64-gcc
```

**Have you included adequate test coverage?**

No, but I removed some test coverage. 😒

