### PR TITLE
dep: update vendored libxml2 to v2.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ### Dependencies
 
-* [CRuby] Vendored libxml2 is updated to [v2.14.5](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.14.5), from v2.13.8. libxml2 v2.14 includes changes to more closely adhere to the HTML5 parser spec. Notably, the content of `iframe` and `noframes` tags is now treated as raw text, where previously it was parsed as PCDATA.
+* [CRuby] Vendored libxml2 is updated to [v2.14.6](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.14.6), from v2.13.8. libxml2 v2.14 includes changes to more closely adhere to the HTML5 parser spec. Notably, the content of `iframe` and `noframes` tags is now treated as raw text, where previously it was parsed as PCDATA.
 * [CRuby] [Windows and MacOS] Vendored libiconv is updated to [v1.18](https://savannah.gnu.org/news/?id=10703)
 * [CRuby] Update to rake-compiler-dock v1.9.1 for building precompiled native gems. (#3404, #3418) @flavorjones
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,8 +1,8 @@
 ---
 libxml2:
-  version: "2.14.5"
-  sha256: "03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b"
-  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.5.sha256sum
+  version: "2.14.6"
+  sha256: "7ce458a0affeb83f0b55f1f4f9e0e55735dbfc1a9de124ee86fb4a66b597203a"
+  # sha-256 hash provided in https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.6.sha256sum
 
 libxslt:
   version: "1.1.43"


### PR DESCRIPTION

**What problem is this PR intended to solve?**

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.14.6
