### PR TITLE
ci: stop testing Ruby 3.1 windows source builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,8 +326,7 @@ jobs:
         sys: ["enable", "disable"]
         ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_win) }}
         exclude:
-          - sys: "enable"
-            ruby: "3.1" # because Ruby 3.1 devkit is built with a version of GCC too old for modern msys2 2025-08
+          - ruby: "3.1" # because Ruby 3.1 devkit is built with a version of GCC too old for modern msys2 2025-08
     runs-on: windows-2022
     steps:
       - name: configure git crlf
@@ -340,7 +339,7 @@ jobs:
       - uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: "${{matrix.ruby}}"
-          mingw: ${{ matrix.ruby == '3.1' && ' ' || 'libxml2 libxslt' }} # '' is falsey, ' ' is truthy
+          mingw: "libxml2 libxslt"
           bundler-cache: true
           bundler: latest
       - uses: actions/cache@v4
@@ -551,8 +550,7 @@ jobs:
         sys: ["enable", "disable"]
         ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_win) }}
         exclude:
-          - sys: "enable"
-            ruby: "3.1" # because Ruby 3.1 devkit is built with a version of GCC too old for modern msys2 2025-08
+          - ruby: "3.1" # because Ruby 3.1 devkit is built with a version of GCC too old for modern msys2 2025-08
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v5
@@ -561,7 +559,7 @@ jobs:
       - uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: "${{matrix.ruby}}"
-          mingw: ${{ matrix.ruby == '3.1' && ' ' || 'libxml2 libxslt' }} # '' is falsey, ' ' is truthy
+          mingw: "libxml2 libxslt"
       - uses: actions/download-artifact@v5
         with:
           name: generic-gem


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Related to (and partial reversion of) ae334cd2.

Modern msys has diverged too far from Ruby 3.1 DevKit to make it worth my time to continue to support source builds.
