### PR TITLE
fixes dangling-doc-comments warnings

### DIFF
--- a/ext/java/nokogiri/internals/NokogiriBlockingQueueInputStream.java
+++ b/ext/java/nokogiri/internals/NokogiriBlockingQueueInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  *
  */
 package nokogiri.internals;

--- a/ext/java/nokogiri/internals/c14n/AttrCompare.java
+++ b/ext/java/nokogiri/internals/c14n/AttrCompare.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/C14nHelper.java
+++ b/ext/java/nokogiri/internals/c14n/C14nHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/CanonicalizationException.java
+++ b/ext/java/nokogiri/internals/c14n/CanonicalizationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer11.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer11.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer11_OmitComments.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer11_OmitComments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer11_WithComments.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer11_WithComments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer20010315.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer20010315.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer20010315Excl.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer20010315Excl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer20010315ExclOmitComments.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer20010315ExclOmitComments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer20010315ExclWithComments.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer20010315ExclWithComments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer20010315OmitComments.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer20010315OmitComments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Canonicalizer20010315WithComments.java
+++ b/ext/java/nokogiri/internals/c14n/Canonicalizer20010315WithComments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/CanonicalizerBase.java
+++ b/ext/java/nokogiri/internals/c14n/CanonicalizerBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/CanonicalizerPhysical.java
+++ b/ext/java/nokogiri/internals/c14n/CanonicalizerPhysical.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/CanonicalizerSpi.java
+++ b/ext/java/nokogiri/internals/c14n/CanonicalizerSpi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/Constants.java
+++ b/ext/java/nokogiri/internals/c14n/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/ElementProxy.java
+++ b/ext/java/nokogiri/internals/c14n/ElementProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/HelperNodeList.java
+++ b/ext/java/nokogiri/internals/c14n/HelperNodeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/IgnoreAllErrorHandler.java
+++ b/ext/java/nokogiri/internals/c14n/IgnoreAllErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/InclusiveNamespaces.java
+++ b/ext/java/nokogiri/internals/c14n/InclusiveNamespaces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/InvalidCanonicalizerException.java
+++ b/ext/java/nokogiri/internals/c14n/InvalidCanonicalizerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/NameSpaceSymbTable.java
+++ b/ext/java/nokogiri/internals/c14n/NameSpaceSymbTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/NodeFilter.java
+++ b/ext/java/nokogiri/internals/c14n/NodeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/UtfHelper.java
+++ b/ext/java/nokogiri/internals/c14n/UtfHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information

--- a/ext/java/nokogiri/internals/c14n/XMLUtils.java
+++ b/ext/java/nokogiri/internals/c14n/XMLUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
**What problem is this PR intended to solve?**

When Nokogiri is compiled on JRuby by `bundle exec rake compile test` command, it raises a lot of warnings. Those are just warnings, but it's not easy to see what are happening during compilation. Among those warnings, this PR fixes dangling-doc-comments warnings.

**Have you included adequate test coverage?**

No.

**Does this change affect the behavior of either the C or the Java implementations?**

No.
