### PR TITLE
Fix serial warnings

### DIFF
--- a/ext/java/nokogiri/Html4ElementDescription.java
+++ b/ext/java/nokogiri/Html4ElementDescription.java
@@ -37,7 +37,7 @@ public class Html4ElementDescription extends RubyObject
     subElements = Collections.synchronizedMap(_subElements);
   }
 
-  protected HTMLElements.Element element;
+  protected transient HTMLElements.Element element;
 
   public
   Html4ElementDescription(Ruby runtime, RubyClass rubyClass)

--- a/ext/java/nokogiri/Html4SaxPushParser.java
+++ b/ext/java/nokogiri/Html4SaxPushParser.java
@@ -32,13 +32,13 @@ public class Html4SaxPushParser extends RubyObject
   private static final long serialVersionUID = 1L;
 
   ParserContext.Options options;
-  IRubyObject saxParser;
+  transient IRubyObject saxParser;
 
-  NokogiriBlockingQueueInputStream stream;
+  transient NokogiriBlockingQueueInputStream stream;
 
-  private ParserTask parserTask = null;
-  private FutureTask<Html4SaxParserContext> futureTask = null;
-  private ExecutorService executor = null;
+  private transient ParserTask parserTask = null;
+  private transient FutureTask<Html4SaxParserContext> futureTask = null;
+  private transient ExecutorService executor = null;
 
   public
   Html4SaxPushParser(Ruby ruby, RubyClass rubyClass)
@@ -189,7 +189,6 @@ public class Html4SaxPushParser extends RubyObject
 
   static class ParserTask extends XmlSaxPushParser.ParserTask /* <Html4SaxPushParser> */
   {
-
     private
     ParserTask(ThreadContext context, IRubyObject handler, InputStream stream)
     {

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -55,7 +55,7 @@ public class XmlDocument extends XmlNode
 {
   private static final long serialVersionUID = 1L;
 
-  private NokogiriNamespaceCache nsCache;
+  private transient NokogiriNamespaceCache nsCache;
 
   /* UserData keys for storing extra info in the document node. */
   public final static String DTD_RAW_DOCUMENT = "DTD_RAW_DOCUMENT";
@@ -71,8 +71,8 @@ public class XmlDocument extends XmlNode
   static { DOCUMENT.setEncoding(USASCIIEncoding.INSTANCE); }
 
   /** cache variables */
-  protected IRubyObject encoding;
-  protected IRubyObject url;
+  protected transient IRubyObject encoding;
+  protected transient IRubyObject url;
 
   public
   XmlDocument(Ruby runtime, RubyClass klazz)

--- a/ext/java/nokogiri/XmlDtd.java
+++ b/ext/java/nokogiri/XmlDtd.java
@@ -40,7 +40,7 @@ public class XmlDtd extends XmlNode
   private static final long serialVersionUID = 1L;
 
   /** cache of children, Nokogiri::XML::NodeSet */
-  protected IRubyObject children = null;
+  protected transient IRubyObject children = null;
 
   /** cache of name => XmlAttributeDecl */
   protected RubyHash attributes = null;
@@ -60,13 +60,13 @@ public class XmlDtd extends XmlNode
   protected RubyHash contentModels;
 
   /** node name */
-  protected IRubyObject name;
+  protected transient IRubyObject name;
 
   /** public ID (or external ID) */
-  protected IRubyObject pubId;
+  protected transient IRubyObject pubId;
 
   /** system ID */
-  protected IRubyObject sysId;
+  protected transient IRubyObject sysId;
 
   public
   XmlDtd(Ruby ruby, RubyClass rubyClass)

--- a/ext/java/nokogiri/XmlElementContent.java
+++ b/ext/java/nokogiri/XmlElementContent.java
@@ -33,8 +33,8 @@ public class XmlElementContent extends RubyObject
   protected String name;
   protected Type type;
   protected Occur occur;
-  protected IRubyObject left;
-  protected IRubyObject right;
+  protected transient IRubyObject left;
+  protected transient IRubyObject right;
 
   /** values hardcoded from nokogiri/xml/element_content.rb; this
    * makes me uneasy, but it works */

--- a/ext/java/nokogiri/XmlElementDecl.java
+++ b/ext/java/nokogiri/XmlElementDecl.java
@@ -25,7 +25,7 @@ public class XmlElementDecl extends XmlNode
   private static final long serialVersionUID = 1L;
 
   RubyArray<?> attrDecls;
-  IRubyObject contentModel;
+  transient IRubyObject contentModel;
 
   public
   XmlElementDecl(Ruby runtime, RubyClass klazz)

--- a/ext/java/nokogiri/XmlEntityDecl.java
+++ b/ext/java/nokogiri/XmlEntityDecl.java
@@ -29,11 +29,11 @@ public class XmlEntityDecl extends XmlNode
   public static final int EXTERNAL_PARAMETER = 5;
   public static final int INTERNAL_PREDEFINED = 6;
 
-  private IRubyObject entityType;
-  private IRubyObject name;
-  private IRubyObject external_id;
-  private IRubyObject system_id;
-  private IRubyObject content;
+  private transient IRubyObject entityType;
+  private transient IRubyObject name;
+  private transient IRubyObject external_id;
+  private transient IRubyObject system_id;
+  private transient IRubyObject content;
 
   XmlEntityDecl(Ruby runtime, RubyClass klass)
   {

--- a/ext/java/nokogiri/XmlNamespace.java
+++ b/ext/java/nokogiri/XmlNamespace.java
@@ -27,7 +27,7 @@ public class XmlNamespace extends RubyObject
 {
   private static final long serialVersionUID = 1L;
 
-  private Attr attr;
+  private transient Attr attr;
   private transient IRubyObject prefixRuby;
   private transient IRubyObject hrefRuby;
   private String prefix;

--- a/ext/java/nokogiri/XmlNode.java
+++ b/ext/java/nokogiri/XmlNode.java
@@ -55,10 +55,10 @@ public class XmlNode extends RubyObject
   protected static final String TEXT_WRAPPER_NAME = "nokogiri_text_wrapper";
 
   /** The underlying Node object. */
-  protected Node node;
+  protected transient Node node;
 
   /* Cached objects */
-  protected IRubyObject content = null;
+  protected transient IRubyObject content = null;
   private transient XmlDocument doc;
   protected transient RubyString name;
 

--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -30,7 +30,7 @@ public class XmlNodeSet extends RubyObject implements NodeList
 {
   private static final long serialVersionUID = 1L;
 
-  IRubyObject[] nodes;
+  transient IRubyObject[] nodes;
 
   public
   XmlNodeSet(Ruby ruby, RubyClass klazz)

--- a/ext/java/nokogiri/XmlReader.java
+++ b/ext/java/nokogiri/XmlReader.java
@@ -66,10 +66,10 @@ public class XmlReader extends RubyObject
   private static final int XML_TEXTREADER_MODE_CLOSED = 4;
   private static final int XML_TEXTREADER_MODE_READING = 5;
 
-  List<ReaderNode> nodeQueue;
+  transient List<ReaderNode> nodeQueue;
   private int state;
   private int position = 0;
-  private XMLPullParserConfiguration config;
+  private transient XMLPullParserConfiguration config;
   private boolean continueParsing = true;
 
   public

--- a/ext/java/nokogiri/XmlRelaxng.java
+++ b/ext/java/nokogiri/XmlRelaxng.java
@@ -36,7 +36,7 @@ import org.xml.sax.SAXException;
 public class XmlRelaxng extends XmlSchema
 {
   private static final long serialVersionUID = 1L;
-  private Verifier verifier;
+  private transient Verifier verifier;
 
   public
   XmlRelaxng(Ruby ruby, RubyClass klazz)

--- a/ext/java/nokogiri/XmlSaxParserContext.java
+++ b/ext/java/nokogiri/XmlSaxParserContext.java
@@ -41,10 +41,10 @@ public class XmlSaxParserContext extends ParserContext
   protected static final String FEATURE_CONTINUE_AFTER_FATAL_ERROR =
     "http://apache.org/xml/features/continue-after-fatal-error";
 
-  protected AbstractSAXParser parser;
+  protected transient AbstractSAXParser parser;
 
-  protected NokogiriHandler handler;
-  protected NokogiriErrorHandler errorHandler;
+  protected transient NokogiriHandler handler;
+  protected transient NokogiriErrorHandler errorHandler;
   private boolean replaceEntities = false;
   private boolean recovery = false;
 

--- a/ext/java/nokogiri/XmlSaxPushParser.java
+++ b/ext/java/nokogiri/XmlSaxPushParser.java
@@ -32,13 +32,13 @@ public class XmlSaxPushParser extends RubyObject
   private static final long serialVersionUID = 1L;
 
   ParserContext.Options options;
-  IRubyObject saxParser;
+  transient IRubyObject saxParser;
 
-  NokogiriBlockingQueueInputStream stream;
+  transient NokogiriBlockingQueueInputStream stream;
 
-  private ParserTask parserTask = null;
-  private FutureTask<XmlSaxParserContext> futureTask = null;
-  private ExecutorService executor = null;
+  private transient ParserTask parserTask = null;
+  private transient FutureTask<XmlSaxParserContext> futureTask = null;
+  private transient ExecutorService executor = null;
   RaiseException ex = null;
 
   public
@@ -231,8 +231,7 @@ public class XmlSaxPushParser extends RubyObject
 
   static class ParserTask extends ParserContext.ParserTask<XmlSaxParserContext>
   {
-
-    final InputStream stream;
+    transient final InputStream stream;
 
     private
     ParserTask(ThreadContext context, IRubyObject handler, InputStream stream)

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -47,7 +47,7 @@ public class XmlSchema extends RubyObject
 {
   private static final long serialVersionUID = 1L;
 
-  private Validator validator;
+  private transient Validator validator;
 
   public
   XmlSchema(Ruby ruby, RubyClass klazz)

--- a/ext/java/nokogiri/XmlXpathContext.java
+++ b/ext/java/nokogiri/XmlXpathContext.java
@@ -146,7 +146,7 @@ public class XmlXpathContext extends RubyObject
     return this.evaluate(context, expr, context.getRuntime().getNil());
   }
 
-  private final NokogiriNamespaceContext nsContext = NokogiriNamespaceContext.create();
+  private transient final NokogiriNamespaceContext nsContext = NokogiriNamespaceContext.create();
 
   @JRubyMethod
   public IRubyObject

--- a/ext/java/nokogiri/XsltStylesheet.java
+++ b/ext/java/nokogiri/XsltStylesheet.java
@@ -54,9 +54,9 @@ public class XsltStylesheet extends RubyObject
 {
   private static final long serialVersionUID = 1L;
 
-  private TransformerFactory factory = null;
-  private Templates sheet = null;
-  private IRubyObject stylesheet = null;
+  private transient TransformerFactory factory = null;
+  private transient Templates sheet = null;
+  private transient IRubyObject stylesheet = null;
   private boolean htmlish = false;
 
   public

--- a/ext/java/nokogiri/internals/NokogiriNamespaceCache.java
+++ b/ext/java/nokogiri/internals/NokogiriNamespaceCache.java
@@ -21,7 +21,6 @@ import org.w3c.dom.Node;
  */
 public class NokogiriNamespaceCache
 {
-
   private final Map<CacheKey, CacheEntry> cache;  // pair of the index of a given key and entry
   private XmlNamespace defaultNamespace = null;
 

--- a/ext/java/nokogiri/internals/NokogiriXPathVariableResolver.java
+++ b/ext/java/nokogiri/internals/NokogiriXPathVariableResolver.java
@@ -1,5 +1,6 @@
 package nokogiri.internals;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import javax.xml.namespace.QName;
 import javax.xml.xpath.XPathVariableResolver;
@@ -10,8 +11,9 @@ import javax.xml.xpath.XPathVariableResolver;
  * @author Ken Bloom <kbloom@gmail.com>
  * @author Yoko Harada <yokolet@gmail.com>
  */
-public class NokogiriXPathVariableResolver implements XPathVariableResolver
+public class NokogiriXPathVariableResolver implements XPathVariableResolver, Serializable
 {
+  private static final long serialVersionUID = 1L;
 
   private final HashMap<QName, String> variables = new HashMap<QName, String>();
 

--- a/ext/java/nokogiri/internals/ParserContext.java
+++ b/ext/java/nokogiri/internals/ParserContext.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.concurrent.Callable;
 
@@ -30,8 +31,8 @@ public abstract class ParserContext extends RubyObject
 {
   private static final long serialVersionUID = 1L;
 
-  protected InputSource source = null;
-  protected IRubyObject detected_encoding = null;
+  protected transient InputSource source = null;
+  protected transient IRubyObject detected_encoding = null;
   protected int stringDataSize = -1;
   protected String java_encoding;
 
@@ -189,8 +190,10 @@ public abstract class ParserContext extends RubyObject
    * Wrap Nokogiri parser options in a utility class.  This is
    * read-only.
    */
-  public static class Options
+  public static class Options implements Serializable
   {
+    private static final long serialVersionUID = 1L;
+
     protected static final long STRICT = 0;
     protected static final long RECOVER = 1;
     protected static final long NOENT = 2;

--- a/ext/java/nokogiri/internals/XmlDomParserContext.java
+++ b/ext/java/nokogiri/internals/XmlDomParserContext.java
@@ -46,9 +46,9 @@ public class XmlDomParserContext extends ParserContext
   private static final String SECURITY_MANAGER = "http://apache.org/xml/properties/security-manager";
 
   protected ParserContext.Options options;
-  protected DOMParser parser;
-  protected NokogiriErrorHandler errorHandler;
-  protected IRubyObject ruby_encoding;
+  protected transient DOMParser parser;
+  protected transient NokogiriErrorHandler errorHandler;
+  protected transient IRubyObject ruby_encoding;
 
   public
   XmlDomParserContext(Ruby runtime, IRubyObject options)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

This PR fixes all warnings of "warning: [serial] non-transient instance field of a serializable class declared with a non-serializable type", when Nokogiri is compiled on JRuby 9.4.

Fixing strategy is:
- The instance field type is from outside of Nokogiri: add transient declaration
- The instance field  type is from Nokogiri but make it serializable requires many changes: add transient declaration
- The instance field  type is from Nokogiri and make it serializable is simple: change the type to serializable

**Have you included adequate test coverage?**

No.

**Does this change affect the behavior of either the C or the Java implementations?**

It should not change any Java implementation behavior. The command `bundle exec rake clean compile test` result on JRuby 9.4 shows the changes don't break any.