### PR TITLE
Build zlib sequentially with `make -j1` to avoid race conditions on Windows

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -792,11 +792,11 @@ else
             end
 
             def compile
-              execute("compile", "make -f win32/Makefile.gcc")
+              execute("compile", "make -j1 -f win32/Makefile.gcc")
             end
 
             def install
-              execute("install", "make -f win32/Makefile.gcc install")
+              execute("install", "make -j1 -f win32/Makefile.gcc install")
             end
           end
           recipe.cross_build_p = cross_build_p


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

When we install gem contains C extension, 
we can give the `make` flag using `MAKEFLAGS` environment variable.

Typically, C extensions are compiled one by one files. 
But, setting flags via `MAKEFLAGS` enables parallel builds, reducing installation time.


When building zlib in parallel sometimes fails on Windows with errors like:

    strip.exe: unable to copy file 'zlib1.dll'; reason: Permission denied

This happens because concurrent targets try to access the same file (`zlib1.dll`) before the linker or antivirus releases the file handle.

To ensure stable builds, force zlib to be built sequentially by using `make -j1` instead of relying on inherited MAKEFLAGS.

**Reproduce**
```
PS C:\prj\nokogiri> git clean -fxd
PS C:\prj\nokogiri> $env:MAKEFLAGS = "-j"
PS C:\prj\nokogiri> rake compile
Ignoring nokogiri-1.18.10 because its extensions are not built. Try: gem pristine nokogiri --version 1.18.10
mkdir -p tmp/x64-mingw-ucrt/nokogiri/3.2.9
cd tmp/x64-mingw-ucrt/nokogiri/3.2.9
C:/Ruby32-x64/bin/ruby.exe -I. ../../../../ext/nokogiri/extconf.rb
checking for whether -std=c99 is accepted as CFLAGS... yes
checking for whether -Wno-declaration-after-statement is accepted as CFLAGS... yes
checking for whether -O2 is accepted as CFLAGS... yes
checking for whether -g is accepted as CFLAGS... yes
checking for whether -Winline is accepted as CFLAGS... yes
checking for whether -Wmissing-noreturn is accepted as CFLAGS... yes
checking for whether -Wconversion is accepted as CFLAGS... no
checking for whether  "-Idummypath" is accepted as CPPFLAGS... yes
Building nokogiri using packaged libraries.
Static linking is enabled.
Cross build is disabled.
Using mini_portile version 2.8.9
---------- IMPORTANT NOTICE ----------
Building Nokogiri with a packaged version of zlib-1.3.1.
Configuration options: --host\=x86_64-w64-mingw32 --enable-static --disable-shared --libdir\=C:/prj/nokogiri/ports/x64-mingw-ucrt/zlib/1.3.1/lib --disable-shared --enable-static CFLAGS\=-fPIC

The Nokogiri maintainers intend to provide timely security updates, but if
this is a concern for you and want to use your OS/distro system library
instead, then abort this installation process and install nokogiri as
instructed at:

  https://nokogiri.org/tutorials/installing_nokogiri.html#installing-using-standard-system-libraries

Downloading zlib-1.3.1.tar.gz (100%) 
Extracting zlib-1.3.1.tar.gz into tmp/x86_64-w64-mingw32/ports/zlib/1.3.1... OK
Running 'compile' for zlib 1.3.1... ERROR. Please review logs to see what happened:
----- contents of 'C:/prj/nokogiri/tmp/x64-mingw-ucrt/nokogiri/3.2.9/tmp/x86_64-w64-mingw32/ports/zlib/1.3.1/compile.log' -----
gcc  -O3 -Wall -c -o adler32.o adler32.c
gcc  -O3 -Wall -c -o compress.o compress.c
gcc  -O3 -Wall -c -o crc32.o crc32.c
gcc  -O3 -Wall -c -o deflate.o deflate.c
gcc  -O3 -Wall -c -o gzclose.o gzclose.c
gcc  -O3 -Wall -c -o gzlib.o gzlib.c
gcc  -O3 -Wall -c -o gzread.o gzread.c
gcc  -O3 -Wall -c -o gzwrite.o gzwrite.c
gcc  -O3 -Wall -c -o infback.o infback.c
gcc  -O3 -Wall -c -o inffast.o inffast.c
gcc  -O3 -Wall -c -o inflate.o inflate.c
gcc  -O3 -Wall -c -o inftrees.o inftrees.c
gcc  -O3 -Wall -c -o trees.o trees.c
gcc  -O3 -Wall -c -o uncompr.o uncompr.c
gcc  -O3 -Wall -c -o zutil.o zutil.c
windres --define GCC_WINDRES -o zlibrc.o win32/zlib1.rc
gcc  -O3 -Wall -I. -c -o example.o test/example.c
gcc  -O3 -Wall -I. -c -o minigzip.o test/minigzip.c
ar rcs libz.a adler32.o compress.o crc32.o deflate.o gzclose.o gzlib.o gzread.o gzwrite.o infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o 
gcc -shared -Wl,--out-implib,libz.dll.a  \
-o zlib1.dll win32/zlib.def adler32.o compress.o crc32.o deflate.o gzclose.o gzlib.o gzread.o gzwrite.o infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o  zlibrc.o
gcc  -o example.exe example.o libz.a
strip zlib1.dll
gcc  -o minigzip.exe minigzip.o libz.a
C:\msys64\ucrt64\bin\strip.exe: unable to copy file 'zlib1.dll'; reason: Permission denied
make: *** [win32/Makefile.gcc:95: zlib1.dll] Error 1
make: *** Waiting for unfinished jobs....
strip example.exe
strip minigzip.exe
----- end of file -----
*** ../../../../ext/nokogiri/extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=../../../../ext/nokogiri
	--curdir
	--ruby=C:/Ruby32-x64/bin/$(RUBY_BASE_NAME)
	--help
	--clean
	--prevent-strip
	--enable-system-libraries
	--disable-system-libraries
	--use-system-libraries
	--enable-system-libraries
	--disable-system-libraries
	--use-system-libraries
	--enable-static
	--disable-static
	--enable-cross-build
	--disable-cross-build
	--enable-xml2-legacy
	--disable-xml2-legacy
	--with-zlib-dir
	--without-zlib-dir
	--with-zlib-include
	--without-zlib-include=${zlib-dir}/include
	--with-zlib-lib
	--without-zlib-lib=${zlib-dir}/lib
	--enable-xml2-legacy
	--disable-xml2-legacy
C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:628:in `block in execute': Failed to complete compile task (RuntimeError)
	from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:594:in `chdir'
	from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:594:in `execute'
	from ../../../../ext/nokogiri/extconf.rb:795:in `compile'
	from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:238:in `cook'
	from ../../../../ext/nokogiri/extconf.rb:550:in `block (2 levels) in process_recipe'
	from ../../../../ext/nokogiri/extconf.rb:329:in `chdir'
	from ../../../../ext/nokogiri/extconf.rb:329:in `chdir_for_build'
	from ../../../../ext/nokogiri/extconf.rb:550:in `block in process_recipe'
	from <internal:kernel>:90:in `tap'
	from ../../../../ext/nokogiri/extconf.rb:448:in `process_recipe'
	from ../../../../ext/nokogiri/extconf.rb:766:in `<main>'
rake aborted!
Command failed with status (1): [C:/Ruby32-x64/bin/ruby.exe -I. ../../../../ext/nokogiri/extconf.rb]

Tasks: TOP => compile => compile:x64-mingw-ucrt => compile:nokogiri:x64-mingw-ucrt => copy:nokogiri:x64-mingw-ucrt:3.2.9 => tmp/x64-mingw-ucrt/nokogiri/3.2.9/nokogiri.so => tmp/x64-mingw-ucrt/nokogiri/3.2.9/Makefile
(See full trace by running task with --trace)
```

<!--
--  If there is an existing issue that describes this, feel free to simply link to that issue.
--
--  Otherwise, please provide enough context for the Nokogiri maintainers to understand your intent.
-->

**Have you included adequate test coverage?**

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
