### PR TITLE
fix: XML::Node#replace returns all nodes reparented

### DIFF
--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -544,7 +544,10 @@ module Nokogiri
         node_or_tags = parent.coerce(node_or_tags)
 
         if node_or_tags.is_a?(XML::NodeSet)
-          node_or_tags.each { |n| add_previous_sibling(n) }
+          node_or_tags = Nokogiri::XML::NodeSet.new(
+            document,
+            node_or_tags.map { |n| add_previous_sibling(n) },
+          )
           unlink
         else
           replace_node(node_or_tags)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Fixes #3567 — tested as fixing the spec included therein.

edit: additionally, I can confirm this change fixes the oddity I encountered that led to this discovery.

I found this comment a bit odd in some code I've recently taken responsibility for: https://gitlab.com/gitlab-org/gitlab/-/blob/104b5aa2ea324e3682e8024566daa53bcd45035a/lib/banzai/filter/references/reference_filter.rb#L272-286

Aren't re-parented nodes the same as the actual replaced nodes? I tried adjusting the code to use the return value of `#replace` and remove all that manual tracking, and sure enough, some specs (which test functionality that relies on the replaced nodes being tracked correctly) started to fail. Those specs pass again with this PR being used.

**Have you included adequate test coverage?**

Not yet — I want to confirm that this change looks OK first before doing so. If you're happy, I'll add specs to the PR before marking as ready.

**Does this change affect the behavior of either the C or the Java implementations?**

What a wonderful question — I have no idea! I'll look into this along with the specs if this looks OK.
