### PR TITLE
feat: add Ruby 4.0.0-preview2 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,8 @@ jobs:
     needs: ["basic"]
     outputs:
       # these are usually the same, but are different once we get to ruby release candidates
-      setup_ruby: "['3.1', '3.2', '3.3', '3.4']"
-      setup_ruby_win: "['3.1', '3.2', '3.3', '3.4']"
+      setup_ruby: "['3.1', '3.2', '3.3', '3.4', '4.0.0-preview2']"
+      setup_ruby_win: "['3.1', '3.2', '3.3', '3.4', '4.0.0-preview2']"
       image_tag: "['3.1', '3.2', '3.3', '3.4']"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add Ruby 4.0.0-preview2 to macOS and Windows CI builds.