### PR TITLE
ci: add riscv64-linux smoke job (QEMU)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,72 @@ jobs:
   #
   #  SECTION run the test suite across a broad matrix of rubies, configs, and systems
   #
+  riscv64:
+    name: "riscv64-linux (QEMU)"
+    needs: [ "basic" ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Cache bundler
+        uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: bundler-${{ runner.os }}-riscv64-${{ hashFiles('Gemfile') }}
+          restore-keys: |
+            bundler-${{ runner.os }}-riscv64-
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
+
+      - name: Build and test in riscv64 container
+        run: |
+          docker run --rm --platform=linux/riscv64 \
+            -v "$PWD:/work" -w /work \
+            ruby:3.4-slim bash -lc '
+              set -euo pipefail
+
+              ruby -v
+              uname -a
+
+              apt-get update
+              apt-get install -y --no-install-recommends \
+                zlib1g-dev \
+                libxml2-dev \
+                libxslt1-dev \
+                build-essential \
+                git \
+                pkg-config \
+                libyaml-dev \
+                patch \
+                xz-utils \
+                liblzma-dev
+              rm -rf /var/lib/apt/lists/*
+              
+              echo "libxml versions:"
+              dpkg -s libxml2 libxml2-dev 2>/dev/null | grep '^Package:' || true
+              dpkg -s libxml2 libxml2-dev 2>/dev/null | grep '^Version:' || true
+              xml2-config --version || true
+              
+              echo "libxslt versions:"
+              dpkg -s libxslt1.1 libxslt1-dev 2>/dev/null | grep '^Package:' || true
+              dpkg -s libxslt1.1 libxslt1-dev 2>/dev/null | grep '^Version:' || true
+              xslt-config --version || true
+              
+              echo "gem: --no-document" > ~/.gemrc
+          
+              bundle config set --local path vendor/bundle
+              bundle config set --local without rdoc
+              bundle config set --local no-document true
+              bundle config set --local jobs 4
+              bundle install --local || bundle install
+              bundle exec rake compile -- --enable-system-libraries
+              bundle exec rake test
+            '
   linux:
     needs: ["basic", "ruby_versions"]
     strategy:


### PR DESCRIPTION
This PR adds an experimental CI job that runs Nokogiri's build and test suite
on `riscv64` using QEMU.

The goal is simply to verify that Nokogiri compiles and runs correctly on the
RISC-V architecture. As RISC-V systems become more accessible (e.g. development
boards and some cloud environments), having minimal CI coverage can help detect
portability issues early.

## What the job does

The job:

- runs inside a `riscv64` container (`ruby:3.4.x-slim`)
- installs system libraries (`libxml2-dev`, `libxslt1-dev`)
- compiles Nokogiri using `--enable-system-libraries`
- runs the test suite using the standard `rake` tasks

To keep runtime reasonable under QEMU emulation:

- Bundler dependencies are cached
- gem documentation generation is disabled
- system libraries are used instead of building Nokogiri’s packaged libxml2

In practice this job completes in roughly ~9 minutes.

## Why system libraries are used

Building Nokogiri's bundled libxml2 under QEMU emulation significantly increases
CI runtime. Using system libraries keeps the job lightweight while still
verifying that Nokogiri compiles and the test suite runs successfully.

The workflow logs also include the detected `libxml2` version for visibility.

## Intent

This job is meant to provide **additional CI signal only**

If preferred, it could be:

- treated as experimental
- marked `continue-on-error`
- adjusted to run a smaller smoke subset of tests
- moved to a small prebuilt container image (e.g. via GHCR) with the required system dependencies preinstalled, to avoid repeated `apt-get` installation and further reduce CI runtime

 Happy to adjust or simplify the workflow if there are preferred conventions for adding new architectures to the CI setup.

If this isn’t something the project wants to maintain in CI long-term, feel free to close the PR — I mostly wanted to share the experiment and the workflow in case it’s useful. 

Thanks for taking a look!