### PR TITLE
dep(test): test against libxml-ruby v6

### DIFF
--- a/Gemfile-libxml-ruby
+++ b/Gemfile-libxml-ruby
@@ -1,3 +1,3 @@
 ENV['TEST_NOKOGIRI_WITH_LIBXML_RUBY'] = "1"
-gem "libxml-ruby", :platform => :mri, :require => false
+gem "libxml-ruby", ">= 6", :platform => :mri, :require => false
 eval_gemfile File.join(File.dirname(ENV['BUNDLE_GEMFILE']),"Gemfile")

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -31,7 +31,7 @@ if ENV["TEST_NOKOGIRI_WITH_LIBXML_RUBY"]
   #  which will a) bundle that gem, and b) set the appropriate env var to
   #  trigger this block
   #
-  require "libxml"
+  require "libxml-ruby"
   warn "#{__FILE__}:#{__LINE__}: loaded libxml-ruby '#{LibXML::XML::VERSION}'"
 end
 


### PR DESCRIPTION
**What problem is this PR intended to solve?**

CI has been failing since libxml-ruby v6 came out with a breaking change to the require path.

Pin to `>= 6` and update the require statement.
