### PR TITLE
ci: add windows-11-arm to source-build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,15 @@ jobs:
       matrix:
         sys: ["enable", "disable"]
         ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_win) }}
-    runs-on: windows-2022
+        os: [ windows-2022 ]
+        include:
+          - sys: "enable"
+            ruby: "3.4"
+            os: windows-11-arm
+          - sys: "disable"
+            ruby: "3.4"
+            os: windows-11-arm
+    runs-on: ${{ matrix.os }}
     steps:
       - name: configure git crlf
         run: |
@@ -543,16 +551,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-2022 ]
         sys: ["enable", "disable"]
         ruby: ${{ fromJSON(needs.ruby_versions.outputs.setup_ruby_win) }}
+        os: [ windows-2022 ]
         include:
-          - os: windows-11-arm
-            sys: "enable"
+          - sys: "enable"
             ruby: "3.4"
-          - os: windows-11-arm
-            sys: "disable"
+            os: windows-11-arm
+          - sys: "disable"
             ruby: "3.4"
+            os: windows-11-arm
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,6 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          setup-ruby-ref: ruby/setup-ruby/d3e3bd032ad2222a8ac878bbccf2aba78864e134
           ruby-version: "${{matrix.ruby}}"
           mingw: "libxml2 libxslt"
           bundler-cache: true
@@ -387,7 +386,6 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          setup-ruby-ref: ruby/setup-ruby/d3e3bd032ad2222a8ac878bbccf2aba78864e134
           ruby-version: truffleruby
           bundler-cache: true
           bundler: 2.5.10
@@ -510,7 +508,6 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          setup-ruby-ref: ruby/setup-ruby/d3e3bd032ad2222a8ac878bbccf2aba78864e134
           ruby-version: "${{matrix.ruby}}"
           apt-get: "libxml2-dev libxslt1-dev pkg-config"
       - uses: actions/download-artifact@v8
@@ -563,7 +560,6 @@ jobs:
           submodules: true
       - uses: ruby/setup-ruby-pkgs@v1
         with:
-          setup-ruby-ref: ruby/setup-ruby/d3e3bd032ad2222a8ac878bbccf2aba78864e134
           ruby-version: "${{matrix.ruby}}"
           mingw: "libxml2 libxslt"
       - uses: actions/download-artifact@v8


### PR DESCRIPTION

**What problem is this PR intended to solve?**

Because we don't yet ship a precompiled `aarch64-mingw-ucrt` platform gem (though this has landed in `main` thanks to https://github.com/sparklemotion/nokogiri/pull/3530), this platform needs to compile from source today.

However, those builds are failing on windows-11-arm images in Github Actions, e.g. https://github.com/ruby/prism/actions/runs/24540427566/job/71745013974?pr=4080

Let's add it to the CI matrix and get it green.

This change mirrors the pattern used in generic-windows-install, adding ruby 3.4 with enable/disable system-libraries on windows-11-arm.
