### PR TITLE
Improve memory debugging in test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,12 @@ Run test/test_memory_usage.rb and look for memory leaks using RSS size and linea
 bundle exec rake compile test:memory_suite
 ```
 
+Run test/test_memory_usage.rb under valgrind, which loops in each test looking for memory errors:
+
+``` sh
+bundle exec rake compile test:memory_suite:valgrind
+```
+
 
 Note that by you can run the test suite with a variety of GC behaviors. For example, running a major after each test completes has, on occasion, been useful for localizing some classes of memory bugs, but does slow the suite down. Some variations of the test suite behavior are available (see `test/helper.rb` for more info):
 

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -101,6 +101,16 @@ class MemorySuiteTestTask < Minitest::TestTask
   end
 end
 
+class MemorySuiteValgrindTestTask < ValgrindTestTask
+  def ruby(*args, **options, &block)
+    ENV["NCPU"] = nil
+    ENV["NOKOGIRI_MEMORY_SUITE"] = "t"
+    ENV["NOKOGIRI_TEST_GC_LEVEL"] = "major"
+
+    super
+  end
+end
+
 if defined?(RubyMemcheck)
   class MemcheckTestTask < RubyMemcheck::TestTask
     def ruby(*args, **options, &block)
@@ -161,6 +171,10 @@ namespace "test" do
   end
 
   MemorySuiteTestTask.create("memory_suite") do |t|
+    nokogiri_test_memory_suite_configuration(t)
+  end
+
+  MemorySuiteValgrindTestTask.create("memory_suite:valgrind") do |t|
     nokogiri_test_memory_suite_configuration(t)
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -224,14 +224,18 @@ module Nokogiri
       end
     end
 
-    def refute_valgrind_errors
-      # force the test to explicitly declare a skip
-      raise "memory stress tests shouldn't be run on JRuby" if Nokogiri.jruby?
+    def refute_valgrind_errors(yield_on_jruby: false)
+      if Nokogiri.jruby?
+        # force the test to explicitly declare a skip
+        raise "memory stress tests shouldn't be run on JRuby" unless yield_on_jruby
 
-      GC.start(full_mark: true) if MemoryDebugger.active?
-      yield.tap do
+        yield.tap { @assertions += 1 }
+      else
         GC.start(full_mark: true) if MemoryDebugger.active?
-        @assertions += 1
+        yield.tap do
+          GC.start(full_mark: true) if MemoryDebugger.active?
+          @assertions += 1
+        end
       end
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -228,8 +228,9 @@ module Nokogiri
       # force the test to explicitly declare a skip
       raise "memory stress tests shouldn't be run on JRuby" if Nokogiri.jruby?
 
+      GC.start(full_mark: true) if MemoryDebugger.active?
       yield.tap do
-        GC.start(full_mark: true) if @@gc_level == :minor
+        GC.start(full_mark: true) if MemoryDebugger.active?
         @assertions += 1
       end
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,6 +21,8 @@ require "yaml"
 
 require "nokogiri"
 
+require_relative "helpers/memory_debugger"
+
 if ENV["TEST_NOKOGIRI_WITH_LIBXML_RUBY"]
   #
   #  if you'd like to test with the libxml-ruby gem loaded, it's
@@ -73,18 +75,6 @@ module Nokogiri
     XML_ATOM_FILE        = File.join(ASSETS_DIR, "atom.xml")
     XSLT_FILE            = File.join(ASSETS_DIR, "staff.xslt")
     XPATH_FILE           = File.join(ASSETS_DIR, "slow-xpath.xml")
-
-    def i_am_running_in_valgrind
-      # https://stackoverflow.com/questions/365458/how-can-i-detect-if-a-program-is-running-from-within-valgrind/62364698#62364698
-      ENV["LD_PRELOAD"] =~ /valgrind|vgpreload/
-    end
-
-    def i_am_running_with_asan
-      # https://stackoverflow.com/questions/35012059/check-whether-sanitizer-like-addresssanitizer-is-active
-      %x"ldd #{Gem.ruby}".include?("libasan.so")
-    rescue
-      false
-    end
 
     def skip_unless_libxml2(msg = "this test should only run with libxml2")
       skip(msg) unless Nokogiri.uses_libxml?
@@ -309,7 +299,7 @@ module Nokogiri
     # otherwise, will loop for 10 seconds, measure vmsize over time, calculate the best-fit linear
     # slope, and fail if there is definitely a leak.
     def memwatch(method, n: nil, retry_once: true, &block)
-      if i_am_running_in_valgrind
+      if MemoryDebugger.active?
         refute_valgrind_errors do
           t1 = Time.now
           loop do

--- a/test/helpers/memory_debugger.rb
+++ b/test/helpers/memory_debugger.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Nokogiri
+  module MemoryDebugger
+    class << self
+      def active?
+        if defined?(@active)
+          @active
+        else
+          @active = valgrind_active? || asan_active?
+        end
+      end
+
+      private
+
+      def valgrind_active?
+        # https://stackoverflow.com/questions/365458/how-can-i-detect-if-a-program-is-running-from-within-valgrind/62364698#62364698
+        ENV["LD_PRELOAD"] =~ /valgrind|vgpreload/
+      end
+
+      def asan_active?
+        # https://stackoverflow.com/questions/35012059/check-whether-sanitizer-like-addresssanitizer-is-active
+        `ldd #{Gem.ruby}`.include?("libasan.so")
+      rescue
+        false
+      end
+    end
+  end
+end

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -846,8 +846,7 @@ module Nokogiri
           end
 
           it "returns an enumerator given no block" do
-            skip("enumerators confuse valgrind") if i_am_running_in_valgrind
-            skip("enumerators confuse ASan") if i_am_running_with_asan
+            skip("enumerators confuse memory debuggers") if Nokogiri::MemoryDebugger.active?
             skip("https://bugs.ruby-lang.org/issues/20085") if RUBY_DESCRIPTION.include?("aarch64") && RUBY_VERSION == "3.3.0"
 
             employees = xml.search("//employee")


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Working through some bug reports related to memory issues, and we need an upgrade of some of our helper methods

- Extract a memory debugger helper to replace `i_am_running_in_valgrind` et al
- Memoize that helper to avoid re-checking
- Improve refute_valgrind_errors to GC before and after yielding
- Extend refute_valgrind_errors to allow yielding on JRuby (for combined functional testing)
- Add a `test:memory_suite:valgrind` rake target

**Have you included adequate test coverage?**

N/A

**Does this change affect the behavior of either the C or the Java implementations?**

N/A
