### PR TITLE
fix: JRuby NONET bypass in XML::Schema (v1.19.x)

### DIFF
--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -8,6 +8,9 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
@@ -285,22 +288,101 @@ public class XmlSchema extends RubyObject
                     String systemId,
                     String baseURI)
     {
-      if (noNet && systemId != null && (systemId.startsWith("http://") || systemId.startsWith("ftp://"))) {
-        if (systemId.startsWith(XMLConstants.W3C_XML_SCHEMA_NS_URI)) {
-          return null; // use default resolver
-        }
+      if (noNet && !effectiveResourceIsLocal(systemId, baseURI)) {
         try {
           this.errorHandler.warning(new SAXParseException(String.format("Attempt to load network entity '%s'", systemId), null));
         } catch (SAXException ex) {
         }
-      } else {
-        String adjusted = adjustSystemIdIfNecessary(currentDir, scriptFileName, baseURI, systemId);
-        lsInput.setPublicId(publicId);
-        lsInput.setSystemId(adjusted != null ? adjusted : systemId);
-        lsInput.setBaseURI(baseURI);
+        return new SchemaLSInput(); // an empty input blocks the fetch
       }
+
+      String adjusted = adjustSystemIdIfNecessary(currentDir, scriptFileName, baseURI, systemId);
+      lsInput.setPublicId(publicId);
+      lsInput.setSystemId(adjusted != null ? adjusted : systemId);
+      lsInput.setBaseURI(baseURI);
       return lsInput;
     }
+  }
+
+  // We enforce NONET for schema resolution by hand because Xerces-J (the JAXP implementation
+  // backing XML::Schema on JRuby) does not implement the standard JAXP property
+  // XMLConstants.ACCESS_EXTERNAL_SCHEMA — so we cannot simply restrict external access on the
+  // SchemaFactory and must classify each resolved resource in the LSResourceResolver instead.
+  //
+  // Decides whether a schema-import resource may be resolved while NONET is on: true means
+  // local (allowed), false means a network resource (blocked). A relative systemId inherits
+  // its document's base, so it is resolved against baseURI before classification — a relative
+  // import under a remote base is a network fetch even though the systemId alone looks local.
+  private static boolean
+  effectiveResourceIsLocal(String systemId, String baseURI)
+  {
+    // a null systemId means there is nothing external to resolve
+    if (systemId == null) {
+      return true;
+    }
+    try {
+      URI uri = new URI(systemId);
+      if (baseURI != null && !baseURI.isEmpty()) {
+        uri = new URI(baseURI).resolve(uri);
+      }
+      return isLocalResource(uri);
+    } catch (URISyntaxException | IllegalArgumentException e) {
+      // fail closed: an unparseable base or systemId (e.g. a raw UNC path "\\host\share") is
+      // not provably local, and the JVM's file/URL handling may still reach the network
+      return false;
+    }
+  }
+
+  // Test seam for the Ruby suite: local_resource?(systemId, baseURI = nil).
+  @JRubyMethod(meta = true, name = "local_resource?", required = 1, optional = 1, visibility = Visibility.PRIVATE)
+  public static IRubyObject
+  local_resource_eh(ThreadContext context, IRubyObject klazz, IRubyObject[] args)
+  {
+    String systemId = args[0].isNil() ? null : args[0].asJavaString();
+    String baseURI = (args.length > 1 && !args[1].isNil()) ? args[1].asJavaString() : null;
+    return context.runtime.newBoolean(effectiveResourceIsLocal(systemId, baseURI));
+  }
+
+  // Classifies an already-parsed URI. Local is a missing scheme, or the "file" scheme, with
+  // no remote authority and no UNC-shaped path. This is intentionally stricter than libxml2's
+  // xmlNoNetExternalEntityLoader, which folds a remote host (file://host/...) into a local
+  // path rather than rejecting it.
+  //
+  // TODO: a Windows drive-letter path like "C:\path" parses as scheme "c" and would be
+  // blocked; support those if we need it later.
+  private static boolean
+  isLocalResource(URI uri)
+  {
+    // only a missing scheme (a relative or absolute path) or file: can be local; any
+    // other scheme is a network resource
+    String scheme = uri.getScheme();
+    if (scheme != null && !scheme.equalsIgnoreCase("file")) {
+      return false;
+    }
+
+    // an opaque "file:" URI (e.g. file:foo, with no "//") is not a usable local path; reject
+    // it, matching libxml2, which does not resolve that form as a local file either
+    if (uri.isOpaque()) {
+      return false;
+    }
+
+    // a non-empty, non-localhost authority is a remote host — file://host/path, or the
+    // schemeless network-path form //host/path. Stricter than libxml2, which folds such a
+    // host into a (failing) local path.
+    String authority = uri.getRawAuthority();
+    if (authority != null && !authority.isEmpty() && !authority.equalsIgnoreCase("localhost")) {
+      return false;
+    }
+
+    // reject UNC-shaped paths even under an allowed authority: file:////host/share,
+    // file://localhost//host/share, and %2f/%5c-encoded variants. getPath() is decoded, so
+    // the encoded forms are normalized before this check.
+    String path = uri.getPath();
+    if (path != null && (path.startsWith("//") || path.indexOf('\\') >= 0)) {
+      return false;
+    }
+
+    return true;
   }
 
   private class SchemaLSInput implements LSInput

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -203,9 +203,6 @@ Init_nokogiri(void)
   rb_const_set(mNokogiri, rb_intern("LIBXSLT_COMPILED_VERSION"), NOKOGIRI_STR_NEW2(LIBXSLT_DOTTED_VERSION));
   rb_const_set(mNokogiri, rb_intern("LIBXSLT_LOADED_VERSION"), NOKOGIRI_STR_NEW2(xsltEngineVersion));
 
-  rb_const_set(mNokogiri, rb_intern("LIBXML_ZLIB_ENABLED"),
-               xmlHasFeature(XML_WITH_ZLIB) == 1 ? Qtrue : Qfalse);
-
 #ifdef NOKOGIRI_PACKAGED_LIBRARIES
   rb_const_set(mNokogiri, rb_intern("PACKAGED_LIBRARIES"), Qtrue);
 #  ifdef NOKOGIRI_PRECOMPILED_LIBRARIES
@@ -227,6 +224,12 @@ Init_nokogiri(void)
 #else
   rb_const_set(mNokogiri, rb_intern("LIBXML_ICONV_ENABLED"), Qfalse);
 #endif
+
+  rb_const_set(mNokogiri, rb_intern("LIBXML_ZLIB_ENABLED"),
+               xmlHasFeature(XML_WITH_ZLIB) == 1 ? Qtrue : Qfalse);
+
+  rb_const_set(mNokogiri, rb_intern("LIBXML_HTTP_ENABLED"),
+               xmlHasFeature(XML_WITH_HTTP) == 1 ? Qtrue : Qfalse);
 
 #ifdef NOKOGIRI_OTHER_LIBRARY_VERSIONS
   rb_const_set(mNokogiri, rb_intern("OTHER_LIBRARY_VERSIONS"), NOKOGIRI_STR_NEW2(NOKOGIRI_OTHER_LIBRARY_VERSIONS));

--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -53,6 +53,14 @@ module Nokogiri
       defined?(Nokogiri::LIBXML_ICONV_ENABLED) && Nokogiri::LIBXML_ICONV_ENABLED
     end
 
+    def libxml2_has_zlib?
+      defined?(Nokogiri::LIBXML_ZLIB_ENABLED) && Nokogiri::LIBXML_ZLIB_ENABLED
+    end
+
+    def libxml2_has_http?
+      defined?(Nokogiri::LIBXML_HTTP_ENABLED) && Nokogiri::LIBXML_HTTP_ENABLED
+    end
+
     def libxslt_has_datetime?
       defined?(Nokogiri::LIBXSLT_DATETIME_ENABLED) && Nokogiri::LIBXSLT_DATETIME_ENABLED
     end
@@ -145,6 +153,8 @@ module Nokogiri
             end
             libxml["memory_management"] = Nokogiri::LIBXML_MEMORY_MANAGEMENT
             libxml["iconv_enabled"] = libxml2_has_iconv?
+            libxml["zlib_enabled"] = libxml2_has_zlib?
+            libxml["http_enabled"] = libxml2_has_http?
             libxml["compiled"] = compiled_libxml_version.to_s
             libxml["loaded"] = loaded_libxml_version.to_s
           end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,6 +22,7 @@ require "yaml"
 require "nokogiri"
 
 require_relative "helpers/memory_debugger"
+require_relative "helpers/mock_server"
 
 if ENV["TEST_NOKOGIRI_WITH_LIBXML_RUBY"]
   #
@@ -102,6 +103,31 @@ module Nokogiri
     def file_url_for(path)
       path_with_leading_slash = path.start_with?("/") ? path : "/#{path}"
       "file://#{path_with_leading_slash}"
+    end
+
+    def assert_network_connection(scheme: "http", path: "/making-a-request", &block)
+      assert tcp_connection_attempted?(scheme:, path:, &block), "should open a network connection"
+    end
+
+    def refute_network_connection(scheme: "http", path: "/making-a-request", &block)
+      refute tcp_connection_attempted?(scheme:, path:, &block), "should not open a network connection"
+    end
+
+    def ignoring_syntax_errors
+      yield
+    rescue Nokogiri::XML::SyntaxError
+    end
+
+    def tcp_connection_attempted?(scheme: "http", path: "/making-a-request")
+      flunk("MockServer is not supported on this platform; the calling test must skip explicitly") unless MockServer.supported?
+
+      listener = MockServer.listener_class.new
+      begin
+        yield("#{scheme}://127.0.0.1:#{listener.port}#{path}")
+      ensure
+        connections = listener.stop
+      end
+      connections.positive?
     end
   end
 

--- a/test/helpers/mock_server.rb
+++ b/test/helpers/mock_server.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "socket"
+
+require_relative "memory_debugger"
+
+module Nokogiri
+  module MockServer
+    def self.listener_class
+      Nokogiri.jruby? ? ThreadListener : ProcessListener
+    end
+
+    def self.supported?
+      listener_class.supported?
+    end
+
+    # Accepts and immediately closes TCP connections on an ephemeral port,
+    # counting them. Runs in a forked child process because on CRuby a parse
+    # that accesses the network blocks in a C call that holds the GVL, so an
+    # in-process listener thread would be starved and could never accept the
+    # connection. The child writes one byte per connection to a pipe, and the
+    # parent counts the bytes after reaping the child.
+    class ProcessListener
+      # Process.fork rules out platforms like Windows, and we also avoid
+      # forking under memory debuggers, where children are traced too.
+      def self.supported?
+        Process.respond_to?(:fork) && !MemoryDebugger.active?
+      end
+
+      attr_reader :port
+
+      def initialize
+        server = TCPServer.new("127.0.0.1", 0)
+        @port = server.addr[1]
+        @reader, writer = IO.pipe
+        @pid = Process.fork do
+          @reader.close
+          writer.sync = true
+          loop do
+            client = server.accept
+            writer.write(".")
+            client.close
+          end
+        end
+        writer.close
+        server.close
+      end
+
+      def stop
+        Process.kill(:TERM, @pid)
+        Process.wait(@pid)
+        @reader.read.length
+      ensure
+        @reader.close
+      end
+    end
+
+    # Same API as ProcessListener, but runs in an in-process thread. JRuby has
+    # no GVL, so the listener thread can accept connections while a parse is
+    # blocked, and avoiding process spawn keeps the tests fast on the JVM.
+    class ThreadListener
+      def self.supported?
+        true
+      end
+
+      attr_reader :port
+
+      def initialize
+        @server = TCPServer.new("127.0.0.1", 0)
+        @port = @server.addr[1]
+        @connections = 0
+        @thread = Thread.new do
+          loop do
+            client = @server.accept
+            @connections += 1
+            client.close
+          end
+        rescue IOError, Errno::EBADF
+        end
+      end
+
+      def stop
+        @server.close
+        @thread.join
+        @connections
+      end
+    end
+  end
+end

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -69,6 +69,8 @@ module TestVersionInfoTests
     assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxml"]["loaded"])
 
     assert(version_info["libxml"].key?("iconv_enabled"))
+    assert(version_info["libxml"].key?("zlib_enabled"))
+    assert(version_info["libxml"].key?("http_enabled"))
     assert(version_info["libxslt"].key?("datetime_enabled"))
   end
 

--- a/test/xml/test_entity_reference.rb
+++ b/test/xml/test_entity_reference.rb
@@ -239,42 +239,24 @@ module Nokogiri
       end
 
       test_relative_and_absolute_path :test_document_dtd_loading_with_nonet do
-        # Make sure that we don't include remote entities unless NOENT is set to true
-        xml = <<~XML
-          <?xml version="1.0" encoding="UTF-8" ?>
-          <!DOCTYPE document SYSTEM "http://foo.bar.com/">
-          <document>
-            <body>&bar;</body>
-          </document>
-        XML
-        doc = @parser.parse(xml, path) do |cfg|
-          cfg.default_xml
-          cfg.dtdload
-        end
+        skip("MockServer not supported") unless Nokogiri::MockServer.supported?
 
-        assert_kind_of Nokogiri::XML::EntityReference, doc.xpath("//body").first.children.first
+        # Make sure that we don't load remote DTDs unless NONET is turned off
+        refute_network_connection do |url|
+          xml = <<~XML
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <!DOCTYPE document SYSTEM "#{url}">
+            <document>
+              <body>&bar;</body>
+            </document>
+          XML
+          doc = @parser.parse(xml, path) do |cfg|
+            cfg.default_xml
+            cfg.dtdload
+          end
 
-        expected = if Nokogiri.uses_libxml?("~> 2.14")
-          [
-            "2:49: ERROR: failed to load \"http://foo.bar.com/\": Attempt to load network entity",
-            # "attempt to load network entity" removed in gnome/libxml2@1b1e8b3c
-            "4:14: ERROR: Entity 'bar' not defined",
-          ]
-        elsif Nokogiri.uses_libxml?("~> 2.13.0")
-          [
-            "2:49: WARNING: failed to load \"http://foo.bar.com/\": Attempt to load network entity",
-            "ERROR: Attempt to load network entity: http://foo.bar.com/",
-            "4:14: ERROR: Entity 'bar' not defined",
-          ]
-        elsif Nokogiri.uses_libxml?
-          [
-            "ERROR: Attempt to load network entity http://foo.bar.com/",
-            "4:14: ERROR: Entity 'bar' not defined",
-          ]
-        else # jruby
-          ["Attempt to load network entity http://foo.bar.com/"]
+          assert_kind_of Nokogiri::XML::EntityReference, doc.xpath("//body").first.children.first
         end
-        assert_equal(expected, doc.errors.map(&:to_s))
       end
       # TODO: can we retrieve a resource pointing to localhost when NONET is set to true ?
     end
@@ -311,33 +293,37 @@ module Nokogiri
       end
 
       test_relative_and_absolute_path :test_more_sax_entity_reference do
+        skip("MockServer not supported") unless Nokogiri::MockServer.supported?
+
         # Make sure that we don't include entity references unless NOENT is set to true
-        xml = <<~XML
-          <?xml version="1.0" encoding="UTF-8" ?>
-          <!DOCTYPE document SYSTEM "http://foo.bar.com/">
-          <document>
-            <body>&bar;</body>
-          </document>
-        XML
-        @parser.parse(xml)
+        refute_network_connection do |url|
+          xml = <<~XML
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <!DOCTYPE document SYSTEM "#{url}">
+            <document>
+              <body>&bar;</body>
+            </document>
+          XML
+          @parser.parse(xml)
 
-        actual = if Nokogiri.uses_libxml?(">= 2.13.0") # gnome/libxml2@b717abdd
-          @parser.document.warnings
-        else
-          @parser.document.errors
+          actual = if Nokogiri.uses_libxml?(">= 2.13.0") # gnome/libxml2@b717abdd
+            @parser.document.warnings
+          else
+            @parser.document.errors
+          end
+
+          refute_nil(actual)
+          refute_empty(actual)
+
+          actual = actual.map { |e| e.to_s.strip }
+          expected = if truffleruby_system_libraries?
+            ["error_func: %s"]
+          else
+            ["Entity 'bar' not defined"]
+          end
+
+          assert_equal(expected, actual)
         end
-
-        refute_nil(actual)
-        refute_empty(actual)
-
-        actual = actual.map { |e| e.to_s.strip }
-        expected = if truffleruby_system_libraries?
-          ["error_func: %s"]
-        else
-          ["Entity 'bar' not defined"]
-        end
-
-        assert_equal(expected, actual)
       end
     end
 

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -354,131 +354,159 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
       assert(child.to_s) # This will raise a valgrind error if the node was freed
     end
 
+    # https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m
+    # https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-8678-w3jw-xfc2
     describe "CVE-2020-26247" do
-      # https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m
-      let(:schema) do
-        <<~EOSCHEMA
-          <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:import namespace="test" schemaLocation="http://localhost:8000/making-a-request"/>
-          </xs:schema>
-        EOSCHEMA
-      end
+      before { skip("MockServer not supported") unless Nokogiri::MockServer.supported? }
 
-      if Nokogiri.uses_libxml?
-        describe "with default parse options" do
-          it "XML::Schema parsing does not attempt to access external DTDs" do
-            doc = Nokogiri::XML::Schema.new(schema)
-            errors = doc.errors.map(&:to_s)
-            refute_empty(
-              errors.grep(/Attempt to load network entity/),
-              "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_empty(
-              errors.grep(/failed to load HTTP resource/),
-              "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
-            )
-            assert_empty(
-              errors.grep(/failed to load external entity/),
-              "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
-            )
-          end
-
-          it "XML::Schema parsing of memory does not attempt to access external DTDs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema)
-            errors = doc.errors.map(&:to_s)
-            refute_empty(
-              errors.grep(/Attempt to load network entity/),
-              "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_empty(
-              errors.grep(/failed to load HTTP resource/),
-              "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
-            )
-            assert_empty(
-              errors.grep(/failed to load external entity/),
-              "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
-            )
-          end
-        end
-
-        describe "with NONET turned off" do
-          it "XML::Schema parsing attempts to access external DTDs" do
-            doc = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions.new.nononet)
-            errors = doc.errors.map(&:to_s)
-            assert_empty(
-              errors.grep(/Attempt to load network entity/),
-              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_equal(1, errors.grep(%r{failed to load.*http://localhost:8000/making-a-request}).length)
-          end
-
-          it "XML::Schema parsing attempts to access external DTDs with kwargs" do
-            doc = Nokogiri::XML::Schema.new(schema, parse_options: Nokogiri::XML::ParseOptions.new.nononet)
-            errors = doc.errors.map(&:to_s)
-            assert_empty(
-              errors.grep(/Attempt to load network entity/),
-              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_equal(1, errors.grep(%r{failed to load.*http://localhost:8000/making-a-request}).length)
-          end
-
-          it "XML::Schema parsing of memory attempts to access external DTDs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema, Nokogiri::XML::ParseOptions.new.nononet)
-            errors = doc.errors.map(&:to_s)
-            assert_empty(
-              errors.grep(/ERROR: Attempt to load network entity/),
-              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_equal(1, errors.grep(%r{failed to load.*http://localhost:8000/making-a-request}).length)
-          end
-
-          it "XML::Schema parsing of memory attempts to access external DTDs with kwargs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema, parse_options: Nokogiri::XML::ParseOptions.new.nononet)
-            errors = doc.errors.map(&:to_s)
-            assert_empty(
-              errors.grep(/ERROR: Attempt to load network entity/),
-              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_equal(1, errors.grep(%r{failed to load.*http://localhost:8000/making-a-request}).length)
-          end
-        end
-      end
+      network_schemata = %w[ http HTTP https HTTPS ftp FTP jar:http jar:https telnet ]
 
       if Nokogiri.jruby?
-        describe "with default parse options" do
-          it "XML::Schema parsing does not attempt to access external DTDs" do
-            doc = Nokogiri::XML::Schema.new(schema)
-            assert_equal 1, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
+        unsupported_schemata = %w[ telnet ]
+        supported_schemata = network_schemata - unsupported_schemata
+      else
+        supported_schemata = []
+        supported_schemata << "http" if Nokogiri::LIBXML_HTTP_ENABLED
+        supported_schemata += %w[ ftp ] if Nokogiri.uses_libxml?("< 2.10.0")
+        unsupported_schemata = network_schemata - supported_schemata
+      end
+
+      schemata_matrix = supported_schemata.map { |s| [s, true] } + unsupported_schemata.map { |s| [s, false] }
+      schemata_matrix.each do |scheme, network_supported|
+        describe "external resource via #{network_supported ? "supported" : "unsupported"} scheme #{scheme.inspect}" do
+          describe "with default parse options" do
+            it "XML::Schema.new does not hit the network" do
+              refute_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                Nokogiri::XML::Schema.new(schema_importing(url))
+              end
+            end
+
+            it "XML::Schema.read_memory does not hit the network" do
+              refute_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                Nokogiri::XML::Schema.read_memory(schema_importing(url))
+              end
+            end
           end
 
-          it "XML::Schema parsing of memory does not attempt to access external DTDs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema)
-            assert_equal 1, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-          end
-        end
+          describe "with NONET turned off" do
+            if network_supported
+              it "XML::Schema.new hits the network" do
+                assert_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  ignoring_syntax_errors do # it's OS-dependent whether the mock TCP server causes a syntax error
+                    Nokogiri::XML::Schema.new(schema_importing(url), Nokogiri::XML::ParseOptions.new.nononet)
+                  end
+                end
+              end
 
-        describe "with NONET turned off" do
-          it "XML::Schema parsing attempts to access external DTDs" do
-            doc = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions.new.nononet)
-            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-          end
+              it "XML::Schema.new with kwargs hits the network" do
+                assert_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  ignoring_syntax_errors do # it's OS-dependent whether the mock TCP server causes a syntax error
+                    Nokogiri::XML::Schema.new(schema_importing(url), parse_options: Nokogiri::XML::ParseOptions.new.nononet)
+                  end
+                end
+              end
 
-          it "XML::Schema parsing attempts to access external DTDs with kwargs" do
-            doc = Nokogiri::XML::Schema.new(schema, parse_options: Nokogiri::XML::ParseOptions.new.nononet)
-            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-          end
+              it "XML::Schema.read_memory hits the network" do
+                assert_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  ignoring_syntax_errors do # it's OS-dependent whether the mock TCP server causes a syntax error
+                    Nokogiri::XML::Schema.read_memory(schema_importing(url), Nokogiri::XML::ParseOptions.new.nononet)
+                  end
+                end
+              end
 
-          it "XML::Schema parsing of memory attempts to access external DTDs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema, Nokogiri::XML::ParseOptions.new.nononet)
-            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-          end
+              it "XML::Schema.read_memory with kwargs hits the network" do
+                assert_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  ignoring_syntax_errors do # it's OS-dependent whether the mock TCP server causes a syntax error
+                    Nokogiri::XML::Schema.read_memory(schema_importing(url), parse_options: Nokogiri::XML::ParseOptions.new.nononet)
+                  end
+                end
+              end
+            else
+              it "XML::Schema.new does not hit the network" do
+                refute_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  Nokogiri::XML::Schema.new(schema_importing(url), Nokogiri::XML::ParseOptions.new.nononet)
+                end
+              end
 
-          it "XML::Schema parsing of memory attempts to access external DTDs with kwargs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema, parse_options: Nokogiri::XML::ParseOptions.new.nononet)
-            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
+              it "XML::Schema.read_memory does not hit the network" do
+                refute_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  Nokogiri::XML::Schema.read_memory(schema_importing(url), Nokogiri::XML::ParseOptions.new.nononet)
+                end
+              end
+            end
           end
         end
       end
     end
+
+    describe "relative import against a remote document base (default parse options)" do
+      before { skip("MockServer not supported") unless Nokogiri::MockServer.supported? }
+
+      it "XML::Schema.from_document does not hit the network" do
+        refute_network_connection(path: "/import.xsd") do |url|
+          base = url.delete_suffix("import.xsd")
+          doc = Nokogiri::XML(schema_importing("import.xsd"), base)
+          Nokogiri::XML::Schema.from_document(doc)
+        end
+      end
+    end
+
+    if Nokogiri.jruby?
+      describe "local resource" do
+        {
+          nil => true,
+          "schema.xsd" => true,
+          "/absolute/schema.xsd" => true,
+          "file:/path/schema.xsd" => true,
+          "file:///path/schema.xsd" => true,
+          "file://localhost/path/schema.xsd" => true,
+          "file:schema.xsd" => false,
+          "http://example.com/schema.xsd" => false,
+          "https://example.com/schema.xsd" => false,
+          "ftp://example.com/schema.xsd" => false,
+          "file://example.com/share/schema.xsd" => false,
+          "file:////host/share/schema.xsd" => false,
+          "file://localhost//host/share/schema.xsd" => false,
+          "//host/share/schema.xsd" => false,
+          "file:/%2f%2fhost/share/schema.xsd" => false,
+          "file:/%5c%5chost/share/schema.xsd" => false,
+          "\\\\host\\share\\schema.xsd" => false,
+          "C:/path/schema.xsd" => false,
+          "jar:file:/archive.jar!/schema.xsd" => false,
+        }.each do |system_id, expected|
+          it "#{system_id.inspect} is #{expected ? "allowed" : "blocked"}" do
+            assert_equal(expected, Nokogiri::XML::Schema.send(:local_resource?, system_id))
+          end
+        end
+      end
+
+      describe "local resource resolved against a base URI" do
+        {
+          ["import.xsd", "http://example.com/"] => false,
+          ["import.xsd", "file:///srv/schemas/"] => true,
+          ["file:///etc/passwd.xsd", "http://example.com/"] => true,
+          ["//host/share.xsd", "file:base.xsd"] => false,
+          ["//host/share.xsd", "file:///srv/"] => false,
+        }.each do |(system_id, base), expected|
+          it "#{system_id.inspect} against #{base.inspect} is #{expected ? "allowed" : "blocked"}" do
+            assert_equal(expected, Nokogiri::XML::Schema.send(:local_resource?, system_id, base))
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def schema_importing(url)
+    <<~EOSCHEMA
+      <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:import namespace="test" schemaLocation="#{url}"/>
+      </xs:schema>
+    EOSCHEMA
+  end
+
+  def schema_location_path(scheme)
+    scheme.match?(/\Ajar:/i) ? "/schema.jar!/import.xsd" : "/import.xsd"
   end
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[JRuby] `XML::Schema` now enforces the `NONET` parse option, which Nokogiri enables by default. It was not enforced on JRuby, so a schema parsed with default options could still fetch external resources over the network, potentially enabling SSRF or XXE attacks and bypassing the mitigation for CVE-2020-26247. See [GHSA-8678-w3jw-xfc2](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-8678-w3jw-xfc2) for more information.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

Java only — this fixes the JRuby (Java) implementation. CRuby is not affected, because libxml2's `xmlNoNetExternalEntityLoader` already blocks all network schemes regardless of scheme or case.
