### PR TITLE
fix: `Node#initialize_copy_with_args` rejects non-Node sources (v1.19.x)

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -971,6 +971,10 @@ rb_xml_node_initialize_copy_with_args(VALUE rb_self, VALUE rb_other, VALUE rb_le
   xmlDocPtr c_new_parent_doc;
   VALUE rb_node_cache;
 
+  if (!rb_obj_is_kind_of(rb_other, cNokogiriXmlNode)) {
+    rb_raise(rb_eTypeError, "argument must be a kind of Nokogiri::XML::Node");
+  }
+
   Noko_Node_Get_Struct(rb_other, xmlNode, c_other);
   c_level = (int)NUM2INT(rb_level);
   c_new_parent_doc = noko_xml_document_unwrap(rb_new_parent_doc);

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -263,6 +263,15 @@ module Nokogiri
           assert_instance_of(subclass, node)
         end
 
+        def test_initialize_copy_with_args_rejects_non_node_source
+          doc = XML::Document.parse("<root/>")
+          namespace = doc.root.add_namespace_definition("x", "u")
+
+          assert_raises(TypeError) do
+            XML::Node.allocate.send(:initialize_copy_with_args, namespace, 1, doc)
+          end
+        end
+
         def test_search_direct_children_of_node
           xml = <<~XML
             <root>


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[CRuby] Fixed a possible invalid memory read when `XML::Node#initialize_copy_with_args` is called with an argument that is not a `Node`. See [GHSA-g9g8-vgvw-g3vf](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-g9g8-vgvw-g3vf) for more information.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

Affects the CRuby implementation only. JRuby is not affected, so no Java change was needed.
