### PR TITLE
fix(CRuby): use-after-free in XPathContext document lifetime (v1.19.x)

### DIFF
--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -12,6 +12,15 @@ static const xmlChar *NOKOGIRI_BUILTIN_PREFIX = (const xmlChar *)"nokogiri-built
 static const xmlChar *NOKOGIRI_BUILTIN_URI = (const xmlChar *)"https://www.nokogiri.org/default_ns/ruby/builtins";
 
 static void
+_noko_xml_xpath_context_dmark(void *data)
+{
+  xmlXPathContextPtr c_context = data;
+  if (c_context->doc && DOC_RUBY_OBJECT_TEST(c_context->doc)) {
+    rb_gc_mark(DOC_RUBY_OBJECT(c_context->doc));
+  }
+}
+
+static void
 _noko_xml_xpath_context_dfree(void *data)
 {
   xmlXPathContextPtr c_context = data;
@@ -21,9 +30,10 @@ _noko_xml_xpath_context_dfree(void *data)
 static const rb_data_type_t _noko_xml_xpath_context_type = {
   .wrap_struct_name = "xmlXPathContext",
   .function = {
+    .dmark = _noko_xml_xpath_context_dmark,
     .dfree = _noko_xml_xpath_context_dfree,
   },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 /* find a CSS class in an HTML element's `class` attribute */

--- a/test/test_memory_usage.rb
+++ b/test/test_memory_usage.rb
@@ -255,6 +255,14 @@ class TestMemoryUsage < Nokogiri::TestCase
       end
     end
 
+    it "XPathContext keeps its document alive" do
+      ctx = Nokogiri::XML::XPathContext.new(Nokogiri::XML::Document.parse("<root><x/></root>"))
+
+      memwatch(__method__) do
+        ctx.evaluate("//x").length
+      end
+    end
+
     it "test_leaking_dtd_nodes_after_internal_subset_removal" do
       # see https://github.com/sparklemotion/nokogiri/issues/1784
       memwatch(__method__) do


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[CRuby] Fixed a possible use-after-free when an `XML::XPathContext` is used after its source document has been garbage collected. See [GHSA-p67v-3w7g-wjg7](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-p67v-3w7g-wjg7) for more information.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

Affects the CRuby implementation only. JRuby is not affected.
