### PR TITLE
fix: use-after-free in `Node#do_xinclude` (v1.19.x)

### DIFF
--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -2150,25 +2150,20 @@ compare(VALUE self, VALUE _other)
 
 
 /*
- * call-seq:
- *   process_xincludes(flags)
- *
- * Loads and substitutes all xinclude elements below the node. The
- * parser context will be initialized with +flags+.
+ * Run XInclude substitution over the tree rooted at +c_node+, with the parser context initialized
+ * from +c_flags+. Collects libxml2's structured errors and raises Nokogiri::XML::SyntaxError (or
+ * RuntimeError) on failure.
  */
-static VALUE
-noko_xml_node__process_xincludes(VALUE rb_node, VALUE rb_flags)
+static void
+_noko_xml_node_process_xinclude_subtree(xmlNodePtr c_node, int c_flags)
 {
   int status ;
-  xmlNodePtr c_node;
   VALUE rb_errors = rb_ary_new();
   libxmlStructuredErrorHandlerState handler_state;
 
-  Noko_Node_Get_Struct(rb_node, xmlNode, c_node);
-
   noko__structured_error_func_save_and_set(&handler_state, (void *)rb_errors, noko__error_array_pusher);
 
-  status = xmlXIncludeProcessTreeFlags(c_node, (int)NUM2INT(rb_flags));
+  status = xmlXIncludeProcessTreeFlags(c_node, c_flags);
 
   noko__structured_error_func_restore(&handler_state);
 
@@ -2181,8 +2176,74 @@ noko_xml_node__process_xincludes(VALUE rb_node, VALUE rb_flags)
       rb_raise(rb_eRuntimeError, "Could not perform xinclude substitution");
     }
   }
+}
+
+
+/*
+ * Whether +c_node+ is an <xi:include> element in either the 2001 or 2003 XInclude namespace.
+ */
+static int
+_noko_xml_node_xinclude_element_p(xmlNodePtr c_node)
+{
+  return c_node->type == XML_ELEMENT_NODE
+         && xmlStrEqual(c_node->name, XINCLUDE_NODE)
+         && c_node->ns != NULL
+         && (xmlStrEqual(c_node->ns->href, XINCLUDE_NS) || xmlStrEqual(c_node->ns->href, XINCLUDE_OLD_NS));
+}
+
+
+/*
+ * call-seq:
+ *   process_xincludes(flags)
+ *
+ * Loads and substitutes all xinclude elements below the node. The
+ * parser context will be initialized with +flags+.
+ */
+static VALUE
+noko_xml_node__process_xincludes(VALUE rb_node, VALUE rb_flags)
+{
+  xmlNodePtr c_node;
+
+  Noko_Node_Get_Struct(rb_node, xmlNode, c_node);
+
+  if (c_node->parent == NULL && _noko_xml_node_xinclude_element_p(c_node)) {
+    rb_raise(rb_eRuntimeError, "cannot process XInclude on an unlinked <xi:include> node");
+  }
+
+  _noko_xml_node_process_xinclude_subtree(c_node, (int)NUM2INT(rb_flags));
 
   return rb_node;
+}
+
+
+/*
+ * Process this single <xi:include> node, substituting an unwrapped copy of it in its place so
+ * that libxml2 frees the copy. This node is unlinked and pinned to the document, so any Ruby
+ * wrapper for it (or for its descendants or namespaces) keeps pointing at valid memory. The
+ * parser context is initialized with +flags+.
+ */
+static VALUE
+noko_xml_node__safe_process_xinclude(VALUE rb_node, VALUE rb_flags)
+{
+  xmlNodePtr c_node, c_copy;
+
+  Noko_Node_Get_Struct(rb_node, xmlNode, c_node);
+
+  if (c_node->parent == NULL) {
+    rb_raise(rb_eRuntimeError, "cannot process XInclude on an unlinked <xi:include> node");
+  }
+
+  c_copy = xmlDocCopyNode(c_node, c_node->doc, 1);
+  if (c_copy == NULL) {
+    rb_raise(rb_eRuntimeError, "Could not copy node for xinclude substitution");
+  }
+
+  xmlReplaceNode(c_node, c_copy);
+  noko_xml_document_pin_node(c_node);
+
+  _noko_xml_node_process_xinclude_subtree(c_copy, (int)NUM2INT(rb_flags));
+
+  return Qnil;
 }
 
 
@@ -2438,6 +2499,7 @@ noko_init_xml_node(void)
   rb_define_method(cNokogiriXmlNode, "unlink", unlink_node, 0);
 
   rb_define_protected_method(cNokogiriXmlNode, "initialize_copy_with_args", rb_xml_node_initialize_copy_with_args, 3);
+  rb_define_protected_method(cNokogiriXmlNode, "safe_process_xinclude", noko_xml_node__safe_process_xinclude, 1);
 
   rb_define_private_method(cNokogiriXmlNode, "add_child_node", add_child, 1);
   rb_define_private_method(cNokogiriXmlNode, "add_next_sibling_node", add_next_sibling, 1);

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -85,8 +85,9 @@ module Nokogiri
             read_memory(string_or_io, url, encoding, options.to_i)
           end
 
-          # do xinclude processing
-          doc.do_xinclude(options) if options.xinclude?
+          # do xinclude processing; the document is freshly parsed and unexposed to Ruby, so the
+          # defensive copy is unnecessary
+          doc.do_xinclude(options, safe_copy: false) if options.xinclude?
 
           doc
         end

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -523,16 +523,67 @@ module Nokogiri
         set_namespace(ns)
       end
 
+      XINCLUDE_NAMESPACES = {
+        "xi2001" => "http://www.w3.org/2001/XInclude",
+        "xi2003" => "http://www.w3.org/2003/XInclude",
+      }.freeze
+      private_constant :XINCLUDE_NAMESPACES
+
+      # Every top-level <xi:include> in the subtree, in either XInclude namespace, excluding
+      # includes nested inside another include's fallback (libxml2 only expands those if the
+      # parent include fails).
+      XINCLUDE_QUERY =
+        "descendant-or-self::xi2001:include[not(ancestor::xi2001:include) and not(ancestor::xi2003:include)] | " \
+        "descendant-or-self::xi2003:include[not(ancestor::xi2001:include) and not(ancestor::xi2003:include)]"
+      private_constant :XINCLUDE_QUERY
+
       ###
-      # Do xinclude substitution on the subtree below node. If given a block, a
-      # Nokogiri::XML::ParseOptions object initialized from +options+, will be
-      # passed to it, allowing more convenient modification of the parser options.
-      def do_xinclude(options = XML::ParseOptions::DEFAULT_XML)
+      # :call-seq:
+      #   do_xinclude(options = ParseOptions::DEFAULT_XML, safe_copy: true) → self
+      #   do_xinclude(options = ParseOptions::DEFAULT_XML, safe_copy: true) { |options| ... } → self
+      #
+      # Do XInclude substitution on the subtree below this node, replacing each +<xi:include>+ with
+      # the content it references.
+      #
+      # [Parameters]
+      # - +options+ (Nokogiri::XML::ParseOptions) The parser options for the substitution. (default
+      #   +ParseOptions::DEFAULT_XML+)
+      #
+      # [Optional Keyword Arguments]
+      # - +safe_copy:+ (Boolean) Operate on a defensive copy of each +<xi:include>+ element, to
+      #   prevent libxml2 from freeing memory that is bound to live Ruby objects. (default +true+)
+      #
+      #   When +true+, each +<xi:include>+ is processed on an unwrapped copy of itself, so libxml2
+      #   frees the copy while the original node is unlinked from the document and kept alive. This
+      #   prevents a use-after-free when the +<xi:include>+ node, or any of its descendants or
+      #   namespaces, has already been exposed to Ruby; as a consequence such a wrapped node ends up
+      #   detached from the document rather than removed or converted in place.
+      #
+      #   When +false+, the document is processed in place. This is faster but only safe when nothing
+      #   in the subtree has been exposed to Ruby (for example, immediately after parsing), which is
+      #   why Document.parse uses it.
+      #
+      #   This option has no effect on the pure-Java backend, which performs XInclude substitution
+      #   during parsing.
+      #
+      # [Yields]
+      #   If a block is given, a Nokogiri::XML::ParseOptions object initialized from +options+ is
+      #   yielded to it, which can be configured before substitution.
+      #
+      # [Returns] +self+ (Nokogiri::XML::Node)
+      def do_xinclude(options = XML::ParseOptions::DEFAULT_XML, safe_copy: true)
         options = Nokogiri::XML::ParseOptions.new(options) if Integer === options
         yield options if block_given?
 
-        # call c extension
-        process_xincludes(options.to_i)
+        if safe_copy && Nokogiri.uses_libxml?
+          xpath(XINCLUDE_QUERY, XINCLUDE_NAMESPACES).each do |include_node|
+            include_node.safe_process_xinclude(options.to_i)
+          end
+        else
+          process_xincludes(options.to_i)
+        end
+
+        self
       end
 
       alias_method :next, :next_sibling

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -98,6 +98,11 @@ module Nokogiri
     def truffleruby_system_libraries?
       RUBY_ENGINE == "truffleruby" && !Nokogiri::PACKAGED_LIBRARIES
     end
+
+    def file_url_for(path)
+      path_with_leading_slash = path.start_with?("/") ? path : "/#{path}"
+      "file://#{path_with_leading_slash}"
+    end
   end
 
   class TestBenchmark < Minitest::BenchSpec

--- a/test/xml/test_xinclude.rb
+++ b/test/xml/test_xinclude.rb
@@ -2,76 +2,371 @@
 
 require "helper"
 
-module Nokogiri
-  module XML
-    class TestXInclude < Nokogiri::TestCase
-      def setup
-        super
-        @xml = Nokogiri::XML.parse(File.read(XML_XINCLUDE_FILE), XML_XINCLUDE_FILE)
-        @included = "this snippet is to be included from xinclude.xml"
+# Namespace axis values for the matrix. These are file-level locals (not `let`s) because the
+# matrix loops below run at class-definition time, before `let` methods exist.
+xi_2001 = "http://www.w3.org/2001/XInclude"
+xi_2003 = "http://www.w3.org/2003/XInclude"
+namespaces = { "2001" => xi_2001, "2003" => xi_2003 }
+
+describe "xinclude processing" do
+  let(:namespace) { xi_2001 }
+  let(:xinclude_file) { Nokogiri::TestBase::XML_XINCLUDE_FILE }
+  let(:included_file) { File.join(Nokogiri::TestBase::ASSETS_DIR, "to_be_xincluded.xml") }
+  let(:included_file_uri) { file_url_for(included_file) }
+  let(:included_content) { "this snippet is to be included from xinclude.xml" }
+  let(:document) do
+    Nokogiri::XML.parse(<<~XML)
+      <root xmlns:xi="#{namespace}">
+        <xi:include href="#{included_file_uri}"/>
+      </root>
+    XML
+  end
+
+  before do
+    skip_unless_libxml2("XInclude behavior and use-after-free protection are specific to the libxml2 C extension")
+  end
+
+  def run_xinclude(target, noxincnode: false, safe_copy: true, nowarning: false)
+    target.do_xinclude(safe_copy: safe_copy) do |options|
+      options.noxincnode if noxincnode
+      options.nowarning if nowarning
+    end
+  end
+
+  it "performs XInclude substitution only when requested during parsing" do
+    xml_doc = nil
+
+    File.open(xinclude_file) do |fp|
+      xml_doc = Nokogiri::XML(fp) do |conf|
+        conf.strict.dtdload.noent.nocdata.xinclude
       end
+    end
 
-      def test_xinclude_on_document_parse
-        skip_unless_libxml2("Pure Java version XInclude has a conflict with NekoDTD setting. This will be fixed later.")
-        # first test that xinclude works when requested
-        xml_doc = nil
+    refute_nil(xml_doc)
+    refute_nil(included = xml_doc.at_xpath("//included"))
+    assert_equal(included_content, included.content)
 
-        File.open(XML_XINCLUDE_FILE) do |fp|
-          xml_doc = Nokogiri::XML(fp) do |conf|
-            conf.strict.dtdload.noent.nocdata.xinclude
+    xml_doc = nil
+
+    File.open(xinclude_file) do |fp|
+      xml_doc = Nokogiri::XML(fp) do |conf|
+        conf.strict.dtdload.noent.nocdata
+      end
+    end
+
+    refute_nil(xml_doc)
+    assert_nil(xml_doc.at_xpath("//included"))
+  end
+
+  it "yields the parse options to a block" do
+    non_default_options = Nokogiri::XML::ParseOptions::NOBLANKS | Nokogiri::XML::ParseOptions::XINCLUDE
+
+    document.do_xinclude(non_default_options) do |options|
+      assert_equal(non_default_options, options.to_i)
+    end
+  end
+
+  it "defaults safe_copy to true, protecting wrapped nodes" do
+    wrapped = document.at_xpath("//xi:include", "xi" => namespace)
+    assert_equal("include", wrapped.name)
+
+    document.do_xinclude(&:noxincnode)
+
+    refute_valgrind_errors { wrapped.name }
+
+    assert_equal("include", wrapped.name)
+    refute_nil(document.at_xpath("//included"))
+  end
+
+  describe "a bare include" do
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          [true, false].each do |safe_copy|
+            it "substitutes the include#{" with NOXINCNODE" if noxincnode}#{" without safe_copy" unless safe_copy}" do
+              run_xinclude(document, noxincnode: noxincnode, safe_copy: safe_copy)
+
+              refute_nil(included = document.at_xpath("//included"))
+              assert_equal(included_content, included.content)
+              assert_nil(document.at_xpath("//xi:include", "xi" => namespace)) if noxincnode
+            end
           end
-        end
-
-        refute_nil(xml_doc)
-        refute_nil(included = xml_doc.at_xpath("//included"))
-        assert_equal(@included, included.content)
-
-        # no xinclude should happen when not requested
-        xml_doc = nil
-
-        File.open(XML_XINCLUDE_FILE) do |fp|
-          xml_doc = Nokogiri::XML(fp) do |conf|
-            conf.strict.dtdload.noent.nocdata
-          end
-        end
-
-        refute_nil(xml_doc)
-        assert_nil(xml_doc.at_xpath("//included"))
-      end
-
-      def test_xinclude_on_document_node
-        skip_unless_libxml2("Pure Java version turns XInclude on against a parser.")
-        assert_nil(@xml.at_xpath("//included"))
-        @xml.do_xinclude
-        refute_nil(included = @xml.at_xpath("//included"))
-        assert_equal(@included, included.content)
-      end
-
-      def test_xinclude_on_element_subtree
-        skip_unless_libxml2("Pure Java version turns XInclude on against a parser.")
-        assert_nil(@xml.at_xpath("//included"))
-        @xml.root.do_xinclude
-        refute_nil(included = @xml.at_xpath("//included"))
-        assert_equal(@included, included.content)
-      end
-
-      def test_do_xinclude_accepts_block
-        non_default_options = Nokogiri::XML::ParseOptions::NOBLANKS |
-          Nokogiri::XML::ParseOptions::XINCLUDE
-
-        @xml.do_xinclude(non_default_options) do |options|
-          assert_equal(non_default_options, options.to_i)
-        end
-      end
-
-      def test_include_nonexistent_throws_exception
-        skip_unless_libxml2("Pure Java version behaves differently")
-
-        @xml.at_xpath("//xi:include")["href"] = "nonexistent.xml"
-        assert_raises(Nokogiri::XML::SyntaxError) do
-          @xml.do_xinclude(&:nowarning)
         end
       end
     end
+  end
+
+  describe "a wrapped <xi:include> element" do
+    let(:wrapped) { document.at_xpath("//xi:include", "xi" => namespace) }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "survives processing#{" with NOXINCNODE" if noxincnode}" do
+            assert_equal("include", wrapped.name)
+
+            run_xinclude(document, noxincnode: noxincnode)
+
+            refute_valgrind_errors { wrapped.name }
+
+            assert_equal("include", wrapped.name)
+            refute_nil(document.at_xpath("//included"))
+          end
+        end
+      end
+    end
+  end
+
+  describe "a wrapped fallback child" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}">
+          <xi:include href="#{included_file_uri}">
+            <xi:fallback><fallback_content/></xi:fallback>
+          </xi:include>
+        </root>
+      XML
+    end
+    let(:wrapped) { document.at_xpath("//xi:fallback", "xi" => namespace) }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "survives processing#{" with NOXINCNODE" if noxincnode}" do
+            assert_equal("fallback", wrapped.name)
+
+            run_xinclude(document, noxincnode: noxincnode)
+
+            refute_valgrind_errors { wrapped.name }
+
+            assert_equal("fallback", wrapped.name)
+            refute_nil(document.at_xpath("//included"))
+          end
+        end
+      end
+    end
+  end
+
+  describe "a wrapped namespace in the subtree" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}">
+          <xi:include href="#{included_file_uri}">
+            <xi:fallback xmlns:foo="http://example.com/foo"/>
+          </xi:include>
+        </root>
+      XML
+    end
+    let(:wrapped) { document.at_xpath("//xi:fallback", "xi" => namespace).namespace_definitions.first }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "survives processing#{" with NOXINCNODE" if noxincnode}" do
+            assert_equal("foo", wrapped.prefix)
+
+            run_xinclude(document, noxincnode: noxincnode)
+
+            refute_valgrind_errors do
+              wrapped.prefix
+              wrapped.href
+            end
+
+            assert_equal("foo", wrapped.prefix)
+            assert_equal("http://example.com/foo", wrapped.href)
+          end
+        end
+      end
+    end
+  end
+
+  describe "multiple wrapped top-level includes" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}">
+          <xi:include href="#{included_file_uri}"/>
+          <xi:include href="#{included_file_uri}"/>
+        </root>
+      XML
+    end
+    let(:wrapped) { document.xpath("//xi:include", "xi" => namespace).to_a }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "preserves every wrapped include#{" with NOXINCNODE" if noxincnode}" do
+            assert_equal(2, wrapped.length)
+            wrapped.each { |include_node| assert_equal("include", include_node.name) }
+
+            run_xinclude(document, noxincnode: noxincnode)
+
+            refute_valgrind_errors { wrapped.each(&:name) }
+
+            wrapped.each { |include_node| assert_equal("include", include_node.name) }
+            assert_equal(2, document.xpath("//included").length)
+          end
+        end
+      end
+    end
+  end
+
+  describe "do_xinclude called on the include node itself" do
+    let(:wrapped) { document.at_xpath("//xi:include", "xi" => namespace) }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "survives processing#{" with NOXINCNODE" if noxincnode}" do
+            refute_nil(wrapped.parent)
+            assert_equal("include", wrapped.name)
+
+            run_xinclude(wrapped, noxincnode: noxincnode)
+
+            refute_valgrind_errors { wrapped.name }
+
+            assert_equal("include", wrapped.name)
+            refute_nil(document.at_xpath("//included"))
+          end
+        end
+      end
+    end
+  end
+
+  describe "a nested include inside a fallback" do
+    # the nested include targets a nonexistent file, so processing it would raise
+    let(:source) do
+      <<~XML
+        <root xmlns:xi="#{namespace}">
+          <xi:include href="#{included_file_uri}">
+            <xi:fallback>
+              <xi:include href="nonexistent.xml"/>
+            </xi:fallback>
+          </xi:include>
+        </root>
+      XML
+    end
+    let(:document) { Nokogiri::XML.parse(source) }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        it "does not process the nested include" do
+          refute_raises do
+            run_xinclude(document)
+          end
+
+          refute_nil(document.at_xpath("//included"))
+        end
+
+        it "does not process the nested include when parsed with XINCLUDE (safe_copy: false)" do
+          parsed = nil
+
+          refute_raises do
+            parsed = Nokogiri::XML.parse(source, &:xinclude)
+          end
+
+          refute_nil(parsed.at_xpath("//included"))
+        end
+      end
+    end
+  end
+
+  describe "an ancestor namespace used inside a fallback" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}" xmlns:foo="http://example.com/foo">
+          <xi:include href="nonexistent.xml">
+            <xi:fallback><foo:content/></xi:fallback>
+          </xi:include>
+        </root>
+      XML
+    end
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        it "reconciles the ancestor namespace in the copied subtree" do
+          run_xinclude(document, nowarning: true)
+
+          refute_nil(content = document.at_xpath("//foo:content", "foo" => "http://example.com/foo"))
+          assert_equal("http://example.com/foo", content.namespace.href)
+        end
+      end
+    end
+  end
+
+  describe "an unlinked <xi:include> node" do
+    let(:orphan) { document.at_xpath("//xi:include", "xi" => namespace).tap(&:unlink) }
+
+    [true, false].each do |safe_copy|
+      it "raises because there is no parent to receive the content#{" with safe_copy false" unless safe_copy}" do
+        assert_raises(RuntimeError) do
+          orphan.do_xinclude(safe_copy: safe_copy)
+        end
+      end
+    end
+  end
+
+  describe "an <xi:include> inside an unlinked subtree" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}">
+          <container>
+            <xi:include href="#{included_file_uri}"/>
+          </container>
+        </root>
+      XML
+    end
+    let(:container) { document.at_xpath("//container").tap(&:unlink) }
+
+    it "processes when called on the unlinked container" do
+      container.do_xinclude
+
+      refute_nil(container.at_xpath(".//included"))
+    end
+
+    it "processes when called on the include whose ancestor is unlinked" do
+      include_node = container.at_xpath("./xi:include", "xi" => namespace)
+
+      include_node.do_xinclude
+
+      refute_nil(container.at_xpath(".//included"))
+    end
+  end
+end
+
+describe "Node#do_xinclude on any backend" do
+  let(:included_file) { File.join(Nokogiri::TestBase::ASSETS_DIR, "to_be_xincluded.xml") }
+  let(:included_file_uri) { file_url_for(included_file) }
+  let(:document) do
+    Nokogiri::XML.parse(<<~XML)
+      <root xmlns:xi="http://www.w3.org/2001/XInclude">
+        <xi:include href="#{included_file_uri}"/>
+      </root>
+    XML
+  end
+
+  it "is callable on a document and returns self" do
+    assert_same(document, document.do_xinclude)
+  end
+
+  it "is callable on a node and returns self" do
+    node = document.root
+
+    assert_same(node, node.do_xinclude)
   end
 end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[CRuby] Fixed a possible use-after-free during XInclude processing via `Node#do_xinclude`. See [GHSA-wfpw-mmfh-qq69](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-wfpw-mmfh-qq69) for more information.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

Affects the CRuby implementation only. The fix is in the C extension and shared Ruby code; JRuby is not affected.
