### PR TITLE
fix: `Document#root=` rejects non-element nodes (v1.19.x)

### DIFF
--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -441,6 +441,10 @@ public class XmlDocument extends XmlNode
     }
     XmlNode newRoot = asXmlNode(context, new_root);
 
+    if (newRoot.node.getNodeType() != Node.ELEMENT_NODE) {
+      throw context.runtime.newTypeError("root must be a Nokogiri::XML::Element");
+    }
+
     IRubyObject root = root(context);
     if (root.isNil()) {
       Node newRootNode;

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -255,12 +255,6 @@ rb_xml_document_root_set(VALUE self, VALUE rb_new_root)
 
   c_document = noko_xml_document_unwrap(self);
 
-  c_current_root = xmlDocGetRootElement(c_document);
-  if (c_current_root) {
-    xmlUnlinkNode(c_current_root);
-    noko_xml_document_pin_node(c_current_root);
-  }
-
   if (!NIL_P(rb_new_root)) {
     if (!rb_obj_is_kind_of(rb_new_root, cNokogiriXmlNode)) {
       rb_raise(rb_eArgError,
@@ -270,13 +264,23 @@ rb_xml_document_root_set(VALUE self, VALUE rb_new_root)
 
     Noko_Node_Get_Struct(rb_new_root, xmlNode, c_new_root);
 
-    /* If the new root's document is not the same as the current document,
-     * then we need to dup the node in to this document. */
-    if (c_new_root->doc != c_document) {
-      c_new_root = xmlDocCopyNode(c_new_root, c_document, 1);
-      if (!c_new_root) {
-        rb_raise(rb_eRuntimeError, "Could not reparent node (xmlDocCopyNode)");
-      }
+    if (c_new_root->type != XML_ELEMENT_NODE) {
+      rb_raise(rb_eTypeError, "root must be a Nokogiri::XML::Element");
+    }
+  }
+
+  c_current_root = xmlDocGetRootElement(c_document);
+  if (c_current_root) {
+    xmlUnlinkNode(c_current_root);
+    noko_xml_document_pin_node(c_current_root);
+  }
+
+  /* If the new root's document is not the same as the current document,
+   * then we need to dup the node in to this document. */
+  if (c_new_root && c_new_root->doc != c_document) {
+    c_new_root = xmlDocCopyNode(c_new_root, c_document, 1);
+    if (!c_new_root) {
+      rb_raise(rb_eRuntimeError, "Could not reparent node (xmlDocCopyNode)");
     }
   }
 

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -1230,6 +1230,19 @@ module Nokogiri
             assert_equal("foo", target.root.content)
           end
 
+          it "raises an exception when assigning a non-element node as the root" do
+            doc = Nokogiri::XML("<root/>")
+            dtd = doc.create_internal_subset("a", nil, nil)
+            dtd.unlink
+
+            e = assert_raises(TypeError) do
+              doc.root = dtd
+            end
+            assert_equal("root must be a Nokogiri::XML::Element", e.message)
+
+            assert_equal("root", doc.root.name)
+          end
+
           it "raises an exception if passed something besides a Node" do
             doc = Nokogiri::XML::Document.parse(<<~EOF)
               <root>


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[CRuby] Fixed a possible use-after-free when `Document#root=` is assigned a non-element node. See [GHSA-wjv4-x9w8-wm3h](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-wjv4-x9w8-wm3h) for more information.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

The vulnerability affects CRuby (libxml2) only. The same input validation was added to the Java implementation for behavioral parity, so both implementations behave identically.
