### PR TITLE
fix(CRuby): avoid UAF in XML::Attr#value= (v1.19.x)

### DIFF
--- a/ext/nokogiri/xml_attr.c
+++ b/ext/nokogiri/xml_attr.c
@@ -10,37 +10,42 @@ VALUE cNokogiriXmlAttr;
  * (e.g., a HTML boolean attribute).
  */
 static VALUE
-set_value(VALUE self, VALUE content)
+noko_xml_attr_set_value(VALUE self, VALUE content)
 {
   xmlAttrPtr attr;
-  xmlChar *value;
-  xmlNode *cur;
 
   Noko_Node_Get_Struct(self, xmlAttr, attr);
 
-  if (attr->children) {
-    xmlFreeNodeList(attr->children);
+  {
+    /* Unlink and pin any wrapped children */
+    xmlNode *cur = attr->children;
+    xmlNode *next;
+
+    while (cur) {
+      next = cur->next;
+      if (cur->_private) {
+        xmlUnlinkNode(cur);
+        noko_xml_document_pin_node(cur);
+      }
+      cur = next;
+    }
   }
-  attr->children = attr->last = NULL;
 
   if (content == Qnil) {
-    return content;
-  }
-
-  value = xmlEncodeEntitiesReentrant(attr->doc, (unsigned char *)StringValueCStr(content));
-  if (xmlStrlen(value) == 0) {
-    attr->children = xmlNewDocText(attr->doc, value);
+    xmlNodeSetContent((xmlNodePtr)attr, NULL); /* Clear any remaining unwrapped children. */
   } else {
-    attr->children = xmlStringGetNodeList(attr->doc, value);
-  }
-  xmlFree(value);
+    xmlChar *value = xmlEncodeEntitiesReentrant(attr->doc, (unsigned char *)StringValueCStr(content));
 
-  for (cur = attr->children; cur; cur = cur->next) {
-    cur->parent = (xmlNode *)attr;
-    cur->doc = attr->doc;
-    if (cur->next == NULL) {
-      attr->last = cur;
+    if (xmlStrlen(value) == 0) {
+      xmlNodeSetContent((xmlNodePtr)attr, NULL); /* Clear any remaining unwrapped children. */
+
+      /* Preserve empty-string attributes as `foo=""` and not boolean `foo` */
+      attr->children = attr->last = xmlNewDocText(attr->doc, value);
+      attr->children->parent = (xmlNode *)attr;
+    } else {
+      xmlNodeSetContent((xmlNodePtr)attr, value);
     }
+    xmlFree(value);
   }
 
   return content;
@@ -53,7 +58,7 @@ set_value(VALUE self, VALUE content)
  * Create a new Attr element on the +document+ with +name+
  */
 static VALUE
-new (int argc, VALUE *argv, VALUE klass)
+noko_xml_attr__new(int argc, VALUE *argv, VALUE klass)
 {
   xmlDocPtr xml_doc;
   VALUE document;
@@ -97,7 +102,7 @@ noko_init_xml_attr(void)
    */
   cNokogiriXmlAttr = rb_define_class_under(mNokogiriXml, "Attr", cNokogiriXmlNode);
 
-  rb_define_singleton_method(cNokogiriXmlAttr, "new", new, -1);
+  rb_define_singleton_method(cNokogiriXmlAttr, "new", noko_xml_attr__new, -1);
 
-  rb_define_method(cNokogiriXmlAttr, "value=", set_value, 1);
+  rb_define_method(cNokogiriXmlAttr, "value=", noko_xml_attr_set_value, 1);
 }

--- a/test/xml/test_attr.rb
+++ b/test/xml/test_attr.rb
@@ -36,6 +36,13 @@ module Nokogiri
         assert_equal(%{street="Y&amp;ent1;"}, street.to_xml.strip)
       end
 
+      def test_set_value_returns_assigned_value
+        attr = Nokogiri::XML.parse("<root foo='bar'/>").root.attribute("foo")
+
+        assert_equal("new value", attr.public_send(:value=, "new value"))
+        assert_nil(attr.public_send(:value=, nil))
+      end
+
       def test_set_value_with_entity_string_in_html_file
         html = Nokogiri::HTML("<html><body><div foo='asdf'>")
         foo = html.at_css("div").attributes["foo"]
@@ -89,6 +96,57 @@ module Nokogiri
         assert_equal("", disabled.value)
         # but we emit a boolean attribute at serialize-time
         assert_equal(%{disabled}, disabled.to_html.strip)
+      end
+
+      def test_set_value_does_not_pin_unwrapped_children
+        skip("memory-safety test specific to libxml2") unless Nokogiri.uses_libxml?
+
+        doc = Nokogiri::XML.parse("<root foo='bar'/>")
+        attr = doc.root.attribute("foo")
+        node_cache = doc.instance_variable_get(:@node_cache)
+        node_cache_size = node_cache.length
+
+        10.times do |i|
+          attr.value = i.to_s
+        end
+
+        assert_equal(node_cache_size, node_cache.length)
+        assert_equal("9", attr.value)
+      end
+
+      def test_set_value_does_not_free_wrapped_children
+        skip("memory-safety test specific to libxml2") unless Nokogiri.uses_libxml?
+
+        attr = Nokogiri::XML.parse("<root foo='bar'/>").root.attribute("foo")
+        child = attr.child # wrap the XML::Text node
+
+        refute_valgrind_errors do
+          attr.value = "new value"
+        end
+
+        assert_equal "bar", child.to_s
+      end
+
+      def test_set_value_preserves_all_wrapped_children
+        skip("memory-safety test specific to libxml2") unless Nokogiri.uses_libxml?
+
+        doc = Nokogiri::XML.parse(<<~XML)
+          <!DOCTYPE root [<!ENTITY e "E">]>
+          <root foo="a&e;b"/>
+        XML
+        attr = doc.root.attribute("foo")
+        old_children = attr.children.to_a
+
+        assert_equal(["a", "&e;", "b"], old_children.map(&:to_s))
+
+        refute_valgrind_errors do
+          attr.value = "new value"
+          GC.start(full_mark: true)
+        end
+
+        assert_equal(["a", "&e;", "b"], old_children.map(&:to_s))
+        assert(old_children.all? { |child| child.parent.nil? })
+        assert_equal("new value", attr.value)
       end
 
       def test_unlink # aliased as :remove


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[CRuby] Fixed a possible use-after-free when setting an attribute value via `XML::Attr#value=` or `#content=`. See [GHSA-phwj-rprq-35pp](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-phwj-rprq-35pp) for more information.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

Affects the CRuby implementation only. JRuby is not affected.
