### PR TITLE
fix: avoid NPE on uninitialized XML::Node structs (v1.19.x)

### DIFF
--- a/ext/java/nokogiri/XmlAttr.java
+++ b/ext/java/nokogiri/XmlAttr.java
@@ -100,6 +100,9 @@ public class XmlAttr extends XmlNode
   public IRubyObject
   value_set(ThreadContext context, IRubyObject content)
   {
+    if (node == null) {
+      throw context.runtime.newRuntimeError("Uninitialized " + getMetaClass().getRealClass().getName() + " struct (null data pointer)");
+    }
     Attr attr = (Attr) node;
     if (content != null && !content.isNil()) {
       attr.setValue(rubyStringToString(XmlNode.encode_special_chars(context, content)));

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -181,8 +181,17 @@ int noko_io_read(void *ctx, char *buffer, int len);
 int noko_io_write(void *ctx, char *buffer, int len);
 int noko_io_close(void *ctx);
 
-#define Noko_Node_Get_Struct(obj,type,sval) ((sval) = (type*)DATA_PTR(obj))
-#define Noko_Namespace_Get_Struct(obj,type,sval) ((sval) = (type*)DATA_PTR(obj))
+static inline void *
+_noko_data_ptr(VALUE rb_object)
+{
+  void *c_data = DATA_PTR(rb_object);
+  if (c_data == NULL) {
+    rb_raise(rb_eRuntimeError, "Uninitialized %" PRIsVALUE " struct (null data pointer)", rb_obj_class(rb_object));
+  }
+  return c_data;
+}
+#define Noko_Node_Get_Struct(obj,type,sval) ((sval) = (type*)_noko_data_ptr(obj))
+#define Noko_Namespace_Get_Struct(obj,type,sval) ((sval) = (type*)_noko_data_ptr(obj))
 
 VALUE noko_xml_node_wrap(VALUE klass, xmlNodePtr node) ;
 VALUE noko_xml_node_wrap_node_set_result(xmlNodePtr node, VALUE node_set) ;

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -708,6 +708,9 @@ noko_xml_document_unwrap(VALUE rb_document)
 {
   xmlDocPtr c_document;
   TypedData_Get_Struct(rb_document, xmlDoc, &xml_doc_type, c_document);
+  if (c_document == NULL) {
+    rb_raise(rb_eRuntimeError, "Uninitialized %" PRIsVALUE " struct (null data pointer)", rb_obj_class(rb_document));
+  }
   return c_document;
 }
 

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -2286,9 +2286,7 @@ in_context(VALUE self, VALUE _str, VALUE _options)
 VALUE
 rb_xml_node_data_ptr_eh(VALUE self)
 {
-  xmlNodePtr c_node;
-  Noko_Node_Get_Struct(self, xmlNode, c_node);
-  return c_node ? Qtrue : Qfalse;
+  return DATA_PTR(self) ? Qtrue : Qfalse;
 }
 
 VALUE

--- a/test/xml/test_attr.rb
+++ b/test/xml/test_attr.rb
@@ -13,6 +13,14 @@ module Nokogiri
         end
       end
 
+      def test_value_set_on_uninitialized_attr_raises_without_crashing
+        attr = Nokogiri::XML::Attr.allocate
+
+        refute_valgrind_errors(yield_on_jruby: true) do
+          assert_raises(RuntimeError) { attr.value = "x" }
+        end
+      end
+
       def test_content=
         xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE)
         address = xml.xpath("//address")[3]

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -651,6 +651,16 @@ module Nokogiri
           assert_equal("UTF-8", xml.encoding)
         end
 
+        def test_encoding_set_on_uninitialized_document_raises_without_crashing
+          skip_unless_libxml2("on jruby a bare document has some partial functionality")
+
+          doc = Nokogiri::XML::Document.allocate
+
+          refute_valgrind_errors do
+            assert_raises(RuntimeError) { doc.encoding = "UTF-8" }
+          end
+        end
+
         def test_memory_explosion_on_invalid_xml
           doc = Nokogiri::XML("<<<")
           refute_nil(doc)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[CRuby] Fixed a null pointer dereference when methods are called on uninitialized wrapper objects (e.g. via `allocate`); these now raise instead of crashing the process. See [GHSA-9cv2-cfxc-v4v2](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-9cv2-cfxc-v4v2) for more information.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

The vulnerability affects CRuby only. The equivalent guard was added to the Java implementation for parity; both now raise rather than crash.
