### PR TITLE
fix(CRuby): use-after-free in Document#encoding= when setter raises (v1.19.x)

### DIFF
--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -319,7 +319,7 @@ public class XmlDocument extends XmlNode
   public IRubyObject
   encoding_set(IRubyObject encoding)
   {
-    this.encoding = encoding;
+    this.encoding = encoding.convertToString();
     return this;
   }
 

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -321,12 +321,13 @@ static VALUE
 set_encoding(VALUE self, VALUE encoding)
 {
   xmlDocPtr doc = noko_xml_document_unwrap(self);
+  xmlChar *new_encoding = xmlStrdup((xmlChar *)StringValueCStr(encoding));
 
   if (doc->encoding) {
     xmlFree(DISCARD_CONST_QUAL_XMLCHAR(doc->encoding));
   }
 
-  doc->encoding = xmlStrdup((xmlChar *)StringValueCStr(encoding));
+  doc->encoding = new_encoding;
 
   return encoding;
 }

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -661,6 +661,16 @@ module Nokogiri
           end
         end
 
+        def test_encoding_setter_raising
+          doc = Nokogiri::XML(%(<?xml version="1.0" encoding="UTF-8"?><root/>))
+          assert_equal("UTF-8", doc.encoding)
+
+          assert_raises(TypeError) { doc.encoding = Object.new }
+
+          result = refute_valgrind_errors(yield_on_jruby: true) { doc.encoding }
+          assert_equal("UTF-8", result)
+        end
+
         def test_memory_explosion_on_invalid_xml
           doc = Nokogiri::XML("<<<")
           refute_nil(doc)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[CRuby] Fixed a possible use-after-free when `Document#encoding=` raises an exception. See [GHSA-5v8h-3h3q-446p](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5v8h-3h3q-446p) for more information.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

The vulnerability affects CRuby (libxml2) only. The equivalent guard was added to the Java implementation for parity.
