### PR TITLE
fix(CRuby): out-of-bounds read in NodeSet#[] with large negative index (v1.19.x)

### DIFF
--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -326,16 +326,16 @@ public class XmlNodeSet extends RubyObject implements NodeList
   //  https://github.com/jruby/jruby/blame/13a3ec76d883a162b9d46c374c6e9eeea27b3261/core/src/main/java/org/jruby/RubyRange.java#L974
   //  once we upgraded the min JRuby version to >= 9.2
   private static IRubyObject
-  rangeBeginLength(ThreadContext context, IRubyObject rangeMaybe, int len, int[] begLen)
+  rangeBeginLength(ThreadContext context, IRubyObject rangeMaybe, int len, long[] begLen)
   {
     RubyRange range = (RubyRange) rangeMaybe;
-    int min = range.begin(context).convertToInteger().getIntValue();
-    int max = range.end(context).convertToInteger().getIntValue();
+    long min = range.begin(context).convertToInteger().getLongValue();
+    long max = range.end(context).convertToInteger().getLongValue();
 
     if (min < 0) {
       min += len;
       if (min < 0) {
-        throw context.runtime.newRangeError(min + ".." + (range.isExcludeEnd() ? "." : "") + max + " out of range");
+        return context.nil;
       }
     }
 
@@ -358,20 +358,22 @@ public class XmlNodeSet extends RubyObject implements NodeList
   slice(ThreadContext context, IRubyObject indexOrRange)
   {
     if (indexOrRange instanceof RubyFixnum) {
-      return slice(context, ((RubyFixnum) indexOrRange).getIntValue());
+      return slice(context, ((RubyFixnum) indexOrRange).getLongValue());
     }
     if (indexOrRange instanceof RubyRange) {
-      int[] begLen = new int[2];
-      rangeBeginLength(context, indexOrRange, nodes.length, begLen);
-      int min = begLen[0];
-      int max = begLen[1];
+      long[] begLen = new long[2];
+      if (rangeBeginLength(context, indexOrRange, nodes.length, begLen).isNil()) {
+        return context.nil;
+      }
+      long min = begLen[0];
+      long max = begLen[1];
       return subseq(context, min, max - min);
     }
     throw context.runtime.newTypeError("index must be an Integer or a Range");
   }
 
   IRubyObject
-  slice(ThreadContext context, int idx)
+  slice(ThreadContext context, long idx)
   {
     if (idx < 0) {
       idx += nodes.length;
@@ -381,15 +383,15 @@ public class XmlNodeSet extends RubyObject implements NodeList
       return context.nil;
     }
 
-    return nodes[idx];
+    return nodes[(int) idx];
   }
 
   @JRubyMethod(name = {"[]", "slice"})
   public IRubyObject
   slice(ThreadContext context, IRubyObject start, IRubyObject length)
   {
-    int s = ((RubyFixnum) start).getIntValue();
-    int l = ((RubyFixnum) length).getIntValue();
+    long s = ((RubyFixnum) start).getLongValue();
+    long l = ((RubyFixnum) length).getLongValue();
 
     if (s < 0) {
       s += nodes.length;
@@ -399,23 +401,15 @@ public class XmlNodeSet extends RubyObject implements NodeList
   }
 
   public IRubyObject
-  subseq(ThreadContext context, int start, int length)
+  subseq(ThreadContext context, long start, long length)
   {
-    if (start > nodes.length) {
+    if (start < 0 || length < 0 || start > nodes.length) {
       return context.nil;
     }
 
-    if (start < 0 || length < 0) {
-      return context.nil;
-    }
+    long end = start + Math.min(length, nodes.length - start);
 
-    if (start + length > nodes.length) {
-      length = nodes.length - start;
-    }
-
-    int to = start + length;
-
-    return newNodeSet(context.runtime, Arrays.copyOfRange(nodes, start, to));
+    return newNodeSet(context.runtime, Arrays.copyOfRange(nodes, (int) start, (int) end));
   }
 
   @JRubyMethod(name = {"to_a", "to_ary"})

--- a/ext/nokogiri/xml_node_set.c
+++ b/ext/nokogiri/xml_node_set.c
@@ -304,7 +304,7 @@ index_at(VALUE rb_self, long offset)
 
   TypedData_Get_Struct(rb_self, xmlNodeSet, &xml_node_set_type, c_self);
 
-  if (offset >= c_self->nodeNr || abs((int)offset) > c_self->nodeNr) {
+  if (offset >= c_self->nodeNr || offset < -c_self->nodeNr) {
     return Qnil;
   }
 

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -729,6 +729,36 @@ module Nokogiri
             assert_nil(node_set[-1 * (node_set.length + 1)])
           end
 
+          it "large_negative_index_truncating_to_in_range_returns_nil" do
+            node_set = xml.search("//employee")
+
+            result = refute_valgrind_errors(yield_on_jruby: true) do
+              node_set[-4294967297]
+            end
+
+            assert_nil(result)
+          end
+
+          it "slice_with_large_negative_index_truncating_to_in_range_returns_nil" do
+            node_set = xml.search("//employee")
+
+            result = refute_valgrind_errors(yield_on_jruby: true) do
+              node_set.slice(-4294967297)
+            end
+
+            assert_nil(result)
+          end
+
+          it "array_slice_with_large_negative_start_truncating_to_in_range_returns_nil" do
+            node_set = xml.search("//employee")
+            assert_nil(node_set[-4294967297, 1])
+          end
+
+          it "array_slice_with_large_negative_range_begin_truncating_to_in_range_returns_nil" do
+            node_set = xml.search("//employee")
+            assert_nil(node_set[-4294967297..-1])
+          end
+
           it "array_index" do
             employees = xml.search("//employee")
             other = xml.search("//position").first

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -719,6 +719,8 @@ module Nokogiri
         end
 
         describe "#[]" do
+          c_long_wider_than_int = [0].pack("l!").bytesize > [0].pack("i!").bytesize
+
           it "negative_index_works" do
             assert(node_set = xml.search("//employee"))
             assert_equal(node_set.last, node_set[-1])
@@ -730,6 +732,7 @@ module Nokogiri
           end
 
           it "large_negative_index_truncating_to_in_range_returns_nil" do
+            skip("long-to-int truncation only occurs where long is wider than int (LP64)") unless c_long_wider_than_int
             node_set = xml.search("//employee")
 
             result = refute_valgrind_errors(yield_on_jruby: true) do
@@ -740,6 +743,7 @@ module Nokogiri
           end
 
           it "slice_with_large_negative_index_truncating_to_in_range_returns_nil" do
+            skip("long-to-int truncation only occurs where long is wider than int (LP64)") unless c_long_wider_than_int
             node_set = xml.search("//employee")
 
             result = refute_valgrind_errors(yield_on_jruby: true) do
@@ -750,11 +754,13 @@ module Nokogiri
           end
 
           it "array_slice_with_large_negative_start_truncating_to_in_range_returns_nil" do
+            skip("long-to-int truncation only occurs where long is wider than int (LP64)") unless c_long_wider_than_int
             node_set = xml.search("//employee")
             assert_nil(node_set[-4294967297, 1])
           end
 
           it "array_slice_with_large_negative_range_begin_truncating_to_in_range_returns_nil" do
+            skip("long-to-int truncation only occurs where long is wider than int (LP64)") unless c_long_wider_than_int
             node_set = xml.search("//employee")
             assert_nil(node_set[-4294967297..-1])
           end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

[CRuby] Fixed an out-of-bounds read in `XML::NodeSet#[]` (alias `#slice`) when given a large negative index. See [GHSA-5prr-v3j2-97mh](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5prr-v3j2-97mh) for more information.

**Have you included adequate test coverage?**

Yes.

**Does this change affect the behavior of either the C or the Java implementations?**

The out-of-bounds read affects CRuby only. On JRuby it returned an incorrect node rather than being memory-unsafe; the index handling was corrected in the Java implementation as well for parity.
