### PR TITLE
Use ALLOCV_N instead of rb_gc_register_address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 ### Improved
 
 * [CRuby] The HTML5 parser now has linear performance when parsing many attributes. Previously performance was quadratic due to two hotspots, one in detecting duplicate attributes and one in constructing the libxml2 data structures. (#3393) @flavorjones
+* [CRuby] Improved XPath argument marshalling performance by using `ALLOCV_N` instead of `rb_gc_register_address`. (#3648) @jhawthorn
 
 
 ### Changed

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -221,6 +221,7 @@ Nokogiri_marshal_xpath_funcall_and_return_values(
 {
   VALUE rb_retval;
   VALUE *argv;
+  VALUE argv_handle;
   VALUE rb_node_set = Qnil;
   xmlNodeSetPtr c_node_set = NULL;
   xmlXPathObjectPtr c_xpath_object;
@@ -228,10 +229,7 @@ Nokogiri_marshal_xpath_funcall_and_return_values(
   assert(ctxt->context->doc);
   assert(DOC_RUBY_OBJECT_TEST(ctxt->context->doc));
 
-  argv = (VALUE *)ruby_xcalloc((size_t)argc, sizeof(VALUE));
-  for (int j = 0 ; j < argc ; ++j) {
-    rb_gc_register_address(&argv[j]);
-  }
+  argv = ALLOCV_N(VALUE, argv_handle, argc);
 
   for (int j = argc - 1 ; j >= 0 ; --j) {
     c_xpath_object = valuePop(ctxt);
@@ -249,10 +247,7 @@ Nokogiri_marshal_xpath_funcall_and_return_values(
                 argv
               );
 
-  for (int j = 0 ; j < argc ; ++j) {
-    rb_gc_unregister_address(&argv[j]);
-  }
-  ruby_xfree(argv);
+  ALLOCV_END(argv_handle);
 
   switch (TYPE(rb_retval)) {
     case T_FLOAT:


### PR DESCRIPTION
rb_gc_register_address is best used for long-lived objects which are going to be eternal. unregistering is O(N) over the total number of registered addresses.

ALLOCV_N allocates on the stack up to a certain size (which pins the object via conservative marking), past that it allocates a GC-managed buffer which also is conservatively marked.

This also ensures we won't leak the memory if the rb_funcall was to raise (I didn't test if that happens, but it seems like it could)