### PR TITLE
Forward port of security fixes from v1.19.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [JRuby] `Document#create_element` and `Node.new` no longer set the namespace to the document's default namespace. The namespace must be set explicitly with `namespace=` or by parenting the node. (#3457, #3463) @flavorjones
 
 
+## v1.19.4 / 2026-06-18
+
+### Security
+
+* [CRuby] (Low) Fixed a possible invalid memory read when `XML::Node#initialize_copy_with_args` is called with an argument that is not a `Node`. See [GHSA-g9g8-vgvw-g3vf](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-g9g8-vgvw-g3vf) for more information.
+* [CRuby] (Low) Fixed a possible use-after-free when an `XML::XPathContext` is used after its source document has been garbage collected. See [GHSA-p67v-3w7g-wjg7](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-p67v-3w7g-wjg7) for more information.
+* [CRuby] (Low) Fixed a possible use-after-free during XInclude processing via `Node#do_xinclude`. See [GHSA-wfpw-mmfh-qq69](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-wfpw-mmfh-qq69) for more information.
+* [CRuby] (Low) Fixed a possible use-after-free when `Document#root=` is assigned a non-element node. See [GHSA-wjv4-x9w8-wm3h](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-wjv4-x9w8-wm3h) for more information.
+* [CRuby] (Low) Fixed a possible use-after-free when setting an attribute value via `XML::Attr#value=` or `#content=`. See [GHSA-phwj-rprq-35pp](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-phwj-rprq-35pp) for more information.
+* [CRuby] (Low) Fixed a null pointer dereference when methods are called on uninitialized wrapper objects (e.g. via `allocate`); these now raise instead of crashing the process. See [GHSA-9cv2-cfxc-v4v2](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-9cv2-cfxc-v4v2) for more information.
+* [CRuby] (Low) Fixed a possible use-after-free when `Document#encoding=` raises an exception. See [GHSA-5v8h-3h3q-446p](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5v8h-3h3q-446p) for more information.
+* [CRuby] (Medium) Fixed an out-of-bounds read in `XML::NodeSet#[]` (alias `#slice`) when given a large negative index. See [GHSA-5prr-v3j2-97mh](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5prr-v3j2-97mh) for more information.
+* [JRuby] (Low) `XML::Schema` now enforces the `NONET` parse option, which Nokogiri enables by default. It was not enforced on JRuby, so a schema parsed with default options could still fetch external resources over the network, potentially enabling SSRF or XXE attacks and bypassing the mitigation for CVE-2020-26247. See [GHSA-8678-w3jw-xfc2](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-8678-w3jw-xfc2) for more information.
+
+
 ## v1.19.3 / 2026-04-27
 
 ### Fixed / Security

--- a/ext/java/nokogiri/XmlAttr.java
+++ b/ext/java/nokogiri/XmlAttr.java
@@ -105,6 +105,9 @@ public class XmlAttr extends XmlNode
   public IRubyObject
   value_set(ThreadContext context, IRubyObject content)
   {
+    if (node == null) {
+      throw context.runtime.newRuntimeError("Uninitialized " + getMetaClass().getRealClass().getName() + " struct (null data pointer)");
+    }
     Attr attr = (Attr) node;
     if (content != null && !content.isNil()) {
       attr.setValue(rubyStringToString(XmlNode.encode_special_chars(context, content)));

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -316,7 +316,7 @@ public class XmlDocument extends XmlNode
   public IRubyObject
   encoding_set(IRubyObject encoding)
   {
-    this.encoding = encoding;
+    this.encoding = encoding.convertToString();
     return this;
   }
 

--- a/ext/java/nokogiri/XmlDocument.java
+++ b/ext/java/nokogiri/XmlDocument.java
@@ -437,6 +437,10 @@ public class XmlDocument extends XmlNode
     }
     XmlNode newRoot = asXmlNode(context, new_root);
 
+    if (newRoot.node.getNodeType() != Node.ELEMENT_NODE) {
+      throw context.runtime.newTypeError("root must be a Nokogiri::XML::Element");
+    }
+
     IRubyObject root = root(context);
     if (root.isNil()) {
       Node newRootNode;

--- a/ext/java/nokogiri/XmlNodeSet.java
+++ b/ext/java/nokogiri/XmlNodeSet.java
@@ -319,17 +319,17 @@ public class XmlNodeSet extends RubyObject implements NodeList
   //  https://github.com/jruby/jruby/blame/13a3ec76d883a162b9d46c374c6e9eeea27b3261/core/src/main/java/org/jruby/RubyRange.java#L974
   //  once we upgraded the min JRuby version to >= 9.2
   private static IRubyObject
-  rangeBeginLength(ThreadContext context, IRubyObject rangeMaybe, int len, int[] begLen)
+  rangeBeginLength(ThreadContext context, IRubyObject rangeMaybe, int len, long[] begLen)
   {
     RubyRange range = (RubyRange) rangeMaybe;
     // TODO: switch to common undeprecated API when 9.4 adds 10 methods
-    int min = range.begin(context).convertToInteger().getIntValue();
-    int max = range.end(context).convertToInteger().getIntValue();
+    long min = range.begin(context).convertToInteger().getLongValue();
+    long max = range.end(context).convertToInteger().getLongValue();
 
     if (min < 0) {
       min += len;
       if (min < 0) {
-        throw context.runtime.newRangeError(min + ".." + (range.isExcludeEnd() ? "." : "") + max + " out of range");
+        return context.nil;
       }
     }
 
@@ -353,13 +353,15 @@ public class XmlNodeSet extends RubyObject implements NodeList
   {
     if (indexOrRange instanceof RubyFixnum) {
       // TODO: switch to common undeprecated API when 9.4 adds 10 methods
-      return slice(context, ((RubyFixnum) indexOrRange).getIntValue());
+      return slice(context, ((RubyFixnum) indexOrRange).getLongValue());
     }
     if (indexOrRange instanceof RubyRange) {
-      int[] begLen = new int[2];
-      rangeBeginLength(context, indexOrRange, nodes.length, begLen);
-      int min = begLen[0];
-      int max = begLen[1];
+      long[] begLen = new long[2];
+      if (rangeBeginLength(context, indexOrRange, nodes.length, begLen).isNil()) {
+        return context.nil;
+      }
+      long min = begLen[0];
+      long max = begLen[1];
       return subseq(context, min, max - min);
     }
     // TODO: switch to common undeprecated API when 9.4 adds 10 methods
@@ -367,7 +369,7 @@ public class XmlNodeSet extends RubyObject implements NodeList
   }
 
   IRubyObject
-  slice(ThreadContext context, int idx)
+  slice(ThreadContext context, long idx)
   {
     if (idx < 0) {
       idx += nodes.length;
@@ -377,7 +379,7 @@ public class XmlNodeSet extends RubyObject implements NodeList
       return context.nil;
     }
 
-    return nodes[idx];
+    return nodes[(int) idx];
   }
 
   @JRubyMethod(name = {"[]", "slice"})
@@ -385,8 +387,8 @@ public class XmlNodeSet extends RubyObject implements NodeList
   slice(ThreadContext context, IRubyObject start, IRubyObject length)
   {
     // TODO: switch to common undeprecated API when 9.4 adds 10 methods
-    int s = ((RubyFixnum) start).getIntValue();
-    int l = ((RubyFixnum) length).getIntValue();
+    long s = ((RubyFixnum) start).getLongValue();
+    long l = ((RubyFixnum) length).getLongValue();
 
     if (s < 0) {
       s += nodes.length;
@@ -396,23 +398,15 @@ public class XmlNodeSet extends RubyObject implements NodeList
   }
 
   public IRubyObject
-  subseq(ThreadContext context, int start, int length)
+  subseq(ThreadContext context, long start, long length)
   {
-    if (start > nodes.length) {
+    if (start < 0 || length < 0 || start > nodes.length) {
       return context.nil;
     }
 
-    if (start < 0 || length < 0) {
-      return context.nil;
-    }
+    long end = start + Math.min(length, nodes.length - start);
 
-    if (start + length > nodes.length) {
-      length = nodes.length - start;
-    }
-
-    int to = start + length;
-
-    return newNodeSet(context.runtime, Arrays.copyOfRange(nodes, start, to));
+    return newNodeSet(context.runtime, Arrays.copyOfRange(nodes, (int) start, (int) end));
   }
 
   @JRubyMethod(name = {"to_a", "to_ary"})

--- a/ext/java/nokogiri/XmlSchema.java
+++ b/ext/java/nokogiri/XmlSchema.java
@@ -7,6 +7,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
@@ -289,22 +292,101 @@ public class XmlSchema extends RubyObject
                     String systemId,
                     String baseURI)
     {
-      if (noNet && systemId != null && (systemId.startsWith("http://") || systemId.startsWith("ftp://"))) {
-        if (systemId.startsWith(XMLConstants.W3C_XML_SCHEMA_NS_URI)) {
-          return null; // use default resolver
-        }
+      if (noNet && !effectiveResourceIsLocal(systemId, baseURI)) {
         try {
           this.errorHandler.warning(new SAXParseException(String.format("Attempt to load network entity '%s'", systemId), null));
         } catch (SAXException ignored) {
         }
-      } else {
-        String adjusted = adjustSystemIdIfNecessary(currentDir, scriptFileName, baseURI, systemId);
-        lsInput.setPublicId(publicId);
-        lsInput.setSystemId(adjusted != null ? adjusted : systemId);
-        lsInput.setBaseURI(baseURI);
+        return new SchemaLSInput(); // an empty input blocks the fetch
       }
+
+      String adjusted = adjustSystemIdIfNecessary(currentDir, scriptFileName, baseURI, systemId);
+      lsInput.setPublicId(publicId);
+      lsInput.setSystemId(adjusted != null ? adjusted : systemId);
+      lsInput.setBaseURI(baseURI);
       return lsInput;
     }
+  }
+
+  // We enforce NONET for schema resolution by hand because Xerces-J (the JAXP implementation
+  // backing XML::Schema on JRuby) does not implement the standard JAXP property
+  // XMLConstants.ACCESS_EXTERNAL_SCHEMA — so we cannot simply restrict external access on the
+  // SchemaFactory and must classify each resolved resource in the LSResourceResolver instead.
+  //
+  // Decides whether a schema-import resource may be resolved while NONET is on: true means
+  // local (allowed), false means a network resource (blocked). A relative systemId inherits
+  // its document's base, so it is resolved against baseURI before classification — a relative
+  // import under a remote base is a network fetch even though the systemId alone looks local.
+  private static boolean
+  effectiveResourceIsLocal(String systemId, String baseURI)
+  {
+    // a null systemId means there is nothing external to resolve
+    if (systemId == null) {
+      return true;
+    }
+    try {
+      URI uri = new URI(systemId);
+      if (baseURI != null && !baseURI.isEmpty()) {
+        uri = new URI(baseURI).resolve(uri);
+      }
+      return isLocalResource(uri);
+    } catch (URISyntaxException | IllegalArgumentException e) {
+      // fail closed: an unparseable base or systemId (e.g. a raw UNC path "\\host\share") is
+      // not provably local, and the JVM's file/URL handling may still reach the network
+      return false;
+    }
+  }
+
+  // Test seam for the Ruby suite: local_resource?(systemId, baseURI = nil).
+  @JRubyMethod(meta = true, name = "local_resource?", required = 1, optional = 1, visibility = Visibility.PRIVATE)
+  public static IRubyObject
+  local_resource_eh(ThreadContext context, IRubyObject klazz, IRubyObject[] args)
+  {
+    String systemId = args[0].isNil() ? null : args[0].asJavaString();
+    String baseURI = (args.length > 1 && !args[1].isNil()) ? args[1].asJavaString() : null;
+    return context.runtime.newBoolean(effectiveResourceIsLocal(systemId, baseURI));
+  }
+
+  // Classifies an already-parsed URI. Local is a missing scheme, or the "file" scheme, with
+  // no remote authority and no UNC-shaped path. This is intentionally stricter than libxml2's
+  // xmlNoNetExternalEntityLoader, which folds a remote host (file://host/...) into a local
+  // path rather than rejecting it.
+  //
+  // TODO: a Windows drive-letter path like "C:\path" parses as scheme "c" and would be
+  // blocked; support those if we need it later.
+  private static boolean
+  isLocalResource(URI uri)
+  {
+    // only a missing scheme (a relative or absolute path) or file: can be local; any
+    // other scheme is a network resource
+    String scheme = uri.getScheme();
+    if (scheme != null && !scheme.equalsIgnoreCase("file")) {
+      return false;
+    }
+
+    // an opaque "file:" URI (e.g. file:foo, with no "//") is not a usable local path; reject
+    // it, matching libxml2, which does not resolve that form as a local file either
+    if (uri.isOpaque()) {
+      return false;
+    }
+
+    // a non-empty, non-localhost authority is a remote host — file://host/path, or the
+    // schemeless network-path form //host/path. Stricter than libxml2, which folds such a
+    // host into a (failing) local path.
+    String authority = uri.getRawAuthority();
+    if (authority != null && !authority.isEmpty() && !authority.equalsIgnoreCase("localhost")) {
+      return false;
+    }
+
+    // reject UNC-shaped paths even under an allowed authority: file:////host/share,
+    // file://localhost//host/share, and %2f/%5c-encoded variants. getPath() is decoded, so
+    // the encoded forms are normalized before this check.
+    String path = uri.getPath();
+    if (path != null && (path.startsWith("//") || path.indexOf('\\') >= 0)) {
+      return false;
+    }
+
+    return true;
   }
 
   private static class SchemaLSInput implements LSInput

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -905,7 +905,10 @@ else
     end
 
     if config_with_xml2_legacy?
-      recipe.configure_options << "--with-legacy"
+      recipe.configure_options += [
+        "--with-legacy",
+        "--with-http",
+      ]
     end
 
     if zlib_recipe

--- a/ext/nokogiri/nokogiri.c
+++ b/ext/nokogiri/nokogiri.c
@@ -203,9 +203,6 @@ Init_nokogiri(void)
   rb_const_set(mNokogiri, rb_intern("LIBXSLT_COMPILED_VERSION"), NOKOGIRI_STR_NEW2(LIBXSLT_DOTTED_VERSION));
   rb_const_set(mNokogiri, rb_intern("LIBXSLT_LOADED_VERSION"), NOKOGIRI_STR_NEW2(xsltEngineVersion));
 
-  rb_const_set(mNokogiri, rb_intern("LIBXML_ZLIB_ENABLED"),
-               xmlHasFeature(XML_WITH_ZLIB) == 1 ? Qtrue : Qfalse);
-
 #ifdef NOKOGIRI_PACKAGED_LIBRARIES
   rb_const_set(mNokogiri, rb_intern("PACKAGED_LIBRARIES"), Qtrue);
 #  ifdef NOKOGIRI_PRECOMPILED_LIBRARIES
@@ -227,6 +224,12 @@ Init_nokogiri(void)
 #else
   rb_const_set(mNokogiri, rb_intern("LIBXML_ICONV_ENABLED"), Qfalse);
 #endif
+
+  rb_const_set(mNokogiri, rb_intern("LIBXML_ZLIB_ENABLED"),
+               xmlHasFeature(XML_WITH_ZLIB) == 1 ? Qtrue : Qfalse);
+
+  rb_const_set(mNokogiri, rb_intern("LIBXML_HTTP_ENABLED"),
+               xmlHasFeature(XML_WITH_HTTP) == 1 ? Qtrue : Qfalse);
 
 #ifdef NOKOGIRI_OTHER_LIBRARY_VERSIONS
   rb_const_set(mNokogiri, rb_intern("OTHER_LIBRARY_VERSIONS"), NOKOGIRI_STR_NEW2(NOKOGIRI_OTHER_LIBRARY_VERSIONS));

--- a/ext/nokogiri/nokogiri.h
+++ b/ext/nokogiri/nokogiri.h
@@ -184,8 +184,17 @@ int noko_io_read(void *ctx, char *buffer, int len);
 int noko_io_write(void *ctx, char *buffer, int len);
 int noko_io_close(void *ctx);
 
-#define Noko_Node_Get_Struct(obj,type,sval) ((sval) = (type*)DATA_PTR(obj))
-#define Noko_Namespace_Get_Struct(obj,type,sval) ((sval) = (type*)DATA_PTR(obj))
+static inline void *
+_noko_data_ptr(VALUE rb_object)
+{
+  void *c_data = DATA_PTR(rb_object);
+  if (c_data == NULL) {
+    rb_raise(rb_eRuntimeError, "Uninitialized %" PRIsVALUE " struct (null data pointer)", rb_obj_class(rb_object));
+  }
+  return c_data;
+}
+#define Noko_Node_Get_Struct(obj,type,sval) ((sval) = (type*)_noko_data_ptr(obj))
+#define Noko_Namespace_Get_Struct(obj,type,sval) ((sval) = (type*)_noko_data_ptr(obj))
 
 VALUE noko_xml_node_wrap(VALUE klass, xmlNodePtr node) ;
 VALUE noko_xml_node_wrap_node_set_result(xmlNodePtr node, VALUE node_set) ;

--- a/ext/nokogiri/xml_attr.c
+++ b/ext/nokogiri/xml_attr.c
@@ -10,37 +10,42 @@ VALUE cNokogiriXmlAttr;
  * (e.g., a HTML boolean attribute).
  */
 static VALUE
-set_value(VALUE self, VALUE content)
+noko_xml_attr_set_value(VALUE self, VALUE content)
 {
   xmlAttrPtr attr;
-  xmlChar *value;
-  xmlNode *cur;
 
   Noko_Node_Get_Struct(self, xmlAttr, attr);
 
-  if (attr->children) {
-    xmlFreeNodeList(attr->children);
+  {
+    /* Unlink and pin any wrapped children */
+    xmlNode *cur = attr->children;
+    xmlNode *next;
+
+    while (cur) {
+      next = cur->next;
+      if (cur->_private) {
+        xmlUnlinkNode(cur);
+        noko_xml_document_pin_node(cur);
+      }
+      cur = next;
+    }
   }
-  attr->children = attr->last = NULL;
 
   if (content == Qnil) {
-    return content;
-  }
-
-  value = xmlEncodeEntitiesReentrant(attr->doc, (unsigned char *)StringValueCStr(content));
-  if (xmlStrlen(value) == 0) {
-    attr->children = xmlNewDocText(attr->doc, value);
+    xmlNodeSetContent((xmlNodePtr)attr, NULL); /* Clear any remaining unwrapped children. */
   } else {
-    attr->children = xmlStringGetNodeList(attr->doc, value);
-  }
-  xmlFree(value);
+    xmlChar *value = xmlEncodeEntitiesReentrant(attr->doc, (unsigned char *)StringValueCStr(content));
 
-  for (cur = attr->children; cur; cur = cur->next) {
-    cur->parent = (xmlNode *)attr;
-    cur->doc = attr->doc;
-    if (cur->next == NULL) {
-      attr->last = cur;
+    if (xmlStrlen(value) == 0) {
+      xmlNodeSetContent((xmlNodePtr)attr, NULL); /* Clear any remaining unwrapped children. */
+
+      /* Preserve empty-string attributes as `foo=""` and not boolean `foo` */
+      attr->children = attr->last = xmlNewDocText(attr->doc, value);
+      attr->children->parent = (xmlNode *)attr;
+    } else {
+      xmlNodeSetContent((xmlNodePtr)attr, value);
     }
+    xmlFree(value);
   }
 
   return content;
@@ -53,7 +58,7 @@ set_value(VALUE self, VALUE content)
  * Create a new Attr element on the +document+ with +name+
  */
 static VALUE
-new (int argc, VALUE *argv, VALUE klass)
+noko_xml_attr__new(int argc, VALUE *argv, VALUE klass)
 {
   xmlDocPtr xml_doc;
   VALUE document;
@@ -97,7 +102,7 @@ noko_init_xml_attr(void)
    */
   cNokogiriXmlAttr = rb_define_class_under(mNokogiriXml, "Attr", cNokogiriXmlNode);
 
-  rb_define_singleton_method(cNokogiriXmlAttr, "new", new, -1);
+  rb_define_singleton_method(cNokogiriXmlAttr, "new", noko_xml_attr__new, -1);
 
-  rb_define_method(cNokogiriXmlAttr, "value=", set_value, 1);
+  rb_define_method(cNokogiriXmlAttr, "value=", noko_xml_attr_set_value, 1);
 }

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -712,6 +712,9 @@ noko_xml_document_unwrap(VALUE rb_document)
 {
   xmlDocPtr c_document;
   TypedData_Get_Struct(rb_document, xmlDoc, &xml_doc_type, c_document);
+  if (c_document == NULL) {
+    rb_raise(rb_eRuntimeError, "Uninitialized %" PRIsVALUE " struct (null data pointer)", rb_obj_class(rb_document));
+  }
   return c_document;
 }
 

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -255,12 +255,6 @@ rb_xml_document_root_set(VALUE self, VALUE rb_new_root)
 
   c_document = noko_xml_document_unwrap(self);
 
-  c_current_root = xmlDocGetRootElement(c_document);
-  if (c_current_root) {
-    xmlUnlinkNode(c_current_root);
-    noko_xml_document_pin_node(c_current_root);
-  }
-
   if (!NIL_P(rb_new_root)) {
     if (!rb_obj_is_kind_of(rb_new_root, cNokogiriXmlNode)) {
       rb_raise(rb_eArgError,
@@ -270,13 +264,23 @@ rb_xml_document_root_set(VALUE self, VALUE rb_new_root)
 
     Noko_Node_Get_Struct(rb_new_root, xmlNode, c_new_root);
 
-    /* If the new root's document is not the same as the current document,
-     * then we need to dup the node in to this document. */
-    if (c_new_root->doc != c_document) {
-      c_new_root = xmlDocCopyNode(c_new_root, c_document, 1);
-      if (!c_new_root) {
-        rb_raise(rb_eRuntimeError, "Could not reparent node (xmlDocCopyNode)");
-      }
+    if (c_new_root->type != XML_ELEMENT_NODE) {
+      rb_raise(rb_eTypeError, "root must be a Nokogiri::XML::Element");
+    }
+  }
+
+  c_current_root = xmlDocGetRootElement(c_document);
+  if (c_current_root) {
+    xmlUnlinkNode(c_current_root);
+    noko_xml_document_pin_node(c_current_root);
+  }
+
+  /* If the new root's document is not the same as the current document,
+   * then we need to dup the node in to this document. */
+  if (c_new_root && c_new_root->doc != c_document) {
+    c_new_root = xmlDocCopyNode(c_new_root, c_document, 1);
+    if (!c_new_root) {
+      rb_raise(rb_eRuntimeError, "Could not reparent node (xmlDocCopyNode)");
     }
   }
 

--- a/ext/nokogiri/xml_document.c
+++ b/ext/nokogiri/xml_document.c
@@ -321,12 +321,13 @@ static VALUE
 set_encoding(VALUE self, VALUE encoding)
 {
   xmlDocPtr doc = noko_xml_document_unwrap(self);
+  xmlChar *new_encoding = xmlStrdup((xmlChar *)StringValueCStr(encoding));
 
   if (doc->encoding) {
     xmlFree(DISCARD_CONST_QUAL_XMLCHAR(doc->encoding));
   }
 
-  doc->encoding = xmlStrdup((xmlChar *)StringValueCStr(encoding));
+  doc->encoding = new_encoding;
 
   return encoding;
 }

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -2154,25 +2154,20 @@ compare(VALUE self, VALUE _other)
 
 
 /*
- * call-seq:
- *   process_xincludes(flags)
- *
- * Loads and substitutes all xinclude elements below the node. The
- * parser context will be initialized with +flags+.
+ * Run XInclude substitution over the tree rooted at +c_node+, with the parser context initialized
+ * from +c_flags+. Collects libxml2's structured errors and raises Nokogiri::XML::SyntaxError (or
+ * RuntimeError) on failure.
  */
-static VALUE
-noko_xml_node__process_xincludes(VALUE rb_node, VALUE rb_flags)
+static void
+_noko_xml_node_process_xinclude_subtree(xmlNodePtr c_node, int c_flags)
 {
   int status ;
-  xmlNodePtr c_node;
   VALUE rb_errors = rb_ary_new();
   libxmlStructuredErrorHandlerState handler_state;
 
-  Noko_Node_Get_Struct(rb_node, xmlNode, c_node);
-
   noko__structured_error_func_save_and_set(&handler_state, (void *)rb_errors, noko__error_array_pusher);
 
-  status = xmlXIncludeProcessTreeFlags(c_node, (int)NUM2INT(rb_flags));
+  status = xmlXIncludeProcessTreeFlags(c_node, c_flags);
 
   noko__structured_error_func_restore(&handler_state);
 
@@ -2185,8 +2180,74 @@ noko_xml_node__process_xincludes(VALUE rb_node, VALUE rb_flags)
       rb_raise(rb_eRuntimeError, "Could not perform xinclude substitution");
     }
   }
+}
+
+
+/*
+ * Whether +c_node+ is an <xi:include> element in either the 2001 or 2003 XInclude namespace.
+ */
+static int
+_noko_xml_node_xinclude_element_p(xmlNodePtr c_node)
+{
+  return c_node->type == XML_ELEMENT_NODE
+         && xmlStrEqual(c_node->name, XINCLUDE_NODE)
+         && c_node->ns != NULL
+         && (xmlStrEqual(c_node->ns->href, XINCLUDE_NS) || xmlStrEqual(c_node->ns->href, XINCLUDE_OLD_NS));
+}
+
+
+/*
+ * call-seq:
+ *   process_xincludes(flags)
+ *
+ * Loads and substitutes all xinclude elements below the node. The
+ * parser context will be initialized with +flags+.
+ */
+static VALUE
+noko_xml_node__process_xincludes(VALUE rb_node, VALUE rb_flags)
+{
+  xmlNodePtr c_node;
+
+  Noko_Node_Get_Struct(rb_node, xmlNode, c_node);
+
+  if (c_node->parent == NULL && _noko_xml_node_xinclude_element_p(c_node)) {
+    rb_raise(rb_eRuntimeError, "cannot process XInclude on an unlinked <xi:include> node");
+  }
+
+  _noko_xml_node_process_xinclude_subtree(c_node, (int)NUM2INT(rb_flags));
 
   return rb_node;
+}
+
+
+/*
+ * Process this single <xi:include> node, substituting an unwrapped copy of it in its place so
+ * that libxml2 frees the copy. This node is unlinked and pinned to the document, so any Ruby
+ * wrapper for it (or for its descendants or namespaces) keeps pointing at valid memory. The
+ * parser context is initialized with +flags+.
+ */
+static VALUE
+noko_xml_node__safe_process_xinclude(VALUE rb_node, VALUE rb_flags)
+{
+  xmlNodePtr c_node, c_copy;
+
+  Noko_Node_Get_Struct(rb_node, xmlNode, c_node);
+
+  if (c_node->parent == NULL) {
+    rb_raise(rb_eRuntimeError, "cannot process XInclude on an unlinked <xi:include> node");
+  }
+
+  c_copy = xmlDocCopyNode(c_node, c_node->doc, 1);
+  if (c_copy == NULL) {
+    rb_raise(rb_eRuntimeError, "Could not copy node for xinclude substitution");
+  }
+
+  xmlReplaceNode(c_node, c_copy);
+  noko_xml_document_pin_node(c_node);
+
+  _noko_xml_node_process_xinclude_subtree(c_copy, (int)NUM2INT(rb_flags));
+
+  return Qnil;
 }
 
 
@@ -2442,6 +2503,7 @@ noko_init_xml_node(void)
   rb_define_method(cNokogiriXmlNode, "unlink", unlink_node, 0);
 
   rb_define_protected_method(cNokogiriXmlNode, "initialize_copy_with_args", rb_xml_node_initialize_copy_with_args, 3);
+  rb_define_protected_method(cNokogiriXmlNode, "safe_process_xinclude", noko_xml_node__safe_process_xinclude, 1);
 
   rb_define_private_method(cNokogiriXmlNode, "add_child_node", add_child, 1);
   rb_define_private_method(cNokogiriXmlNode, "add_next_sibling_node", add_next_sibling, 1);

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -971,6 +971,10 @@ rb_xml_node_initialize_copy_with_args(VALUE rb_self, VALUE rb_other, VALUE rb_le
   xmlDocPtr c_new_parent_doc;
   VALUE rb_node_cache;
 
+  if (!rb_obj_is_kind_of(rb_other, cNokogiriXmlNode)) {
+    rb_raise(rb_eTypeError, "argument must be a kind of Nokogiri::XML::Node");
+  }
+
   Noko_Node_Get_Struct(rb_other, xmlNode, c_other);
   c_level = (int)NUM2INT(rb_level);
   c_new_parent_doc = noko_xml_document_unwrap(rb_new_parent_doc);

--- a/ext/nokogiri/xml_node.c
+++ b/ext/nokogiri/xml_node.c
@@ -2351,9 +2351,7 @@ in_context(VALUE self, VALUE _str, VALUE _options)
 VALUE
 rb_xml_node_data_ptr_eh(VALUE self)
 {
-  xmlNodePtr c_node;
-  Noko_Node_Get_Struct(self, xmlNode, c_node);
-  return c_node ? Qtrue : Qfalse;
+  return DATA_PTR(self) ? Qtrue : Qfalse;
 }
 
 VALUE

--- a/ext/nokogiri/xml_node_set.c
+++ b/ext/nokogiri/xml_node_set.c
@@ -304,7 +304,7 @@ index_at(VALUE rb_self, long offset)
 
   TypedData_Get_Struct(rb_self, xmlNodeSet, &xml_node_set_type, c_self);
 
-  if (offset >= c_self->nodeNr || abs((int)offset) > c_self->nodeNr) {
+  if (offset >= c_self->nodeNr || offset < -c_self->nodeNr) {
     return Qnil;
   }
 

--- a/ext/nokogiri/xml_xpath_context.c
+++ b/ext/nokogiri/xml_xpath_context.c
@@ -12,6 +12,15 @@ static const xmlChar *NOKOGIRI_BUILTIN_PREFIX = (const xmlChar *)"nokogiri-built
 static const xmlChar *NOKOGIRI_BUILTIN_URI = (const xmlChar *)"https://www.nokogiri.org/default_ns/ruby/builtins";
 
 static void
+_noko_xml_xpath_context_dmark(void *data)
+{
+  xmlXPathContextPtr c_context = data;
+  if (c_context->doc && DOC_RUBY_OBJECT_TEST(c_context->doc)) {
+    rb_gc_mark(DOC_RUBY_OBJECT(c_context->doc));
+  }
+}
+
+static void
 _noko_xml_xpath_context_dfree(void *data)
 {
   xmlXPathContextPtr c_context = data;
@@ -21,9 +30,10 @@ _noko_xml_xpath_context_dfree(void *data)
 static const rb_data_type_t _noko_xml_xpath_context_type = {
   .wrap_struct_name = "xmlXPathContext",
   .function = {
+    .dmark = _noko_xml_xpath_context_dmark,
     .dfree = _noko_xml_xpath_context_dfree,
   },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 /* find a CSS class in an HTML element's `class` attribute */

--- a/lib/nokogiri/version/info.rb
+++ b/lib/nokogiri/version/info.rb
@@ -53,6 +53,14 @@ module Nokogiri
       defined?(Nokogiri::LIBXML_ICONV_ENABLED) && Nokogiri::LIBXML_ICONV_ENABLED
     end
 
+    def libxml2_has_zlib?
+      defined?(Nokogiri::LIBXML_ZLIB_ENABLED) && Nokogiri::LIBXML_ZLIB_ENABLED
+    end
+
+    def libxml2_has_http?
+      defined?(Nokogiri::LIBXML_HTTP_ENABLED) && Nokogiri::LIBXML_HTTP_ENABLED
+    end
+
     def libxslt_has_datetime?
       defined?(Nokogiri::LIBXSLT_DATETIME_ENABLED) && Nokogiri::LIBXSLT_DATETIME_ENABLED
     end
@@ -145,6 +153,8 @@ module Nokogiri
             end
             libxml["memory_management"] = Nokogiri::LIBXML_MEMORY_MANAGEMENT
             libxml["iconv_enabled"] = libxml2_has_iconv?
+            libxml["zlib_enabled"] = libxml2_has_zlib?
+            libxml["http_enabled"] = libxml2_has_http?
             libxml["compiled"] = compiled_libxml_version.to_s
             libxml["loaded"] = loaded_libxml_version.to_s
           end

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -85,8 +85,9 @@ module Nokogiri
             read_memory(string_or_io, url, encoding, options.to_i)
           end
 
-          # do xinclude processing
-          doc.do_xinclude(options) if options.xinclude?
+          # do xinclude processing; the document is freshly parsed and unexposed to Ruby, so the
+          # defensive copy is unnecessary
+          doc.do_xinclude(options, safe_copy: false) if options.xinclude?
 
           doc
         end

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -648,16 +648,67 @@ module Nokogiri
         set_namespace(ns)
       end
 
+      XINCLUDE_NAMESPACES = {
+        "xi2001" => "http://www.w3.org/2001/XInclude",
+        "xi2003" => "http://www.w3.org/2003/XInclude",
+      }.freeze
+      private_constant :XINCLUDE_NAMESPACES
+
+      # Every top-level <xi:include> in the subtree, in either XInclude namespace, excluding
+      # includes nested inside another include's fallback (libxml2 only expands those if the
+      # parent include fails).
+      XINCLUDE_QUERY =
+        "descendant-or-self::xi2001:include[not(ancestor::xi2001:include) and not(ancestor::xi2003:include)] | " \
+        "descendant-or-self::xi2003:include[not(ancestor::xi2001:include) and not(ancestor::xi2003:include)]"
+      private_constant :XINCLUDE_QUERY
+
       ###
-      # Do xinclude substitution on the subtree below node. If given a block, a
-      # Nokogiri::XML::ParseOptions object initialized from +options+, will be
-      # passed to it, allowing more convenient modification of the parser options.
-      def do_xinclude(options = XML::ParseOptions::DEFAULT_XML)
+      # :call-seq:
+      #   do_xinclude(options = ParseOptions::DEFAULT_XML, safe_copy: true) → self
+      #   do_xinclude(options = ParseOptions::DEFAULT_XML, safe_copy: true) { |options| ... } → self
+      #
+      # Do XInclude substitution on the subtree below this node, replacing each +<xi:include>+ with
+      # the content it references.
+      #
+      # [Parameters]
+      # - +options+ (Nokogiri::XML::ParseOptions) The parser options for the substitution. (default
+      #   +ParseOptions::DEFAULT_XML+)
+      #
+      # [Optional Keyword Arguments]
+      # - +safe_copy:+ (Boolean) Operate on a defensive copy of each +<xi:include>+ element, to
+      #   prevent libxml2 from freeing memory that is bound to live Ruby objects. (default +true+)
+      #
+      #   When +true+, each +<xi:include>+ is processed on an unwrapped copy of itself, so libxml2
+      #   frees the copy while the original node is unlinked from the document and kept alive. This
+      #   prevents a use-after-free when the +<xi:include>+ node, or any of its descendants or
+      #   namespaces, has already been exposed to Ruby; as a consequence such a wrapped node ends up
+      #   detached from the document rather than removed or converted in place.
+      #
+      #   When +false+, the document is processed in place. This is faster but only safe when nothing
+      #   in the subtree has been exposed to Ruby (for example, immediately after parsing), which is
+      #   why Document.parse uses it.
+      #
+      #   This option has no effect on the pure-Java backend, which performs XInclude substitution
+      #   during parsing.
+      #
+      # [Yields]
+      #   If a block is given, a Nokogiri::XML::ParseOptions object initialized from +options+ is
+      #   yielded to it, which can be configured before substitution.
+      #
+      # [Returns] +self+ (Nokogiri::XML::Node)
+      def do_xinclude(options = XML::ParseOptions::DEFAULT_XML, safe_copy: true)
         options = Nokogiri::XML::ParseOptions.new(options) if Integer === options
         yield options if block_given?
 
-        # call c extension
-        process_xincludes(options.to_i)
+        if safe_copy && Nokogiri.uses_libxml?
+          xpath(XINCLUDE_QUERY, XINCLUDE_NAMESPACES).each do |include_node|
+            include_node.safe_process_xinclude(options.to_i)
+          end
+        else
+          process_xincludes(options.to_i)
+        end
+
+        self
       end
 
       alias_method :next, :next_sibling

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,6 +22,7 @@ require "yaml"
 require "nokogiri"
 
 require_relative "helpers/memory_debugger"
+require_relative "helpers/mock_server"
 
 if ENV["TEST_NOKOGIRI_WITH_LIBXML_RUBY"]
   #
@@ -102,6 +103,31 @@ module Nokogiri
     def file_url_for(path)
       path_with_leading_slash = path.start_with?("/") ? path : "/#{path}"
       "file://#{path_with_leading_slash}"
+    end
+
+    def assert_network_connection(scheme: "http", path: "/making-a-request", &block)
+      assert tcp_connection_attempted?(scheme:, path:, &block), "should open a network connection"
+    end
+
+    def refute_network_connection(scheme: "http", path: "/making-a-request", &block)
+      refute tcp_connection_attempted?(scheme:, path:, &block), "should not open a network connection"
+    end
+
+    def ignoring_syntax_errors
+      yield
+    rescue Nokogiri::XML::SyntaxError
+    end
+
+    def tcp_connection_attempted?(scheme: "http", path: "/making-a-request")
+      flunk("MockServer is not supported on this platform; the calling test must skip explicitly") unless MockServer.supported?
+
+      listener = MockServer.listener_class.new
+      begin
+        yield("#{scheme}://127.0.0.1:#{listener.port}#{path}")
+      ensure
+        connections = listener.stop
+      end
+      connections.positive?
     end
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -98,6 +98,11 @@ module Nokogiri
     def truffleruby_system_libraries?
       RUBY_ENGINE == "truffleruby" && !Nokogiri::PACKAGED_LIBRARIES
     end
+
+    def file_url_for(path)
+      path_with_leading_slash = path.start_with?("/") ? path : "/#{path}"
+      "file://#{path_with_leading_slash}"
+    end
   end
 
   class TestBenchmark < Minitest::BenchSpec

--- a/test/helpers/mock_server.rb
+++ b/test/helpers/mock_server.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "socket"
+
+require_relative "memory_debugger"
+
+module Nokogiri
+  module MockServer
+    def self.listener_class
+      Nokogiri.jruby? ? ThreadListener : ProcessListener
+    end
+
+    def self.supported?
+      listener_class.supported?
+    end
+
+    # Accepts and immediately closes TCP connections on an ephemeral port,
+    # counting them. Runs in a forked child process because on CRuby a parse
+    # that accesses the network blocks in a C call that holds the GVL, so an
+    # in-process listener thread would be starved and could never accept the
+    # connection. The child writes one byte per connection to a pipe, and the
+    # parent counts the bytes after reaping the child.
+    class ProcessListener
+      # Process.fork rules out platforms like Windows, and we also avoid
+      # forking under memory debuggers, where children are traced too.
+      def self.supported?
+        Process.respond_to?(:fork) && !MemoryDebugger.active?
+      end
+
+      attr_reader :port
+
+      def initialize
+        server = TCPServer.new("127.0.0.1", 0)
+        @port = server.addr[1]
+        @reader, writer = IO.pipe
+        @pid = Process.fork do
+          @reader.close
+          writer.sync = true
+          loop do
+            client = server.accept
+            writer.write(".")
+            client.close
+          end
+        end
+        writer.close
+        server.close
+      end
+
+      def stop
+        Process.kill(:TERM, @pid)
+        Process.wait(@pid)
+        @reader.read.length
+      ensure
+        @reader.close
+      end
+    end
+
+    # Same API as ProcessListener, but runs in an in-process thread. JRuby has
+    # no GVL, so the listener thread can accept connections while a parse is
+    # blocked, and avoiding process spawn keeps the tests fast on the JVM.
+    class ThreadListener
+      def self.supported?
+        true
+      end
+
+      attr_reader :port
+
+      def initialize
+        @server = TCPServer.new("127.0.0.1", 0)
+        @port = @server.addr[1]
+        @connections = 0
+        @thread = Thread.new do
+          loop do
+            client = @server.accept
+            @connections += 1
+            client.close
+          end
+        rescue IOError, Errno::EBADF
+        end
+      end
+
+      def stop
+        @server.close
+        @thread.join
+        @connections
+      end
+    end
+  end
+end

--- a/test/test_memory_usage.rb
+++ b/test/test_memory_usage.rb
@@ -255,6 +255,14 @@ class TestMemoryUsage < Nokogiri::TestCase
       end
     end
 
+    it "XPathContext keeps its document alive" do
+      ctx = Nokogiri::XML::XPathContext.new(Nokogiri::XML::Document.parse("<root><x/></root>"))
+
+      memwatch(__method__) do
+        ctx.evaluate("//x").length
+      end
+    end
+
     it "test_leaking_dtd_nodes_after_internal_subset_removal" do
       # see https://github.com/sparklemotion/nokogiri/issues/1784
       memwatch(__method__) do

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -69,6 +69,8 @@ module TestVersionInfoTests
     assert_equal("#{major}.#{minor}.#{bug}", Nokogiri::VERSION_INFO["libxml"]["loaded"])
 
     assert(version_info["libxml"].key?("iconv_enabled"))
+    assert(version_info["libxml"].key?("zlib_enabled"))
+    assert(version_info["libxml"].key?("http_enabled"))
     assert(version_info["libxslt"].key?("datetime_enabled"))
   end
 

--- a/test/xml/test_attr.rb
+++ b/test/xml/test_attr.rb
@@ -36,6 +36,13 @@ module Nokogiri
         assert_equal(%{street="Y&amp;ent1;"}, street.to_xml.strip)
       end
 
+      def test_set_value_returns_assigned_value
+        attr = Nokogiri::XML.parse("<root foo='bar'/>").root.attribute("foo")
+
+        assert_equal("new value", attr.public_send(:value=, "new value"))
+        assert_nil(attr.public_send(:value=, nil))
+      end
+
       def test_set_value_with_entity_string_in_html_file
         html = Nokogiri::HTML("<html><body><div foo='asdf'>")
         foo = html.at_css("div").attributes["foo"]
@@ -89,6 +96,57 @@ module Nokogiri
         assert_equal("", disabled.value)
         # but we emit a boolean attribute at serialize-time
         assert_equal(%{disabled}, disabled.to_html.strip)
+      end
+
+      def test_set_value_does_not_pin_unwrapped_children
+        skip("memory-safety test specific to libxml2") unless Nokogiri.uses_libxml?
+
+        doc = Nokogiri::XML.parse("<root foo='bar'/>")
+        attr = doc.root.attribute("foo")
+        node_cache = doc.instance_variable_get(:@node_cache)
+        node_cache_size = node_cache.length
+
+        10.times do |i|
+          attr.value = i.to_s
+        end
+
+        assert_equal(node_cache_size, node_cache.length)
+        assert_equal("9", attr.value)
+      end
+
+      def test_set_value_does_not_free_wrapped_children
+        skip("memory-safety test specific to libxml2") unless Nokogiri.uses_libxml?
+
+        attr = Nokogiri::XML.parse("<root foo='bar'/>").root.attribute("foo")
+        child = attr.child # wrap the XML::Text node
+
+        refute_valgrind_errors do
+          attr.value = "new value"
+        end
+
+        assert_equal "bar", child.to_s
+      end
+
+      def test_set_value_preserves_all_wrapped_children
+        skip("memory-safety test specific to libxml2") unless Nokogiri.uses_libxml?
+
+        doc = Nokogiri::XML.parse(<<~XML)
+          <!DOCTYPE root [<!ENTITY e "E">]>
+          <root foo="a&e;b"/>
+        XML
+        attr = doc.root.attribute("foo")
+        old_children = attr.children.to_a
+
+        assert_equal(["a", "&e;", "b"], old_children.map(&:to_s))
+
+        refute_valgrind_errors do
+          attr.value = "new value"
+          GC.start(full_mark: true)
+        end
+
+        assert_equal(["a", "&e;", "b"], old_children.map(&:to_s))
+        assert(old_children.all? { |child| child.parent.nil? })
+        assert_equal("new value", attr.value)
       end
 
       def test_unlink # aliased as :remove

--- a/test/xml/test_attr.rb
+++ b/test/xml/test_attr.rb
@@ -13,6 +13,14 @@ module Nokogiri
         end
       end
 
+      def test_value_set_on_uninitialized_attr_raises_without_crashing
+        attr = Nokogiri::XML::Attr.allocate
+
+        refute_valgrind_errors(yield_on_jruby: true) do
+          assert_raises(RuntimeError) { attr.value = "x" }
+        end
+      end
+
       def test_content=
         xml = Nokogiri::XML.parse(File.read(XML_FILE), XML_FILE)
         address = xml.xpath("//address")[3]

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -661,6 +661,16 @@ module Nokogiri
           end
         end
 
+        def test_encoding_setter_raising
+          doc = Nokogiri::XML(%(<?xml version="1.0" encoding="UTF-8"?><root/>))
+          assert_equal("UTF-8", doc.encoding)
+
+          assert_raises(TypeError) { doc.encoding = Object.new }
+
+          result = refute_valgrind_errors(yield_on_jruby: true) { doc.encoding }
+          assert_equal("UTF-8", result)
+        end
+
         def test_memory_explosion_on_invalid_xml
           doc = Nokogiri::XML("<<<")
           refute_nil(doc)

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -1230,6 +1230,19 @@ module Nokogiri
             assert_equal("foo", target.root.content)
           end
 
+          it "raises an exception when assigning a non-element node as the root" do
+            doc = Nokogiri::XML("<root/>")
+            dtd = doc.create_internal_subset("a", nil, nil)
+            dtd.unlink
+
+            e = assert_raises(TypeError) do
+              doc.root = dtd
+            end
+            assert_equal("root must be a Nokogiri::XML::Element", e.message)
+
+            assert_equal("root", doc.root.name)
+          end
+
           it "raises an exception if passed something besides a Node" do
             doc = Nokogiri::XML::Document.parse(<<~EOF)
               <root>

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -651,6 +651,16 @@ module Nokogiri
           assert_equal("UTF-8", xml.encoding)
         end
 
+        def test_encoding_set_on_uninitialized_document_raises_without_crashing
+          skip_unless_libxml2("on jruby a bare document has some partial functionality")
+
+          doc = Nokogiri::XML::Document.allocate
+
+          refute_valgrind_errors do
+            assert_raises(RuntimeError) { doc.encoding = "UTF-8" }
+          end
+        end
+
         def test_memory_explosion_on_invalid_xml
           doc = Nokogiri::XML("<<<")
           refute_nil(doc)

--- a/test/xml/test_entity_reference.rb
+++ b/test/xml/test_entity_reference.rb
@@ -239,42 +239,24 @@ module Nokogiri
       end
 
       test_relative_and_absolute_path :test_document_dtd_loading_with_nonet do
-        # Make sure that we don't include remote entities unless NOENT is set to true
-        xml = <<~XML
-          <?xml version="1.0" encoding="UTF-8" ?>
-          <!DOCTYPE document SYSTEM "http://foo.bar.com/">
-          <document>
-            <body>&bar;</body>
-          </document>
-        XML
-        doc = @parser.parse(xml, path) do |cfg|
-          cfg.default_xml
-          cfg.dtdload
-        end
+        skip("MockServer not supported") unless Nokogiri::MockServer.supported?
 
-        assert_kind_of Nokogiri::XML::EntityReference, doc.xpath("//body").first.children.first
+        # Make sure that we don't load remote DTDs unless NONET is turned off
+        refute_network_connection do |url|
+          xml = <<~XML
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <!DOCTYPE document SYSTEM "#{url}">
+            <document>
+              <body>&bar;</body>
+            </document>
+          XML
+          doc = @parser.parse(xml, path) do |cfg|
+            cfg.default_xml
+            cfg.dtdload
+          end
 
-        expected = if Nokogiri.uses_libxml?("~> 2.14")
-          [
-            "2:49: ERROR: failed to load \"http://foo.bar.com/\": Attempt to load network entity",
-            # "attempt to load network entity" removed in gnome/libxml2@1b1e8b3c
-            "4:14: ERROR: Entity 'bar' not defined",
-          ]
-        elsif Nokogiri.uses_libxml?("~> 2.13.0")
-          [
-            "2:49: WARNING: failed to load \"http://foo.bar.com/\": Attempt to load network entity",
-            "ERROR: Attempt to load network entity: http://foo.bar.com/",
-            "4:14: ERROR: Entity 'bar' not defined",
-          ]
-        elsif Nokogiri.uses_libxml?
-          [
-            "ERROR: Attempt to load network entity http://foo.bar.com/",
-            "4:14: ERROR: Entity 'bar' not defined",
-          ]
-        else # jruby
-          ["Attempt to load network entity http://foo.bar.com/"]
+          assert_kind_of Nokogiri::XML::EntityReference, doc.xpath("//body").first.children.first
         end
-        assert_equal(expected, doc.errors.map(&:to_s))
       end
       # TODO: can we retrieve a resource pointing to localhost when NONET is set to true ?
     end
@@ -311,33 +293,37 @@ module Nokogiri
       end
 
       test_relative_and_absolute_path :test_more_sax_entity_reference do
+        skip("MockServer not supported") unless Nokogiri::MockServer.supported?
+
         # Make sure that we don't include entity references unless NOENT is set to true
-        xml = <<~XML
-          <?xml version="1.0" encoding="UTF-8" ?>
-          <!DOCTYPE document SYSTEM "http://foo.bar.com/">
-          <document>
-            <body>&bar;</body>
-          </document>
-        XML
-        @parser.parse(xml)
+        refute_network_connection do |url|
+          xml = <<~XML
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <!DOCTYPE document SYSTEM "#{url}">
+            <document>
+              <body>&bar;</body>
+            </document>
+          XML
+          @parser.parse(xml)
 
-        actual = if Nokogiri.uses_libxml?(">= 2.13.0") # gnome/libxml2@b717abdd
-          @parser.document.warnings
-        else
-          @parser.document.errors
+          actual = if Nokogiri.uses_libxml?(">= 2.13.0") # gnome/libxml2@b717abdd
+            @parser.document.warnings
+          else
+            @parser.document.errors
+          end
+
+          refute_nil(actual)
+          refute_empty(actual)
+
+          actual = actual.map { |e| e.to_s.strip }
+          expected = if truffleruby_system_libraries?
+            ["error_func: %s"]
+          else
+            ["Entity 'bar' not defined"]
+          end
+
+          assert_equal(expected, actual)
         end
-
-        refute_nil(actual)
-        refute_empty(actual)
-
-        actual = actual.map { |e| e.to_s.strip }
-        expected = if truffleruby_system_libraries?
-          ["error_func: %s"]
-        else
-          ["Entity 'bar' not defined"]
-        end
-
-        assert_equal(expected, actual)
       end
     end
 

--- a/test/xml/test_node.rb
+++ b/test/xml/test_node.rb
@@ -263,6 +263,15 @@ module Nokogiri
           assert_instance_of(subclass, node)
         end
 
+        def test_initialize_copy_with_args_rejects_non_node_source
+          doc = XML::Document.parse("<root/>")
+          namespace = doc.root.add_namespace_definition("x", "u")
+
+          assert_raises(TypeError) do
+            XML::Node.allocate.send(:initialize_copy_with_args, namespace, 1, doc)
+          end
+        end
+
         def test_search_direct_children_of_node
           xml = <<~XML
             <root>

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -729,6 +729,36 @@ module Nokogiri
             assert_nil(node_set[-1 * (node_set.length + 1)])
           end
 
+          it "large_negative_index_truncating_to_in_range_returns_nil" do
+            node_set = xml.search("//employee")
+
+            result = refute_valgrind_errors(yield_on_jruby: true) do
+              node_set[-4294967297]
+            end
+
+            assert_nil(result)
+          end
+
+          it "slice_with_large_negative_index_truncating_to_in_range_returns_nil" do
+            node_set = xml.search("//employee")
+
+            result = refute_valgrind_errors(yield_on_jruby: true) do
+              node_set.slice(-4294967297)
+            end
+
+            assert_nil(result)
+          end
+
+          it "array_slice_with_large_negative_start_truncating_to_in_range_returns_nil" do
+            node_set = xml.search("//employee")
+            assert_nil(node_set[-4294967297, 1])
+          end
+
+          it "array_slice_with_large_negative_range_begin_truncating_to_in_range_returns_nil" do
+            node_set = xml.search("//employee")
+            assert_nil(node_set[-4294967297..-1])
+          end
+
           it "array_index" do
             employees = xml.search("//employee")
             other = xml.search("//position").first

--- a/test/xml/test_node_set.rb
+++ b/test/xml/test_node_set.rb
@@ -719,6 +719,8 @@ module Nokogiri
         end
 
         describe "#[]" do
+          c_long_wider_than_int = [0].pack("l!").bytesize > [0].pack("i!").bytesize
+
           it "negative_index_works" do
             assert(node_set = xml.search("//employee"))
             assert_equal(node_set.last, node_set[-1])
@@ -730,6 +732,7 @@ module Nokogiri
           end
 
           it "large_negative_index_truncating_to_in_range_returns_nil" do
+            skip("long-to-int truncation only occurs where long is wider than int (LP64)") unless c_long_wider_than_int
             node_set = xml.search("//employee")
 
             result = refute_valgrind_errors(yield_on_jruby: true) do
@@ -740,6 +743,7 @@ module Nokogiri
           end
 
           it "slice_with_large_negative_index_truncating_to_in_range_returns_nil" do
+            skip("long-to-int truncation only occurs where long is wider than int (LP64)") unless c_long_wider_than_int
             node_set = xml.search("//employee")
 
             result = refute_valgrind_errors(yield_on_jruby: true) do
@@ -750,11 +754,13 @@ module Nokogiri
           end
 
           it "array_slice_with_large_negative_start_truncating_to_in_range_returns_nil" do
+            skip("long-to-int truncation only occurs where long is wider than int (LP64)") unless c_long_wider_than_int
             node_set = xml.search("//employee")
             assert_nil(node_set[-4294967297, 1])
           end
 
           it "array_slice_with_large_negative_range_begin_truncating_to_in_range_returns_nil" do
+            skip("long-to-int truncation only occurs where long is wider than int (LP64)") unless c_long_wider_than_int
             node_set = xml.search("//employee")
             assert_nil(node_set[-4294967297..-1])
           end

--- a/test/xml/test_schema.rb
+++ b/test/xml/test_schema.rb
@@ -354,131 +354,159 @@ class TestNokogiriXMLSchema < Nokogiri::TestCase
       assert(child.to_s) # This will raise a valgrind error if the node was freed
     end
 
+    # https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m
+    # https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-8678-w3jw-xfc2
     describe "CVE-2020-26247" do
-      # https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m
-      let(:schema) do
-        <<~EOSCHEMA
-          <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-            <xs:import namespace="test" schemaLocation="http://localhost:8000/making-a-request"/>
-          </xs:schema>
-        EOSCHEMA
-      end
+      before { skip("MockServer not supported") unless Nokogiri::MockServer.supported? }
 
-      if Nokogiri.uses_libxml?
-        describe "with default parse options" do
-          it "XML::Schema parsing does not attempt to access external DTDs" do
-            doc = Nokogiri::XML::Schema.new(schema)
-            errors = doc.errors.map(&:to_s)
-            refute_empty(
-              errors.grep(/Attempt to load network entity/),
-              "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_empty(
-              errors.grep(/failed to load HTTP resource/),
-              "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
-            )
-            assert_empty(
-              errors.grep(/failed to load external entity/),
-              "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
-            )
-          end
-
-          it "XML::Schema parsing of memory does not attempt to access external DTDs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema)
-            errors = doc.errors.map(&:to_s)
-            refute_empty(
-              errors.grep(/Attempt to load network entity/),
-              "Should see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_empty(
-              errors.grep(/failed to load HTTP resource/),
-              "Should not see xmlIO.c:xmlCheckHTTPInput() raising 'failed to load HTTP resource'",
-            )
-            assert_empty(
-              errors.grep(/failed to load external entity/),
-              "Should not see xmlIO.c:xmlDefaultExternalEntityLoader() raising 'failed to load external entity'",
-            )
-          end
-        end
-
-        describe "with NONET turned off" do
-          it "XML::Schema parsing attempts to access external DTDs" do
-            doc = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions.new.nononet)
-            errors = doc.errors.map(&:to_s)
-            assert_empty(
-              errors.grep(/Attempt to load network entity/),
-              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_equal(1, errors.grep(%r{failed to load.*http://localhost:8000/making-a-request}).length)
-          end
-
-          it "XML::Schema parsing attempts to access external DTDs with kwargs" do
-            doc = Nokogiri::XML::Schema.new(schema, parse_options: Nokogiri::XML::ParseOptions.new.nononet)
-            errors = doc.errors.map(&:to_s)
-            assert_empty(
-              errors.grep(/Attempt to load network entity/),
-              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_equal(1, errors.grep(%r{failed to load.*http://localhost:8000/making-a-request}).length)
-          end
-
-          it "XML::Schema parsing of memory attempts to access external DTDs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema, Nokogiri::XML::ParseOptions.new.nononet)
-            errors = doc.errors.map(&:to_s)
-            assert_empty(
-              errors.grep(/ERROR: Attempt to load network entity/),
-              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_equal(1, errors.grep(%r{failed to load.*http://localhost:8000/making-a-request}).length)
-          end
-
-          it "XML::Schema parsing of memory attempts to access external DTDs with kwargs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema, parse_options: Nokogiri::XML::ParseOptions.new.nononet)
-            errors = doc.errors.map(&:to_s)
-            assert_empty(
-              errors.grep(/ERROR: Attempt to load network entity/),
-              "Should not see xmlIO.c:xmlNoNetExternalEntityLoader() raising XML_IO_NETWORK_ATTEMPT",
-            )
-            assert_equal(1, errors.grep(%r{failed to load.*http://localhost:8000/making-a-request}).length)
-          end
-        end
-      end
+      network_schemata = %w[ http HTTP https HTTPS ftp FTP jar:http jar:https telnet ]
 
       if Nokogiri.jruby?
-        describe "with default parse options" do
-          it "XML::Schema parsing does not attempt to access external DTDs" do
-            doc = Nokogiri::XML::Schema.new(schema)
-            assert_equal 1, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
+        unsupported_schemata = %w[ telnet ]
+        supported_schemata = network_schemata - unsupported_schemata
+      else
+        supported_schemata = []
+        supported_schemata << "http" if Nokogiri::LIBXML_HTTP_ENABLED
+        supported_schemata += %w[ ftp ] if Nokogiri.uses_libxml?("< 2.10.0")
+        unsupported_schemata = network_schemata - supported_schemata
+      end
+
+      schemata_matrix = supported_schemata.map { |s| [s, true] } + unsupported_schemata.map { |s| [s, false] }
+      schemata_matrix.each do |scheme, network_supported|
+        describe "external resource via #{network_supported ? "supported" : "unsupported"} scheme #{scheme.inspect}" do
+          describe "with default parse options" do
+            it "XML::Schema.new does not hit the network" do
+              refute_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                Nokogiri::XML::Schema.new(schema_importing(url))
+              end
+            end
+
+            it "XML::Schema.read_memory does not hit the network" do
+              refute_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                Nokogiri::XML::Schema.read_memory(schema_importing(url))
+              end
+            end
           end
 
-          it "XML::Schema parsing of memory does not attempt to access external DTDs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema)
-            assert_equal 1, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-          end
-        end
+          describe "with NONET turned off" do
+            if network_supported
+              it "XML::Schema.new hits the network" do
+                assert_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  ignoring_syntax_errors do # it's OS-dependent whether the mock TCP server causes a syntax error
+                    Nokogiri::XML::Schema.new(schema_importing(url), Nokogiri::XML::ParseOptions.new.nononet)
+                  end
+                end
+              end
 
-        describe "with NONET turned off" do
-          it "XML::Schema parsing attempts to access external DTDs" do
-            doc = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions.new.nononet)
-            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-          end
+              it "XML::Schema.new with kwargs hits the network" do
+                assert_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  ignoring_syntax_errors do # it's OS-dependent whether the mock TCP server causes a syntax error
+                    Nokogiri::XML::Schema.new(schema_importing(url), parse_options: Nokogiri::XML::ParseOptions.new.nononet)
+                  end
+                end
+              end
 
-          it "XML::Schema parsing attempts to access external DTDs with kwargs" do
-            doc = Nokogiri::XML::Schema.new(schema, parse_options: Nokogiri::XML::ParseOptions.new.nononet)
-            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-          end
+              it "XML::Schema.read_memory hits the network" do
+                assert_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  ignoring_syntax_errors do # it's OS-dependent whether the mock TCP server causes a syntax error
+                    Nokogiri::XML::Schema.read_memory(schema_importing(url), Nokogiri::XML::ParseOptions.new.nononet)
+                  end
+                end
+              end
 
-          it "XML::Schema parsing of memory attempts to access external DTDs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema, Nokogiri::XML::ParseOptions.new.nononet)
-            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
-          end
+              it "XML::Schema.read_memory with kwargs hits the network" do
+                assert_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  ignoring_syntax_errors do # it's OS-dependent whether the mock TCP server causes a syntax error
+                    Nokogiri::XML::Schema.read_memory(schema_importing(url), parse_options: Nokogiri::XML::ParseOptions.new.nononet)
+                  end
+                end
+              end
+            else
+              it "XML::Schema.new does not hit the network" do
+                refute_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  Nokogiri::XML::Schema.new(schema_importing(url), Nokogiri::XML::ParseOptions.new.nononet)
+                end
+              end
 
-          it "XML::Schema parsing of memory attempts to access external DTDs with kwargs" do
-            doc = Nokogiri::XML::Schema.read_memory(schema, parse_options: Nokogiri::XML::ParseOptions.new.nononet)
-            assert_equal 0, doc.errors.map(&:to_s).grep(/WARNING: Attempt to load network entity/).length
+              it "XML::Schema.read_memory does not hit the network" do
+                refute_network_connection(scheme:, path: schema_location_path(scheme)) do |url|
+                  Nokogiri::XML::Schema.read_memory(schema_importing(url), Nokogiri::XML::ParseOptions.new.nononet)
+                end
+              end
+            end
           end
         end
       end
     end
+
+    describe "relative import against a remote document base (default parse options)" do
+      before { skip("MockServer not supported") unless Nokogiri::MockServer.supported? }
+
+      it "XML::Schema.from_document does not hit the network" do
+        refute_network_connection(path: "/import.xsd") do |url|
+          base = url.delete_suffix("import.xsd")
+          doc = Nokogiri::XML(schema_importing("import.xsd"), base)
+          Nokogiri::XML::Schema.from_document(doc)
+        end
+      end
+    end
+
+    if Nokogiri.jruby?
+      describe "local resource" do
+        {
+          nil => true,
+          "schema.xsd" => true,
+          "/absolute/schema.xsd" => true,
+          "file:/path/schema.xsd" => true,
+          "file:///path/schema.xsd" => true,
+          "file://localhost/path/schema.xsd" => true,
+          "file:schema.xsd" => false,
+          "http://example.com/schema.xsd" => false,
+          "https://example.com/schema.xsd" => false,
+          "ftp://example.com/schema.xsd" => false,
+          "file://example.com/share/schema.xsd" => false,
+          "file:////host/share/schema.xsd" => false,
+          "file://localhost//host/share/schema.xsd" => false,
+          "//host/share/schema.xsd" => false,
+          "file:/%2f%2fhost/share/schema.xsd" => false,
+          "file:/%5c%5chost/share/schema.xsd" => false,
+          "\\\\host\\share\\schema.xsd" => false,
+          "C:/path/schema.xsd" => false,
+          "jar:file:/archive.jar!/schema.xsd" => false,
+        }.each do |system_id, expected|
+          it "#{system_id.inspect} is #{expected ? "allowed" : "blocked"}" do
+            assert_equal(expected, Nokogiri::XML::Schema.send(:local_resource?, system_id))
+          end
+        end
+      end
+
+      describe "local resource resolved against a base URI" do
+        {
+          ["import.xsd", "http://example.com/"] => false,
+          ["import.xsd", "file:///srv/schemas/"] => true,
+          ["file:///etc/passwd.xsd", "http://example.com/"] => true,
+          ["//host/share.xsd", "file:base.xsd"] => false,
+          ["//host/share.xsd", "file:///srv/"] => false,
+        }.each do |(system_id, base), expected|
+          it "#{system_id.inspect} against #{base.inspect} is #{expected ? "allowed" : "blocked"}" do
+            assert_equal(expected, Nokogiri::XML::Schema.send(:local_resource?, system_id, base))
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def schema_importing(url)
+    <<~EOSCHEMA
+      <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:import namespace="test" schemaLocation="#{url}"/>
+      </xs:schema>
+    EOSCHEMA
+  end
+
+  def schema_location_path(scheme)
+    scheme.match?(/\Ajar:/i) ? "/schema.jar!/import.xsd" : "/import.xsd"
   end
 end

--- a/test/xml/test_xinclude.rb
+++ b/test/xml/test_xinclude.rb
@@ -2,76 +2,371 @@
 
 require "helper"
 
-module Nokogiri
-  module XML
-    class TestXInclude < Nokogiri::TestCase
-      def setup
-        super
-        @xml = Nokogiri::XML.parse(File.read(XML_XINCLUDE_FILE), XML_XINCLUDE_FILE)
-        @included = "this snippet is to be included from xinclude.xml"
+# Namespace axis values for the matrix. These are file-level locals (not `let`s) because the
+# matrix loops below run at class-definition time, before `let` methods exist.
+xi_2001 = "http://www.w3.org/2001/XInclude"
+xi_2003 = "http://www.w3.org/2003/XInclude"
+namespaces = { "2001" => xi_2001, "2003" => xi_2003 }
+
+describe "xinclude processing" do
+  let(:namespace) { xi_2001 }
+  let(:xinclude_file) { Nokogiri::TestBase::XML_XINCLUDE_FILE }
+  let(:included_file) { File.join(Nokogiri::TestBase::ASSETS_DIR, "to_be_xincluded.xml") }
+  let(:included_file_uri) { file_url_for(included_file) }
+  let(:included_content) { "this snippet is to be included from xinclude.xml" }
+  let(:document) do
+    Nokogiri::XML.parse(<<~XML)
+      <root xmlns:xi="#{namespace}">
+        <xi:include href="#{included_file_uri}"/>
+      </root>
+    XML
+  end
+
+  before do
+    skip_unless_libxml2("XInclude behavior and use-after-free protection are specific to the libxml2 C extension")
+  end
+
+  def run_xinclude(target, noxincnode: false, safe_copy: true, nowarning: false)
+    target.do_xinclude(safe_copy: safe_copy) do |options|
+      options.noxincnode if noxincnode
+      options.nowarning if nowarning
+    end
+  end
+
+  it "performs XInclude substitution only when requested during parsing" do
+    xml_doc = nil
+
+    File.open(xinclude_file) do |fp|
+      xml_doc = Nokogiri::XML(fp) do |conf|
+        conf.strict.dtdload.noent.nocdata.xinclude
       end
+    end
 
-      def test_xinclude_on_document_parse
-        skip_unless_libxml2("Pure Java version XInclude has a conflict with NekoDTD setting. This will be fixed later.")
-        # first test that xinclude works when requested
-        xml_doc = nil
+    refute_nil(xml_doc)
+    refute_nil(included = xml_doc.at_xpath("//included"))
+    assert_equal(included_content, included.content)
 
-        File.open(XML_XINCLUDE_FILE) do |fp|
-          xml_doc = Nokogiri::XML(fp) do |conf|
-            conf.strict.dtdload.noent.nocdata.xinclude
+    xml_doc = nil
+
+    File.open(xinclude_file) do |fp|
+      xml_doc = Nokogiri::XML(fp) do |conf|
+        conf.strict.dtdload.noent.nocdata
+      end
+    end
+
+    refute_nil(xml_doc)
+    assert_nil(xml_doc.at_xpath("//included"))
+  end
+
+  it "yields the parse options to a block" do
+    non_default_options = Nokogiri::XML::ParseOptions::NOBLANKS | Nokogiri::XML::ParseOptions::XINCLUDE
+
+    document.do_xinclude(non_default_options) do |options|
+      assert_equal(non_default_options, options.to_i)
+    end
+  end
+
+  it "defaults safe_copy to true, protecting wrapped nodes" do
+    wrapped = document.at_xpath("//xi:include", "xi" => namespace)
+    assert_equal("include", wrapped.name)
+
+    document.do_xinclude(&:noxincnode)
+
+    refute_valgrind_errors { wrapped.name }
+
+    assert_equal("include", wrapped.name)
+    refute_nil(document.at_xpath("//included"))
+  end
+
+  describe "a bare include" do
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          [true, false].each do |safe_copy|
+            it "substitutes the include#{" with NOXINCNODE" if noxincnode}#{" without safe_copy" unless safe_copy}" do
+              run_xinclude(document, noxincnode: noxincnode, safe_copy: safe_copy)
+
+              refute_nil(included = document.at_xpath("//included"))
+              assert_equal(included_content, included.content)
+              assert_nil(document.at_xpath("//xi:include", "xi" => namespace)) if noxincnode
+            end
           end
-        end
-
-        refute_nil(xml_doc)
-        refute_nil(included = xml_doc.at_xpath("//included"))
-        assert_equal(@included, included.content)
-
-        # no xinclude should happen when not requested
-        xml_doc = nil
-
-        File.open(XML_XINCLUDE_FILE) do |fp|
-          xml_doc = Nokogiri::XML(fp) do |conf|
-            conf.strict.dtdload.noent.nocdata
-          end
-        end
-
-        refute_nil(xml_doc)
-        assert_nil(xml_doc.at_xpath("//included"))
-      end
-
-      def test_xinclude_on_document_node
-        skip_unless_libxml2("Pure Java version turns XInclude on against a parser.")
-        assert_nil(@xml.at_xpath("//included"))
-        @xml.do_xinclude
-        refute_nil(included = @xml.at_xpath("//included"))
-        assert_equal(@included, included.content)
-      end
-
-      def test_xinclude_on_element_subtree
-        skip_unless_libxml2("Pure Java version turns XInclude on against a parser.")
-        assert_nil(@xml.at_xpath("//included"))
-        @xml.root.do_xinclude
-        refute_nil(included = @xml.at_xpath("//included"))
-        assert_equal(@included, included.content)
-      end
-
-      def test_do_xinclude_accepts_block
-        non_default_options = Nokogiri::XML::ParseOptions::NOBLANKS |
-          Nokogiri::XML::ParseOptions::XINCLUDE
-
-        @xml.do_xinclude(non_default_options) do |options|
-          assert_equal(non_default_options, options.to_i)
-        end
-      end
-
-      def test_include_nonexistent_throws_exception
-        skip_unless_libxml2("Pure Java version behaves differently")
-
-        @xml.at_xpath("//xi:include")["href"] = "nonexistent.xml"
-        assert_raises(Nokogiri::XML::SyntaxError) do
-          @xml.do_xinclude(&:nowarning)
         end
       end
     end
+  end
+
+  describe "a wrapped <xi:include> element" do
+    let(:wrapped) { document.at_xpath("//xi:include", "xi" => namespace) }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "survives processing#{" with NOXINCNODE" if noxincnode}" do
+            assert_equal("include", wrapped.name)
+
+            run_xinclude(document, noxincnode: noxincnode)
+
+            refute_valgrind_errors { wrapped.name }
+
+            assert_equal("include", wrapped.name)
+            refute_nil(document.at_xpath("//included"))
+          end
+        end
+      end
+    end
+  end
+
+  describe "a wrapped fallback child" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}">
+          <xi:include href="#{included_file_uri}">
+            <xi:fallback><fallback_content/></xi:fallback>
+          </xi:include>
+        </root>
+      XML
+    end
+    let(:wrapped) { document.at_xpath("//xi:fallback", "xi" => namespace) }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "survives processing#{" with NOXINCNODE" if noxincnode}" do
+            assert_equal("fallback", wrapped.name)
+
+            run_xinclude(document, noxincnode: noxincnode)
+
+            refute_valgrind_errors { wrapped.name }
+
+            assert_equal("fallback", wrapped.name)
+            refute_nil(document.at_xpath("//included"))
+          end
+        end
+      end
+    end
+  end
+
+  describe "a wrapped namespace in the subtree" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}">
+          <xi:include href="#{included_file_uri}">
+            <xi:fallback xmlns:foo="http://example.com/foo"/>
+          </xi:include>
+        </root>
+      XML
+    end
+    let(:wrapped) { document.at_xpath("//xi:fallback", "xi" => namespace).namespace_definitions.first }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "survives processing#{" with NOXINCNODE" if noxincnode}" do
+            assert_equal("foo", wrapped.prefix)
+
+            run_xinclude(document, noxincnode: noxincnode)
+
+            refute_valgrind_errors do
+              wrapped.prefix
+              wrapped.href
+            end
+
+            assert_equal("foo", wrapped.prefix)
+            assert_equal("http://example.com/foo", wrapped.href)
+          end
+        end
+      end
+    end
+  end
+
+  describe "multiple wrapped top-level includes" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}">
+          <xi:include href="#{included_file_uri}"/>
+          <xi:include href="#{included_file_uri}"/>
+        </root>
+      XML
+    end
+    let(:wrapped) { document.xpath("//xi:include", "xi" => namespace).to_a }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "preserves every wrapped include#{" with NOXINCNODE" if noxincnode}" do
+            assert_equal(2, wrapped.length)
+            wrapped.each { |include_node| assert_equal("include", include_node.name) }
+
+            run_xinclude(document, noxincnode: noxincnode)
+
+            refute_valgrind_errors { wrapped.each(&:name) }
+
+            wrapped.each { |include_node| assert_equal("include", include_node.name) }
+            assert_equal(2, document.xpath("//included").length)
+          end
+        end
+      end
+    end
+  end
+
+  describe "do_xinclude called on the include node itself" do
+    let(:wrapped) { document.at_xpath("//xi:include", "xi" => namespace) }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        [true, false].each do |noxincnode|
+          it "survives processing#{" with NOXINCNODE" if noxincnode}" do
+            refute_nil(wrapped.parent)
+            assert_equal("include", wrapped.name)
+
+            run_xinclude(wrapped, noxincnode: noxincnode)
+
+            refute_valgrind_errors { wrapped.name }
+
+            assert_equal("include", wrapped.name)
+            refute_nil(document.at_xpath("//included"))
+          end
+        end
+      end
+    end
+  end
+
+  describe "a nested include inside a fallback" do
+    # the nested include targets a nonexistent file, so processing it would raise
+    let(:source) do
+      <<~XML
+        <root xmlns:xi="#{namespace}">
+          <xi:include href="#{included_file_uri}">
+            <xi:fallback>
+              <xi:include href="nonexistent.xml"/>
+            </xi:fallback>
+          </xi:include>
+        </root>
+      XML
+    end
+    let(:document) { Nokogiri::XML.parse(source) }
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        it "does not process the nested include" do
+          refute_raises do
+            run_xinclude(document)
+          end
+
+          refute_nil(document.at_xpath("//included"))
+        end
+
+        it "does not process the nested include when parsed with XINCLUDE (safe_copy: false)" do
+          parsed = nil
+
+          refute_raises do
+            parsed = Nokogiri::XML.parse(source, &:xinclude)
+          end
+
+          refute_nil(parsed.at_xpath("//included"))
+        end
+      end
+    end
+  end
+
+  describe "an ancestor namespace used inside a fallback" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}" xmlns:foo="http://example.com/foo">
+          <xi:include href="nonexistent.xml">
+            <xi:fallback><foo:content/></xi:fallback>
+          </xi:include>
+        </root>
+      XML
+    end
+
+    namespaces.each do |label, ns|
+      describe "in the #{label} namespace" do
+        let(:namespace) { ns }
+
+        it "reconciles the ancestor namespace in the copied subtree" do
+          run_xinclude(document, nowarning: true)
+
+          refute_nil(content = document.at_xpath("//foo:content", "foo" => "http://example.com/foo"))
+          assert_equal("http://example.com/foo", content.namespace.href)
+        end
+      end
+    end
+  end
+
+  describe "an unlinked <xi:include> node" do
+    let(:orphan) { document.at_xpath("//xi:include", "xi" => namespace).tap(&:unlink) }
+
+    [true, false].each do |safe_copy|
+      it "raises because there is no parent to receive the content#{" with safe_copy false" unless safe_copy}" do
+        assert_raises(RuntimeError) do
+          orphan.do_xinclude(safe_copy: safe_copy)
+        end
+      end
+    end
+  end
+
+  describe "an <xi:include> inside an unlinked subtree" do
+    let(:document) do
+      Nokogiri::XML.parse(<<~XML)
+        <root xmlns:xi="#{namespace}">
+          <container>
+            <xi:include href="#{included_file_uri}"/>
+          </container>
+        </root>
+      XML
+    end
+    let(:container) { document.at_xpath("//container").tap(&:unlink) }
+
+    it "processes when called on the unlinked container" do
+      container.do_xinclude
+
+      refute_nil(container.at_xpath(".//included"))
+    end
+
+    it "processes when called on the include whose ancestor is unlinked" do
+      include_node = container.at_xpath("./xi:include", "xi" => namespace)
+
+      include_node.do_xinclude
+
+      refute_nil(container.at_xpath(".//included"))
+    end
+  end
+end
+
+describe "Node#do_xinclude on any backend" do
+  let(:included_file) { File.join(Nokogiri::TestBase::ASSETS_DIR, "to_be_xincluded.xml") }
+  let(:included_file_uri) { file_url_for(included_file) }
+  let(:document) do
+    Nokogiri::XML.parse(<<~XML)
+      <root xmlns:xi="http://www.w3.org/2001/XInclude">
+        <xi:include href="#{included_file_uri}"/>
+      </root>
+    XML
+  end
+
+  it "is callable on a document and returns self" do
+    assert_same(document, document.do_xinclude)
+  end
+
+  it "is callable on a node and returns self" do
+    node = document.root
+
+    assert_same(node, node.do_xinclude)
   end
 end


### PR DESCRIPTION
Forward port of security fixes from v1.19.x:

- #3639 fix: JRuby NONET bypass in XML::Schema
- #3640 fix: `Node#initialize_copy_with_args` rejects non-Node sources
- #3641 fix(CRuby): use-after-free in XPathContext document lifetime
- #3642 fix: use-after-free in `Node#do_xinclude`
- #3643 fix: `Document#root=` rejects non-element nodes
- #3644 fix(CRuby): avoid UAF in XML::Attr#value=
- #3645 fix: avoid NPE on uninitialized XML::Node structs
- #3646 fix(CRuby): use-after-free in `Document#encoding=` when setter raises
- #3647 fix(CRuby): out-of-bounds read in `NodeSet#[]` with large negative index
