### PR TITLE
fix: fatal error: 'nokogiri_gumbo.h' file not found

### DIFF
--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -1114,7 +1114,7 @@ else
       end
     end
   end
-  append_cppflags("-I#{File.join(libgumbo_recipe.path, "include")}")
+  $CPPFLAGS << " -I#{File.join(libgumbo_recipe.path, "include")}"
   $libs = $libs + " " + File.join(libgumbo_recipe.path, "lib", "libgumbo.a")
   $LIBPATH = $LIBPATH | [File.join(libgumbo_recipe.path, "lib")]
   ensure_func("gumbo_parse_with_options", "nokogiri_gumbo.h")


### PR DESCRIPTION
<!--
--  Thank you for contributing to Nokogiri! To help us prioritize, please take care to answer the
--  questions below when you submit this pull request.
--
--  The Nokogiri core team work off of `main`, so please submit all PRs based on the `main`
--  branch. We generally will cherry-pick relevant bug fixes onto the current release branch.
-->

**What problem is this PR intended to solve?**

Fixes issues #3576 and #3634.

append_cppflags is forcing -Werror which causes warning from Ruby to bubble up to error instead. This makes paths say they are not valid and don't get added to CPPFLAGS even though they should be fine, eg:

```
append_cppflags: checking for whether -I/.../ext/nokogiri/ports/arm64-darwin25/libgumbo/1.0.0-nokogiri/include is accepted as CPPFLAGS... -------------------- no
```

This change modifies $CPPFLAGS directly for libgumbo which skips setting -Werror. It's not necessary to use append_cppflags to check for compiler compatibility because all C compilers support `-I<dir>`.

**Have you included adequate test coverage?**

No I only built it locally (ruby 3.3.7) to verify it succeeds:
```
gem install --local nokogiri-1.20.0.dev.gem --platform ruby
```

<!--
-- We have a thorough test suite that allows us to create releases confidently and prevent
-- accidental regressions. Any proposed change in behavior __must__ be accompanied by tests.
--
-- If possible, please try to write the tests so that they communicate intent.
-->

**Does this change affect the behavior of either the C or the Java implementations?**

No.

<!--
-- If so, has the behavior change been made to _both_ implementations?
-- 
-- If not, the maintainers can probably help! Tell us what's missing (or what's blocking you), and
-- then submit this PR as a "Draft".
-->
