### PR TITLE
Update the XSLT stylesheet's _private after compaction

### DIFF
--- a/ext/nokogiri/xslt_stylesheet.c
+++ b/ext/nokogiri/xslt_stylesheet.c
@@ -18,11 +18,28 @@ dealloc(void *data)
   ruby_xfree(wrapper);
 }
 
+/*
+ * Nokogiri_wrap_xslt_stylesheet stores this object's own VALUE in the libxslt
+ * stylesheet's `_private`, and transform() reads it back through the extension
+ * callbacks. Compaction relocates the object, so that copy has to be updated --
+ * the same treatment xmlNode and xmlNamespace already give their `_private`.
+ */
+static void
+update_references(void *data)
+{
+  nokogiriXsltStylesheetTuple *wrapper = (nokogiriXsltStylesheetTuple *)data;
+
+  if (wrapper->ss && wrapper->ss->_private) {
+    wrapper->ss->_private = (void *)rb_gc_location((VALUE)wrapper->ss->_private);
+  }
+}
+
 static const rb_data_type_t nokogiri_xslt_stylesheet_tuple_type = {
   .wrap_struct_name = "nokogiriXsltStylesheetTuple",
   .function = {
     .dmark = mark,
     .dfree = dealloc,
+    .dcompact = update_references,
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };


### PR DESCRIPTION
`Nokogiri_wrap_xslt_stylesheet` stores the Stylesheet's own `VALUE` in libxslt's `_private`:

```c
ss->_private = (void *)self;                       // xslt_stylesheet.c:63
```

and the extension callbacks read it back on every transform:

```c
(VALUE)ctxt->style->_private,                      // :399 initFunc, :417 shutdownFunc
```

but `nokogiri_xslt_stylesheet_tuple_type` declares `.dmark` and `.dfree` and no `.dcompact`. So compaction relocates the Stylesheet and libxslt keeps the pre-move address.

The gem already does the right thing two files over — this is the same three lines `xml_node.c:31-38` and `xml_namespace.c:45-52` use:

```c
node->_private = (void *)rb_gc_location((VALUE)node->_private);
```

so this just gives the stylesheet type the treatment its siblings already have.

## Reachability

Narrower than it first looks, and worth stating precisely: `ctxt->style->_private` is read only from `initFunc` and `shutdownFunc`, which libxslt invokes via `xsltInitCtxtExts`/`xsltFreeCtxtExts` for extension-module URIs the stylesheet actually declares. **A stylesheet with no registered XSLT extension module never reads `_private` at all.**

So this needs `Nokogiri::XSLT.register` (or an equivalent `xsl:extension-element-prefixes` binding) plus a compaction between compiling the stylesheet and transforming with it. Stylesheets are long-lived by design — compile once, transform many — which is exactly the shape that gets caught.

## Verification

Built `main` and the patched tree in the same step that ran the test, so the artifact can't drift from the source:

```
                              main       with this patch
transform after compaction    3/3 fail   3/3 pass
no compaction (control)       3/3 pass   3/3 pass
```

The precondition is asserted rather than assumed — each run prints the stylesheet's address before and after and confirms it relocated, with 200/200 witnesses also relocating:

```
stylesheet VALUE addr before: 0xffff9ec46de8 (slot_size 40)
witnesses relocated: 200/200
stylesheet VALUE addr after:  0xffff9ea23e08  MOVED
PRECONDITION relocation: true
RESULT: FAILED NoMethodError: undefined method 'to_s' for an instance of #<#<Class:0x...>>
```

That `NoMethodError` is the defect surfacing benignly — libxslt handed the stale address back and `TypedData_Get_Struct` got whatever object now occupies the slot. Filling the vacated slots with instances of a marker class instead makes nokogiri's own C code say so directly: `TypeError: wrong argument type HuntMarker (expected nokogiriXsltStylesheetTuple)` from inside `transform`.

Ruby 4.0.6 aarch64-linux, in a container. Reproduced on the precompiled platform gem (1.19.4-aarch64-linux-gnu, packaged libxml2 2.13.9 / libxslt 1.1.43) and on a `--use-system-libraries` build against libxml2 2.9.14 / libxslt 1.1.35, so it isn't a linked-library artifact. The churn is size-matched to the subject's `slot_size` of 40 — with 100-byte String churn instead, this reports clean.

## Two related sites I have *not* patched here

The same sweep found the IO `VALUE` stashed in two persistent libxml2 objects, both of which also lack a `dmark`/`dcompact`:

- `xml_reader.c:699-705` — `xmlReaderForIO(..., (void *)rb_io, ...)`, read via `noko_io_read` on every subsequent `#read`
- `xml_sax_parser_context.c:90-93` — `xmlCreateIOParserCtxt(..., (void *)rb_io, ...)`, read on every later `parse_with`

Both reproduce through the documented public API (`Nokogiri::XML::Reader.new(StringIO)` then `#read` after a `GC.compact` SEGVs 3/3 for me), and `@source` / `@input` keep the IO alive but are marked *movably*, so it's a use-after-move rather than a use-after-free.

I left them out because the fix isn't a `dcompact` one-liner: the `VALUE` lives inside a libxml2 struct with no slot we own, so it needs either a malloc'd holder threaded through `noko_io_read` — like the `nokogiriTuplePtr` in `xml_document.c` — or pinning. That's a design call I'd rather you made. Happy to open a separate PR once you've said which way you'd want it, or an issue with the reproducers if that's easier.

For contrast, the two *synchronous* IO sites are fine: `html4_document.c:51` and `xml_document.c:388` pass `(void *)rb_io` to `htmlReadIO`/`xmlReadIO`, which parse fully within the call, so the IO is a live stack argument and conservative scanning pins it. The distinction is persistence, not the cast.

Found while sweeping native gems for dangling `VALUE`s after compaction.