### PR TITLE
ci: get libiconv from somewhere else

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
       - '*'
 
 permissions: {}
+env:
+  # gnu.org has frequent downtime, so use the mirror at nokogiri.org
+  NOKOGIRI_USE_MIRRORED_GNU_SOURCE: "t"
 jobs:
   #
   #  SECTION pre-checks for fast feedback loops, and to gate the rest of the suite
@@ -702,6 +705,7 @@ jobs:
           PLAT: ${{matrix.plat}}
         run: |
           docker run --rm -v "$(pwd):/nokogiri" -w /nokogiri \
+            -e NOKOGIRI_USE_MIRRORED_GNU_SOURCE \
             "ghcr.io/rake-compiler/rake-compiler-dock-image:${RCD_IMAGE_VERSION}-mri-${PLAT}" \
             ./scripts/test-gem-build gems "$PLAT"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -14,6 +14,9 @@ on:
       - .github/workflows/upstream.yml # this file
 
 permissions: {}
+env:
+  # gnu.org has frequent downtime, so use the mirror at nokogiri.org
+  NOKOGIRI_USE_MIRRORED_GNU_SOURCE: "t"
 jobs:
   xmlsoft-head:
     permissions:

--- a/ext/nokogiri/extconf.rb
+++ b/ext/nokogiri/extconf.rb
@@ -243,6 +243,16 @@ def gnome_source
   "https://download.gnome.org"
 end
 
+def gnu_source
+  # As of 2026-08, gnu.org has enough downtime to make CI jobs fail regularly, so allow downloading
+  # from a copy hosted on nokogiri.org.
+  if ENV["NOKOGIRI_USE_MIRRORED_GNU_SOURCE"]
+    "https://nokogiri.org/mirror"
+  else
+    "https://ftpmirror.gnu.org"
+  end
+end
+
 LOCAL_PACKAGE_RESPONSE = Object.new
 def LOCAL_PACKAGE_RESPONSE.%(package)
   package ? "yes: #{package}" : "no"
@@ -827,7 +837,7 @@ else
         cross_build_p,
       ) do |recipe|
         recipe.files = [{
-          url: "https://ftpmirror.gnu.org/gnu/libiconv/#{recipe.name}-#{recipe.version}.tar.gz",
+          url: "#{gnu_source}/gnu/libiconv/#{recipe.name}-#{recipe.version}.tar.gz",
           sha256: dependencies["libiconv"]["sha256"],
         }]
 


### PR DESCRIPTION

**What problem is this PR intended to solve?**

ftpmirror.gnu.org has been very unstable and CI has been failing as a result of libiconv downloads failing.

This change downloads a copy of the libiconv tarball (checksum will be verified) from nokogiri.org where I just put it with sparklemotion/nokogiri.org@f717734d

