### PR TITLE
gumbo: do not use an end tag token whose name has been freed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby] Builder now correctly builds namespaced nodes that define their own namespace when that ns prefix collides with one defined by the parent (or another ancestor). (#3458, #3461) @flavorjones
 * [CRuby] `Reader.outer_xml` and `.inner_xml` properly capture syntax errors. (#3558) @flavorjones
 * [CRuby MacOS] Fixed an issue handling SIGINT during HTML5 parsing. (#3528, #3535) @stevecheckoway
+* [CRuby] gumbo: `gumbo_parse_with_options` no longer crashes when `stop_on_first_error` is set and the parse ends on an unknown end tag in a fragment context. This is a C API path; it is not reachable from Ruby, because Nokogiri never sets `stop_on_first_error`. @jeremy
 * [JRuby] Fixed multiple issues with `Node#namespace_definitions` so that it now behaves identically to CRuby. (#2543, #3460) @flavorjones
 * [JRuby] `Document#create_element` and `Node.new` no longer set the namespace to the document's default namespace. The namespace must be set explicitly with `namespace=` or by parenting the node. (#3457, #3463) @flavorjones
 

--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -1025,14 +1025,29 @@ static GumboNode* pop_current_node(GumboParser* parser) {
       && state->_closed_html_tag
     )
   ;
+  // The tree construction loop frees an unknown end tag's name once it is done
+  // with the token, so the current token can be an end tag that no longer names
+  // anything. That happens when stop_on_first_error ends the loop on the same
+  // iteration that freed the name, leaving this token current for
+  // finish_parsing. Such a token cannot match any node, and passing it on would
+  // break node_qualified_tagname_is's precondition that an unknown tag carries
+  // a name.
+  const GumboToken* current_token = state->_current_token;
+  const bool current_token_names_an_end_tag =
+    current_token->type == GUMBO_TOKEN_END_TAG
+    && (
+      current_token->v.end_tag.tag != GUMBO_TAG_UNKNOWN
+      || current_token->v.end_tag.name
+    )
+  ;
   if (
     (
-      state->_current_token->type != GUMBO_TOKEN_END_TAG
+      !current_token_names_an_end_tag
       || !node_qualified_tagname_is (
         current_node,
         GUMBO_NAMESPACE_HTML,
-        state->_current_token->v.end_tag.tag,
-        state->_current_token->v.end_tag.name
+        current_token->v.end_tag.tag,
+        current_token->v.end_tag.name
       )
     )
     && !is_closed_body_or_html_tag

--- a/gumbo-parser/test/parser.cc
+++ b/gumbo-parser/test/parser.cc
@@ -2337,4 +2337,21 @@ TEST_F(GumboParserTest, FosterParenting) {
   EXPECT_EQ(std::string("quux"), text->v.text.text);
 }
 
+// stop_on_first_error can end the tree construction loop on the same iteration
+// that freed an unknown end tag's name. finish_parsing then still sees that
+// token as current. Before the fix in pop_current_node this aborted on
+// node_qualified_tagname_is's assertion, and dereferenced NULL when the
+// current node also had an unknown tag and assertions were compiled out.
+TEST_F(GumboParserTest, StopOnFirstErrorAfterUnknownEndTag) {
+  options_.stop_on_first_error = true;
+  ParseFragment("</ta>", "div", GUMBO_NAMESPACE_HTML);
+  ASSERT_TRUE(output_ != NULL);
+}
+
+TEST_F(GumboParserTest, StopOnFirstErrorAfterUnknownEndTagWithUnknownNode) {
+  options_.stop_on_first_error = true;
+  ParseFragment("<custom-el></ta>", "div", GUMBO_NAMESPACE_HTML);
+  ASSERT_TRUE(output_ != NULL);
+}
+
 }  // namespace


### PR DESCRIPTION
`gumbo_parse_with_options()` crashes when `GumboOptions.stop_on_first_error` is `true` and the
parse ends on an unknown end tag inside a fragment context.

**This is a C API path. It is not reachable from Ruby.** `common_options()` in
`ext/nokogiri/gumbo.c` assigns `max_attributes`, `max_errors`, `max_tree_depth` and
`parse_noscript_content_as_text`, and the fragment path adds `fragment_context`,
`fragment_namespace`, `fragment_encoding`, `quirks_mode` and
`fragment_context_has_form_ancestor`. It never assigns `stop_on_first_error`, and
`kGumboDefaultOptions` sets it `false`. `rg -n stop_on_first_error ext/ lib/` returns no hits.
So no HTML reaches this through `Nokogiri::HTML5`. I am reporting and fixing it because the
option is part of the public C interface.

## The defect

The tree construction loop frees an unknown end tag's name once it is done with the token, and
sets it to NULL (`parser.c:4862-4867`):

```c
if (token.type == GUMBO_TOKEN_END_TAG &&
    token.v.end_tag.tag == GUMBO_TAG_UNKNOWN)
{
  gumbo_free(token.v.end_tag.name);
  token.v.end_tag.name = NULL;
}
```

The loop exit condition can fire on that same iteration:

```c
} while (
  (token.type != GUMBO_TOKEN_EOF || state->_reprocess_current_token)
  && !(options->stop_on_first_error && parser._output->document_error)
);
```

`finish_parsing()` then still sees that token as `state->_current_token`. `pop_current_node()`
passes `tag == GUMBO_TAG_UNKNOWN` together with `name == NULL` into
`node_qualified_tagname_is()`, whose precondition is the opposite:

```c
assert(tag != GUMBO_TAG_UNKNOWN || name);   // parser.c:603
```

A fragment context is required. `fragment_parser_init` pushes an `html` root onto
`_open_elements`. In a document parse `_open_elements` is empty at that point, `pop_current_node`
returns NULL, and this is never reached.

**Two outcomes, depending on how the library was built.**

With assertions enabled — which is how Nokogiri builds it — the process aborts on line 603.

With `NDEBUG` the assertion is gone. If the current node's own tag is also `GUMBO_TAG_UNKNOWN`
and the namespace matches, `node_qualified_tagname_is` does not return early at line 607. It
reaches line 611 and calls `gumbo_ascii_strcasecmp(element_name, NULL)`, which dereferences NULL:

```
AddressSanitizer: SEGV on unknown address 0x000000000000
The signal is caused by a READ memory access.
    #0 gumbo_ascii_strcasecmp        ascii.c:5
    #1 node_qualified_tagname_is     parser.c:611
    #2 pop_current_node              parser.c:1031
    #3 finish_parsing                parser.c:2449
    #4 gumbo_parse_with_options      parser.c:4879
```

## The fix

Such a token cannot name any node, so `pop_current_node` treats it as no match rather than asking
`node_qualified_tagname_is` a question that violates its precondition. The node then gets
`GUMBO_INSERTION_IMPLICIT_END_TAG`, which is what already happens for every other early exit.

## Measurements

Host: **arm64-darwin**, Apple clang. Built directly from `gumbo-parser/src` with `clang -O2`, in
both the assertion and the `NDEBUG` configuration.

| input | fragment context | before (assertions) | before (`NDEBUG`) | after, both |
|---|---|---|---|---|
| `</ta>` | `template` | abort, line 603 | ok | ok |
| `</ta>` | `div` | abort, line 603 | ok | ok |
| `<custom-el></ta>` | `div` | abort, line 603 | **SEGV** | ok |
| `<custom-el></ta>` | `template` | abort, line 603 | **SEGV** | ok |
| `<foo-bar><baz-qux></ta>` | `div` | abort, line 603 | **SEGV** | ok |
| `<custom-el></zz>` | `custom-el` | abort, line 603 | **SEGV** | ok |
| `</ta>` | none (document) | ok | ok | ok |

Control: every row above is clean before and after with `stop_on_first_error = false`.

**No behaviour change anywhere else.** I built the parser before and after the change and dumped
the full tree for every node — type, tag, namespace, attribute count and **`parse_flags`**, since
`parse_flags` is the only thing this change can affect. Corpus: the 1,792 html5lib
tree-construction cases (192 of them with a fragment context), each parsed with
`stop_on_first_error` both `false` and `true`.

```
sofe=0   identical  1792
sofe=1   identical  1792
```

3,584 parses, byte-identical output, no crash on either side.

That corpus contains none of the triggering inputs, so on its own it could not tell a fix from a
no-op. Running the same differential over the cases in the table above shows the instrument does
fire: `<custom-el></ta>` and the other three unknown-node rows go from exit 139 to exit 0.

## Tests

Two tests added to `gumbo-parser/test/parser.cc`. Without the fix the suite aborts at the first
of them:

```
[ RUN      ] GumboParserTest.StopOnFirstErrorAfterUnknownEndTag
Assertion failed: (tag != GUMBO_TAG_UNKNOWN || name), function node_qualified_tagname_is,
file parser.c, line 603.
make: *** [check] Abort trap: 6
```

With the fix:

```
[==========] 593 tests from 9 test cases ran.
[  PASSED  ] 593 tests.
```

Ruby suite, `test/html5/*_test.rb`: **2839 runs, 10321 assertions, 0 failures, 0 errors, 24 skips**.

## One thing this PR does not fix

The same option leaks memory on a different input. With `stop_on_first_error = true` and a parse
that exits mid-tag, the tokenizer's in-flight tag state leaks its attribute vector
(`start_new_tag` → `gumbo_vector_init` in `vector.c:28` → `gumbo_alloc` in `util.c:25`). It
reproduces on `<td><template></te` and needs no fragment context. That is a separate cleanup path
and I have left it out to keep this change small. Happy to do it here or in a follow-up,
whichever you prefer.

The two early exits that **are** reachable from Ruby do not leak. Measured with ASan and LSan at
Nokogiri's defaults, across four fragment contexts: `<div>`×5000 returns
`GUMBO_STATUS_TREE_TOO_DEEP` and 5,000 attributes returns `GUMBO_STATUS_TOO_MANY_ATTRIBUTES`,
both with no leak.

## Provenance

Found by coverage-guided fuzzing of `gumbo_parse_with_options` (libFuzzer, ASan and UBSan,
1,991,470 executions), which reported no other crash. 160 artifacts reduced to this one signature,
and 0 of the 160 reproduce with `stop_on_first_error = false`.
