### PR TITLE
gumbo: fix foster parented text not being merged into preceding text node

### DIFF
--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -973,7 +973,33 @@ static void maybe_flush_text_node_buffer(GumboParser* parser) {
   );
 
   InsertionLocation location = get_appropriate_insertion_location(parser, NULL);
-  if (location.target->type == GUMBO_NODE_DOCUMENT) {
+  GumboNode* prev = NULL;
+  if (location.target->type == GUMBO_NODE_ELEMENT ||
+      location.target->type == GUMBO_NODE_TEMPLATE) {
+    GumboVector* siblings = &location.target->v.element.children;
+    if (location.index == -1) {
+      if (siblings->length > 0) prev = siblings->data[siblings->length - 1];
+    } else if (location.index > 0) {
+      prev = siblings->data[location.index - 1];
+    }
+  }
+  if (prev != NULL &&
+      (prev->type == GUMBO_NODE_TEXT || prev->type == GUMBO_NODE_WHITESPACE) &&
+      (text_node->type == GUMBO_NODE_TEXT ||
+       text_node->type == GUMBO_NODE_WHITESPACE)) {
+    GumboText* prev_data = &prev->v.text;
+    size_t prev_length = strlen(prev_data->text);
+    size_t added_length = strlen(text_node_data->text);
+    char* merged = gumbo_alloc(prev_length + added_length + 1);
+    memcpy(merged, prev_data->text, prev_length);
+    memcpy(merged + prev_length, text_node_data->text, added_length + 1);
+    gumbo_free((void*) prev_data->text);
+    prev_data->text = merged;
+    if (text_node->type == GUMBO_NODE_TEXT) {
+      prev->type = GUMBO_NODE_TEXT;
+    }
+    destroy_node(text_node);
+  } else if (location.target->type == GUMBO_NODE_DOCUMENT) {
     // The DOM does not allow Document nodes to have Text children, so per the
     // spec, they are dropped on the floor.
     destroy_node(text_node);

--- a/gumbo-parser/test/parser.cc
+++ b/gumbo-parser/test/parser.cc
@@ -941,18 +941,13 @@ TEST_F(GumboParserTest, MisnestedTable2) {
   GumboNode* td1 = GetChild(tr1, 0);
   ASSERT_EQ(GUMBO_NODE_ELEMENT, td1->type);
   EXPECT_EQ(GUMBO_TAG_TD, GetTag(td1));
-  ASSERT_EQ(3, GetChildCount(td1));
+  ASSERT_EQ(2, GetChildCount(td1));
 
   GumboNode* cell1 = GetChild(td1, 0);
   ASSERT_EQ(GUMBO_NODE_TEXT, cell1->type);
-  EXPECT_STREQ("Cell1", cell1->v.text.text);
+  EXPECT_STREQ("Cell1Cell3", cell1->v.text.text);
 
-  // Foster-parented out of the inner <tr>
-  GumboNode* cell3 = GetChild(td1, 1);
-  ASSERT_EQ(GUMBO_NODE_TEXT, cell3->type);
-  EXPECT_STREQ("Cell3", cell3->v.text.text);
-
-  GumboNode* table2 = GetChild(td1, 2);
+  GumboNode* table2 = GetChild(td1, 1);
   ASSERT_EQ(GUMBO_NODE_ELEMENT, table2->type);
   EXPECT_EQ(GUMBO_TAG_TABLE, GetTag(table2));
   ASSERT_EQ(1, GetChildCount(table2));
@@ -2335,6 +2330,85 @@ TEST_F(GumboParserTest, FosterParenting) {
   text = GetChild(p, 0);
   ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
   EXPECT_EQ(std::string("quux"), text->v.text.text);
+}
+
+TEST_F(GumboParserTest, FosterParentingTextMergedIntoPrecedingText) {
+  Parse("x<table>x");
+
+  GumboNode* body;
+  GetAndAssertBody(root_, &body);
+  ASSERT_EQ(2, GetChildCount(body));
+
+  // The second "x" is foster-parented out of the table. Per the "insert a
+  // character" algorithm it is appended to the text node immediately before
+  // the adjusted insertion location, not inserted as a sibling.
+  GumboNode* text = GetChild(body, 0);
+  ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
+  EXPECT_STREQ("xx", text->v.text.text);
+  EXPECT_EQ(body, text->parent);
+  EXPECT_EQ(0, text->index_within_parent);
+  // The merged runs are not contiguous in the source ("<table>" sits between
+  // them), so original_text keeps only the first run's span.
+  EXPECT_EQ("x", ToString(text->v.text.original_text));
+  EXPECT_EQ(0, text->v.text.start_pos.offset);
+
+  GumboNode* table = GetChild(body, 1);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, table->type);
+  EXPECT_EQ(GUMBO_TAG_TABLE, GetTag(table));
+  EXPECT_EQ(1, table->index_within_parent);
+}
+
+TEST_F(GumboParserTest, FosterParentingTextPromotesPrecedingWhitespace) {
+  Parse("<div> <table>x</table></div>");
+
+  GumboNode* body;
+  GetAndAssertBody(root_, &body);
+  ASSERT_EQ(1, GetChildCount(body));
+
+  GumboNode* div = GetChild(body, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, div->type);
+  EXPECT_EQ(GUMBO_TAG_DIV, GetTag(div));
+  ASSERT_EQ(2, GetChildCount(div));
+
+  // The whitespace-only " " node absorbs the foster-parented "x" and is
+  // promoted from GUMBO_NODE_WHITESPACE to GUMBO_NODE_TEXT.
+  GumboNode* text = GetChild(div, 0);
+  ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
+  EXPECT_STREQ(" x", text->v.text.text);
+
+  GumboNode* table = GetChild(div, 1);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, table->type);
+  EXPECT_EQ(GUMBO_TAG_TABLE, GetTag(table));
+}
+
+TEST_F(GumboParserTest, FosterParentingTextMergedAcrossMultipleFlushes) {
+  // "A" is flushed when <table> opens; " B" and " B" are foster-parented out
+  // of the table in two separate flushes. All three runs must end up in a
+  // single text node.
+  Parse("A<table><tr> B</tr> B</table>");
+
+  GumboNode* body;
+  GetAndAssertBody(root_, &body);
+  ASSERT_EQ(2, GetChildCount(body));
+
+  GumboNode* text = GetChild(body, 0);
+  ASSERT_EQ(GUMBO_NODE_TEXT, text->type);
+  EXPECT_STREQ("A B B", text->v.text.text);
+
+  GumboNode* table = GetChild(body, 1);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, table->type);
+  EXPECT_EQ(GUMBO_TAG_TABLE, GetTag(table));
+  ASSERT_EQ(1, GetChildCount(table));
+
+  GumboNode* tbody = GetChild(table, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, tbody->type);
+  EXPECT_EQ(GUMBO_TAG_TBODY, GetTag(tbody));
+  ASSERT_EQ(1, GetChildCount(tbody));
+
+  GumboNode* tr = GetChild(tbody, 0);
+  ASSERT_EQ(GUMBO_NODE_ELEMENT, tr->type);
+  EXPECT_EQ(GUMBO_TAG_TR, GetTag(tr));
+  ASSERT_EQ(0, GetChildCount(tr));
 }
 
 }  // namespace


### PR DESCRIPTION
Hi, I'm maintainer of [gumbo-parser](https://codeberg.org/gumbo-parser/gumbo-parser) repo.

While tinkering with the Gumbo's test suite over at Codeberg, I came across a very nasty bug in text foster parenting that could never have been detected by the html5lib-based tree-construction tests: the Python bindings rebuild Gumbo's tree through html5lib's treebuilder, whose insertText() appends character data to a trailing text node, so Gumbo's erroneously split text nodes were merged back together before the tree was ever compared against the expected output.

I've compared the proposed change against current Chromium and Firefox, and it matches their behavior in every affected test case.

Chromium tree example:

<img width="742" height="608" alt="image" src="https://github.com/user-attachments/assets/f5777005-40ac-4ffb-af19-63b495db4d2d" />

Firefox tree example:

<img width="610" height="537" alt="image" src="https://github.com/user-attachments/assets/b62aca94-96b6-49a1-92cf-9d527ef6d931" />

Best regards, Grigory