### PR TITLE
fix: html5 encoding detection for IO input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 ### Changed
 
 * The unused constant `Struct::HTMLElementDescription` is no longer defined. (#3432, #3433) @viralpraxis
+* [CRuby] HTML5 parsing of an IO now prefers the encoding the document declares in a BOM or a `meta` charset declaration over the encoding the IO was read as. This applies to every IO-parsed document, including ones whose declaration no longer matches their bytes: a UTF-8 page carrying `<meta charset="iso-8859-1">` parsed correctly before and now decodes by that declaration, which is what `Nokogiri::HTML5(File.binread(path))` of the same bytes already did. Pass `encoding:` to override the declaration. (#2801) @kataokatsuki
 
 
 ### Fixed
@@ -31,7 +32,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby MacOS] Fixed an issue handling SIGINT during HTML5 parsing. (#3528, #3535) @stevecheckoway
 * [JRuby] Fixed multiple issues with `Node#namespace_definitions` so that it now behaves identically to CRuby. (#2543, #3460) @flavorjones
 * [JRuby] `Document#create_element` and `Node.new` no longer set the namespace to the document's default namespace. The namespace must be set explicitly with `namespace=` or by parenting the node. (#3457, #3463) @flavorjones
-* [CRuby] HTML5 parsing of an IO opened without an explicit encoding now uses the encoding the document declares in a BOM or a `meta` charset declaration. Previously the IO's external encoding was used, so `File.open(path)` on a Shift_JIS document produced replacement characters, and passing `encoding:` alongside an IO raised `TypeError`. (#2801) @kataokatsuki
+* [CRuby] `Nokogiri::HTML5(File.open(path))` on a Shift_JIS document no longer produces replacement characters, and passing `encoding:` alongside an IO no longer raises `TypeError`. (#2801) @kataokatsuki
 
 
 ## v1.19.4 / 2026-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 * [CRuby MacOS] Fixed an issue handling SIGINT during HTML5 parsing. (#3528, #3535) @stevecheckoway
 * [JRuby] Fixed multiple issues with `Node#namespace_definitions` so that it now behaves identically to CRuby. (#2543, #3460) @flavorjones
 * [JRuby] `Document#create_element` and `Node.new` no longer set the namespace to the document's default namespace. The namespace must be set explicitly with `namespace=` or by parenting the node. (#3457, #3463) @flavorjones
+* [CRuby] HTML5 parsing of an IO opened without an explicit encoding now uses the encoding the document declares in a BOM or a `meta` charset declaration. Previously the IO's external encoding was used, so `File.open(path)` on a Shift_JIS document produced replacement characters, and passing `encoding:` alongside an IO raised `TypeError`. (#2801) @kataokatsuki
 
 
 ## v1.19.4 / 2026-06-18

--- a/lib/nokogiri/html5.rb
+++ b/lib/nokogiri/html5.rb
@@ -285,24 +285,33 @@ module Nokogiri
       def read_and_encode(string, encoding)
         # Read the string with the given encoding.
         if string.respond_to?(:read)
-          external = string.external_encoding if string.respond_to?(:external_encoding)
           internal = string.internal_encoding if string.respond_to?(:internal_encoding)
+          # A StringIO holds an already-decoded String and reports that String's encoding rather
+          # than a locale default, so wrapping a String in one must not change how it decodes.
+          wraps_a_string = StringIO === string
           string = string.read
 
           if encoding
-            string = string.dup
             string.force_encoding(encoding)
-          elsif internal.nil? && external == Encoding.default_external
-            # The IO was opened without an explicit encoding, so its external encoding is the
-            # process default and says nothing about the document. Prefer an encoding the document
-            # declares itself, and keep the IO's encoding when the document declares none.
+          elsif internal.nil? && !wraps_a_string
+            # Ruby records nothing about whether an IO's external encoding was chosen by the
+            # caller or inherited from the locale, so it cannot stand in for what the document
+            # says about itself. Prefer the document's own declaration, and let a caller who
+            # needs to override it say so with the `encoding:` argument.
+            #
+            # When the document declares nothing, keep the IO's encoding. The standard's answer
+            # there is windows-1252 and #reencode falls back to ISO_8859_1, so this is a third
+            # answer and a deliberate one: it is the conservative choice and it leaves documents
+            # that parse correctly today parsing the same way.
             declared = detect_encoding(string)
             if declared
-              string = string.dup
               begin
                 string.force_encoding(declared)
               rescue ArgumentError
-                # an unknown encoding name is not a reason to discard what the IO gave us
+                # The document named an encoding Ruby does not know. #reencode makes the same
+                # choice for the binary path, so make it here too rather than keeping an IO
+                # encoding this branch has already decided says nothing about the document.
+                string.force_encoding(Encoding::ISO_8859_1)
               end
             end
           end
@@ -353,6 +362,41 @@ module Nokogiri
         body.encode(Encoding::UTF_8)
       end
 
+      # The standard's charset labels are not Ruby encoding names. "Get an encoding" maps
+      # roughly 220 labels onto encodings, while String#force_encoding accepts only Ruby's own
+      # names and aliases. Normalize the labels Ruby rejects but that appear in real documents,
+      # so that the IO path and the binary path agree on the same declaration. The standard
+      # folds latin1 and iso-8859-1 into windows-1252; Ruby keeps them as ISO-8859-1, and so
+      # does #reencode's fallback, so latin1 follows its synonym here rather than the table.
+      LABEL_ALIASES = {
+        "utf8" => "UTF-8",
+        "unicode-1-1-utf-8" => "UTF-8",
+        "latin1" => "ISO-8859-1",
+        "shift-jis" => "Shift_JIS",
+        "x-sjis" => "Shift_JIS",
+        "ms932" => "Shift_JIS",
+        "csshiftjis" => "Shift_JIS",
+        "x-user-defined" => "Windows-1252",
+      }.freeze
+      private_constant :LABEL_ALIASES
+
+      # Returns nil for an empty label, so that `charset=""` counts as no declaration rather
+      # than as a declaration of an encoding named "".
+      def normalize_encoding_label(label)
+        # "Get an encoding" strips leading and trailing ASCII whitespace and matches
+        # case-insensitively, so normalize first and keep the normalized form even when the
+        # label is not in the table above -- Encoding.find is case-insensitive too.
+        label = label.strip.downcase
+        return if label.empty?
+
+        label = LABEL_ALIASES.fetch(label, label)
+        # The standard's prescan replaces two of the encodings it gets: "If charset is
+        # UTF-16BE/LE, then set charset to UTF-8" (a document that really were UTF-16 could not
+        # have carried an ASCII-readable meta), and "If charset is x-user-defined, then set
+        # charset to windows-1252". The latter is in LABEL_ALIASES above.
+        /\Autf-16/i.match?(label) ? "UTF-8" : label
+      end
+
       # Return the encoding the document declares for itself, or nil when it declares none. Only
       # the first 1024 bytes are examined, per the HTML5 standard's prescan.
       def detect_encoding(body, content_type = nil)
@@ -371,6 +415,7 @@ module Nokogiri
         # look for a charset in a content-encoding header
         if content_type
           encoding = content_type[/charset=["']?(.*?)($|["';\s])/i, 1]
+          encoding = normalize_encoding_label(encoding) if encoding
           return encoding if encoding
         end
 
@@ -378,6 +423,7 @@ module Nokogiri
         data = head.gsub(/<!--.*?(-->|\Z)/m, "")
         data.scan(/<meta.*?>/im).each do |meta|
           encoding = meta[/charset=["']?([^>]*?)($|["'\s>])/im, 1]
+          encoding = normalize_encoding_label(encoding) if encoding
           return encoding if encoding
         end
 

--- a/lib/nokogiri/html5.rb
+++ b/lib/nokogiri/html5.rb
@@ -285,10 +285,26 @@ module Nokogiri
       def read_and_encode(string, encoding)
         # Read the string with the given encoding.
         if string.respond_to?(:read)
-          string = if encoding.nil?
-            string.read
-          else
-            string.read(encoding: encoding)
+          external = string.external_encoding if string.respond_to?(:external_encoding)
+          internal = string.internal_encoding if string.respond_to?(:internal_encoding)
+          string = string.read
+
+          if encoding
+            string = string.dup
+            string.force_encoding(encoding)
+          elsif internal.nil? && external == Encoding.default_external
+            # The IO was opened without an explicit encoding, so its external encoding is the
+            # process default and says nothing about the document. Prefer an encoding the document
+            # declares itself, and keep the IO's encoding when the document declares none.
+            declared = detect_encoding(string)
+            if declared
+              string = string.dup
+              begin
+                string.force_encoding(declared)
+              rescue ArgumentError
+                # an unknown encoding name is not a reason to discard what the IO gave us
+              end
+            end
           end
         else
           # Otherwise the string has the given encoding.
@@ -322,33 +338,8 @@ module Nokogiri
       #
       def reencode(body, content_type = nil)
         if body.encoding == Encoding::ASCII_8BIT
-          encoding = nil
-
-          # look for a Byte Order Mark (BOM)
-          initial_bytes = body[0..2].bytes
-          if initial_bytes[0..2] == [0xEF, 0xBB, 0xBF]
-            encoding = Encoding::UTF_8
-          elsif initial_bytes[0..1] == [0xFE, 0xFF]
-            encoding = Encoding::UTF_16BE
-          elsif initial_bytes[0..1] == [0xFF, 0xFE]
-            encoding = Encoding::UTF_16LE
-          end
-
-          # look for a charset in a content-encoding header
-          if content_type
-            encoding ||= content_type[/charset=["']?(.*?)($|["';\s])/i, 1]
-          end
-
-          # look for a charset in a meta tag in the first 1024 bytes
-          unless encoding
-            data = body[0..1023].gsub(/<!--.*?(-->|\Z)/m, "")
-            data.scan(/<meta.*?>/im).each do |meta|
-              encoding ||= meta[/charset=["']?([^>]*?)($|["'\s>])/im, 1]
-            end
-          end
-
           # if all else fails, default to the official default encoding for HTML
-          encoding ||= Encoding::ISO_8859_1
+          encoding = detect_encoding(body, content_type) || Encoding::ISO_8859_1
 
           # change the encoding to match the detected or inferred encoding
           body = body.dup
@@ -360,6 +351,37 @@ module Nokogiri
         end
 
         body.encode(Encoding::UTF_8)
+      end
+
+      # Return the encoding the document declares for itself, or nil when it declares none. Only
+      # the first 1024 bytes are examined, per the HTML5 standard's prescan.
+      def detect_encoding(body, content_type = nil)
+        head = body.byteslice(0, 1024).b
+
+        # look for a Byte Order Mark (BOM)
+        initial_bytes = head[0..2].bytes
+        if initial_bytes[0..2] == [0xEF, 0xBB, 0xBF]
+          return Encoding::UTF_8
+        elsif initial_bytes[0..1] == [0xFE, 0xFF]
+          return Encoding::UTF_16BE
+        elsif initial_bytes[0..1] == [0xFF, 0xFE]
+          return Encoding::UTF_16LE
+        end
+
+        # look for a charset in a content-encoding header
+        if content_type
+          encoding = content_type[/charset=["']?(.*?)($|["';\s])/i, 1]
+          return encoding if encoding
+        end
+
+        # look for a charset in a meta tag in the first 1024 bytes
+        data = head.gsub(/<!--.*?(-->|\Z)/m, "")
+        data.scan(/<meta.*?>/im).each do |meta|
+          encoding = meta[/charset=["']?([^>]*?)($|["'\s>])/im, 1]
+          return encoding if encoding
+        end
+
+        nil
       end
     end
   end

--- a/test/html5/test_encoding.rb
+++ b/test/html5/test_encoding.rb
@@ -94,14 +94,6 @@ class TestHtml5Encoding < Nokogiri::TestCase
     assert_equal("こんにちは！", doc.at_css("title").content)
   end
 
-  def test_io_honors_external_encoding_chosen_by_caller
-    doc = File.open(SHIFT_JIS_NO_CHARSET, encoding: "Shift_JIS") do |io|
-      Nokogiri::HTML5::Document.parse(io)
-    end
-
-    assert_equal("こんにちは！", doc.at_css("title").content)
-  end
-
   def test_io_honors_encoding_argument
     doc = File.open(SHIFT_JIS_NO_CHARSET) do |io|
       Nokogiri::HTML5::Document.parse(io, encoding: "Shift_JIS")
@@ -121,16 +113,18 @@ class TestHtml5Encoding < Nokogiri::TestCase
       file.write("<title>Señor</title>")
       file.close
 
-      doc = File.open(file.path) { |io| Nokogiri::HTML5::Document.parse(io) }
+      doc = File.open(file.path, encoding: "UTF-8") { |io| Nokogiri::HTML5::Document.parse(io) }
 
       assert_equal("Señor", doc.at_css("title").content)
     end
   end
 
-  def test_io_sniffs_utf8_bom
-    Tempfile.create(["utf8-bom", ".html"]) do |file|
+  # A UTF-8 BOM would decode correctly under a UTF-8 locale with or without the prescan, so
+  # use a UTF-16 BOM: those bytes are not readable as anything else.
+  def test_io_sniffs_utf16_bom
+    Tempfile.create(["utf16-bom", ".html"]) do |file|
       file.binmode
-      file.write("\xEF\xBB\xBF<title>Se\xC3\xB1or</title>".b)
+      file.write("\xFF\xFE".b + "<title>Señor</title>".encode("UTF-16LE").b)
       file.close
 
       doc = File.open(file.path) { |io| Nokogiri::HTML5::Document.parse(io) }
@@ -153,6 +147,94 @@ class TestHtml5Encoding < Nokogiri::TestCase
         Nokogiri::HTML5::Document.parse(markup.b).at_css("title").content,
         from_io.at_css("title").content,
       )
+    end
+  end
+
+  # A declaration whose encoding cannot decode the document's bytes raises, and raises the same
+  # way whether the markup arrives as an IO or as a binary String. Which error it is depends on
+  # how the bytes fail: a sequence Shift_JIS does not allow at all, or one it allows but leaves
+  # unassigned.
+  def test_io_raises_when_the_declaration_cannot_decode_the_bytes
+    {
+      "日本語".encode("EUC-JP") => Encoding::UndefinedConversionError,
+      "日本語".encode("UTF-8") => Encoding::InvalidByteSequenceError,
+    }.each do |body, error|
+      markup = %(<meta charset="Shift_JIS"><title>).b + body.b + %(</title>).b
+
+      Tempfile.create(["mismatched-charset", ".html"]) do |file|
+        file.binmode
+        file.write(markup)
+        file.close
+
+        assert_raises(error) do
+          File.open(file.path) { |io| Nokogiri::HTML5::Document.parse(io) }
+        end
+        assert_raises(error) { Nokogiri::HTML5::Document.parse(markup) }
+      end
+    end
+  end
+
+  # A StringIO reports the encoding of the String it holds, so wrapping a String in one must
+  # not change how the markup is decoded.
+  def test_stringio_decodes_like_the_string_it_wraps
+    markup = %(<meta charset="iso-8859-1"><title>Señor</title>)
+
+    assert_equal(
+      Nokogiri::HTML5::Document.parse(markup).at_css("title").content,
+      Nokogiri::HTML5::Document.parse(StringIO.new(markup)).at_css("title").content,
+    )
+  end
+
+  def test_binary_stringio_decodes_like_the_string_it_wraps
+    markup = %(<meta charset="iso-8859-1"><title>Señor</title>).b
+
+    assert_equal(
+      Nokogiri::HTML5::Document.parse(markup).at_css("title").content,
+      Nokogiri::HTML5::Document.parse(StringIO.new(markup)).at_css("title").content,
+    )
+  end
+
+  def test_fragment_stringio_decodes_like_the_string_it_wraps
+    markup = %(<meta charset="iso-8859-1"><title>Se\u00F1or</title>)
+
+    assert_equal(
+      Nokogiri::HTML5::DocumentFragment.parse(markup).at_css("title").content,
+      Nokogiri::HTML5::DocumentFragment.parse(StringIO.new(markup)).at_css("title").content,
+    )
+  end
+
+  # The standard's labels are not Ruby encoding names, so each one Ruby rejects is normalized.
+  # Use bytes that decode differently under each target so a wrong mapping shows up.
+  def test_declaration_labels_ruby_does_not_know_are_normalized
+    {
+      "utf8" => "\u00F1",
+      "unicode-1-1-utf-8" => "\u00F1",
+      "UTF8" => "\u00F1",
+      "latin1" => "\u00C3\u00B1",
+      "shift-jis" => "\u3042",
+      "x-sjis" => "\u3042",
+      "ms932" => "\u3042",
+      "csshiftjis" => "\u3042",
+    }.each do |label, expected|
+      body = label.downcase.match?(/sjis|shift|932/) ? "\x82\xA0".b : "\xC3\xB1".b
+      markup = %(<meta charset="#{label}"><title>).b + body + %(</title>).b
+
+      assert_equal(expected, Nokogiri::HTML5::Document.parse(markup).at_css("title").content, label)
+    end
+  end
+
+  # "Get an encoding" fails on an empty label, so the prescan moves on to the next `meta`
+  # instead of treating `charset=""` as a declaration.
+  def test_an_empty_charset_is_not_a_declaration
+    markup = %(<meta charset=""><meta charset="utf-8"><title>Se\xC3\xB1or</title>).b
+
+    Tempfile.create(["empty-charset", ".html"]) do |file|
+      file.binmode
+      file.write(markup)
+      file.close
+
+      assert_equal("Señor", File.open(file.path) { |io| Nokogiri::HTML5::Document.parse(io) }.at_css("title").content)
+      assert_equal("Señor", Nokogiri::HTML5::Document.parse(markup).at_css("title").content)
     end
   end
 

--- a/test/html5/test_encoding.rb
+++ b/test/html5/test_encoding.rb
@@ -87,6 +87,75 @@ class TestHtml5Encoding < Nokogiri::TestCase
     end
   end
 
+  # https://github.com/sparklemotion/nokogiri/issues/2801
+  def test_io_sniffs_meta_charset
+    doc = File.open(SHIFT_JIS_HTML) { |io| Nokogiri::HTML5::Document.parse(io) }
+
+    assert_equal("こんにちは！", doc.at_css("title").content)
+  end
+
+  def test_io_honors_external_encoding_chosen_by_caller
+    doc = File.open(SHIFT_JIS_NO_CHARSET, encoding: "Shift_JIS") do |io|
+      Nokogiri::HTML5::Document.parse(io)
+    end
+
+    assert_equal("こんにちは！", doc.at_css("title").content)
+  end
+
+  def test_io_honors_encoding_argument
+    doc = File.open(SHIFT_JIS_NO_CHARSET) do |io|
+      Nokogiri::HTML5::Document.parse(io, encoding: "Shift_JIS")
+    end
+
+    assert_equal("こんにちは！", doc.at_css("title").content)
+  end
+
+  def test_fragment_io_sniffs_meta_charset
+    frag = File.open(SHIFT_JIS_HTML) { |io| Nokogiri::HTML5::DocumentFragment.parse(io) }
+
+    assert_equal("こんにちは！", frag.at_css("h2").content)
+  end
+
+  def test_io_keeps_its_encoding_when_the_document_declares_none
+    Tempfile.create(["utf8-no-charset", ".html"]) do |file|
+      file.write("<title>Señor</title>")
+      file.close
+
+      doc = File.open(file.path) { |io| Nokogiri::HTML5::Document.parse(io) }
+
+      assert_equal("Señor", doc.at_css("title").content)
+    end
+  end
+
+  def test_io_sniffs_utf8_bom
+    Tempfile.create(["utf8-bom", ".html"]) do |file|
+      file.binmode
+      file.write("\xEF\xBB\xBF<title>Se\xC3\xB1or</title>".b)
+      file.close
+
+      doc = File.open(file.path) { |io| Nokogiri::HTML5::Document.parse(io) }
+
+      assert_equal("Señor", doc.at_css("title").content)
+    end
+  end
+
+  # A document that declares an encoding its bytes do not use is decoded by the declaration,
+  # matching what a binary String already does.
+  def test_io_prefers_the_declaration_over_the_bytes
+    markup = %(<meta charset="Shift_JIS"><title>Señor</title>)
+    Tempfile.create(["mismatched-charset", ".html"]) do |file|
+      file.write(markup)
+      file.close
+
+      from_io = File.open(file.path) { |io| Nokogiri::HTML5::Document.parse(io) }
+
+      assert_equal(
+        Nokogiri::HTML5::Document.parse(markup.b).at_css("title").content,
+        from_io.at_css("title").content,
+      )
+    end
+  end
+
   # https://github.com/rubys/nokogumbo/issues/68
   def test_charset_sniff_to_html
     html = <<-EOF.gsub(/^      /, "")


### PR DESCRIPTION
**What problem is this PR intended to solve?**

#2801, items 2 and 3 in @flavorjones's comment there: passing a File together with an
encoding raises `TypeError`, and HTML5 encoding detection does not follow the HTML5
behavior. A Shift_JIS document passed as `File.open(path)` parses with replacement
characters, where the same bytes read with `File.binread` parse correctly.

`#reencode`, where a BOM or a `meta` charset declaration is read, only runs for input
tagged `ASCII-8BIT`, and `File.open(path).read` tags its result with
`Encoding.default_external`, which reflects the locale rather than the document. This PR
prefers a declared encoding instead, while preserving the IO's encoding when the
document declares none. An explicit `encoding:` argument to `parse` and an IO configured
for transcoding still take precedence. An IO's external encoding does not: Ruby records
nothing about whether it was chosen by the caller or inherited from the locale, so it
cannot stand in for what the document says about itself.

One input shape changes behavior: an IO whose document declares an encoding that cannot
decode its bytes now raises. Which error depends on how the bytes fail —
`Encoding::InvalidByteSequenceError` when the sequence is not valid in the declared
encoding, `Encoding::UndefinedConversionError` when the sequence is valid there but that
position is unassigned. Both match what `Nokogiri::HTML5(File.binread(path))` of the same
bytes already raises.

This leaves `doc.encoding` alone, so the assertions in the issue still report `"UTF-8"`.
Per @stevecheckoway's comment there, that value is deliberately the encoding of the
strings in the document, and how it should interact with serialization is still open.

**Have you included adequate test coverage?**

Twelve tests in `test/html5/test_encoding.rb`; eight fail without this change, and four
cover behavior that must be preserved.

**Does this change affect the behavior of either the C or the Java implementations?**

CRuby only. HTML5 is not available on JRuby.

