### PR TITLE
Close files opened for Pathname document parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Nokogiri follows [Semantic Versioning](https://semver.org/), please see the [REA
 
 ### Fixed
 
+* `XML::Document.parse` and `HTML4::Document.parse` close files they open for `Pathname` inputs. (#3682) @OskarEichler
 * [CRuby] When a namespace is set on an unparented node, ensure the namespace is defined on the node. (#3459, #3462)
 * [CRuby] Builder now correctly builds namespaced nodes that define their own namespace when that ns prefix collides with one defined by the parent (or another ancestor). (#3458, #3461) @flavorjones
 * [CRuby] `Reader.outer_xml` and `.inner_xml` properly capture syntax errors. (#3558) @flavorjones

--- a/lib/nokogiri/html4/document.rb
+++ b/lib/nokogiri/html4/document.rb
@@ -205,8 +205,9 @@ module Nokogiri
           if input.respond_to?(:read)
             if input.is_a?(Pathname)
               # resolve the Pathname to the file and open it as an IO object, see #2110
-              input = input.expand_path.open
-              url ||= input.path
+              return input.expand_path.open do |io|
+                parse(io, url: url, encoding: encoding, options: options)
+              end
             end
 
             unless encoding

--- a/lib/nokogiri/xml/document.rb
+++ b/lib/nokogiri/xml/document.rb
@@ -75,8 +75,9 @@ module Nokogiri
             # TODO: should we instead check for respond_to?(:to_path) ?
             if string_or_io.is_a?(Pathname)
               # resolve the Pathname to the file and open it as an IO object, see #2110
-              string_or_io = string_or_io.expand_path.open
-              url ||= string_or_io.path
+              return string_or_io.expand_path.open do |io|
+                parse(io, url: url, encoding: encoding, options: options)
+              end
             end
 
             read_io(string_or_io, url, encoding, options.to_i)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,7 @@ require "nokogiri"
 
 require_relative "helpers/memory_debugger"
 require_relative "helpers/mock_server"
+require_relative "helpers/tracking_pathname"
 
 if ENV["TEST_NOKOGIRI_WITH_LIBXML_RUBY"]
   #

--- a/test/helpers/tracking_pathname.rb
+++ b/test/helpers/tracking_pathname.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+module Nokogiri
+  module TestHelpers
+    class TrackingPathname < Pathname
+      attr_reader :opened_io
+
+      def expand_path
+        self
+      end
+
+      def open(*args, &block)
+        if block
+          super(*args) do |io|
+            @opened_io = io
+            block.call(io)
+          end
+        else
+          @opened_io = super(*args)
+        end
+      end
+    end
+  end
+end

--- a/test/html4/test_document.rb
+++ b/test/html4/test_document.rb
@@ -6,25 +6,6 @@ module Nokogiri
   module HTML4
     class TestDocument < Nokogiri::TestCase
       describe Nokogiri::HTML4::Document do
-        class TrackingPathname < Pathname
-          attr_reader :opened_io
-
-          def expand_path
-            self
-          end
-
-          def open(*args, &block)
-            if block
-              super(*args) do |io|
-                @opened_io = io
-                block.call(io)
-              end
-            else
-              @opened_io = super(*args)
-            end
-          end
-        end
-
         let(:html) { Nokogiri::HTML4.parse(File.read(HTML_FILE)) }
 
         def test_nil_css
@@ -649,7 +630,7 @@ module Nokogiri
         def test_parse_can_take_pathnames
           assert_operator(File.size(HTML_FILE), :>, 4096) # file must be big enough to trip the read callback more than once
 
-          pathname = TrackingPathname.new(HTML_FILE)
+          pathname = Nokogiri::TestHelpers::TrackingPathname.new(HTML_FILE)
           doc = Nokogiri::HTML4.parse(pathname)
 
           # an arbitrary assertion on the structure of the document

--- a/test/html4/test_document.rb
+++ b/test/html4/test_document.rb
@@ -6,6 +6,25 @@ module Nokogiri
   module HTML4
     class TestDocument < Nokogiri::TestCase
       describe Nokogiri::HTML4::Document do
+        class TrackingPathname < Pathname
+          attr_reader :opened_io
+
+          def expand_path
+            self
+          end
+
+          def open(*args, &block)
+            if block
+              super(*args) do |io|
+                @opened_io = io
+                block.call(io)
+              end
+            else
+              @opened_io = super(*args)
+            end
+          end
+        end
+
         let(:html) { Nokogiri::HTML4.parse(File.read(HTML_FILE)) }
 
         def test_nil_css
@@ -630,11 +649,13 @@ module Nokogiri
         def test_parse_can_take_pathnames
           assert_operator(File.size(HTML_FILE), :>, 4096) # file must be big enough to trip the read callback more than once
 
-          doc = Nokogiri::HTML4.parse(Pathname.new(HTML_FILE))
+          pathname = TrackingPathname.new(HTML_FILE)
+          doc = Nokogiri::HTML4.parse(pathname)
 
           # an arbitrary assertion on the structure of the document
           assert_equal(166, doc.css("a").length)
           assert_equal(HTML_FILE, doc.url)
+          assert_predicate(pathname.opened_io, :closed?)
         end
 
         def test_html?

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -8,6 +8,25 @@ module Nokogiri
   module XML
     class TestDocument < Nokogiri::TestCase
       describe Nokogiri::XML::Document do
+        class TrackingPathname < Pathname
+          attr_reader :opened_io
+
+          def expand_path
+            self
+          end
+
+          def open(*args, &block)
+            if block
+              super(*args) do |io|
+                @opened_io = io
+                block.call(io)
+              end
+            else
+              @opened_io = super(*args)
+            end
+          end
+        end
+
         URI = if URI.const_defined?(:DEFAULT_PARSER)
           ::URI::DEFAULT_PARSER
         else
@@ -788,7 +807,8 @@ module Nokogiri
         def test_parse_can_take_pathnames
           assert_operator(File.size(XML_ATOM_FILE), :>, 4096) # file must be big enough to trip the read callback more than once
 
-          doc = Nokogiri::XML.parse(Pathname.new(XML_ATOM_FILE))
+          pathname = TrackingPathname.new(XML_ATOM_FILE)
+          doc = Nokogiri::XML.parse(pathname)
 
           # an arbitrary assertion on the structure of the document
           assert_equal(20, doc.xpath(
@@ -796,6 +816,7 @@ module Nokogiri
             "xmlns" => "http://www.w3.org/2005/Atom",
           ).length)
           assert_equal(XML_ATOM_FILE, doc.url)
+          assert_predicate(pathname.opened_io, :closed?)
         end
 
         def test_search_on_empty_documents

--- a/test/xml/test_document.rb
+++ b/test/xml/test_document.rb
@@ -8,25 +8,6 @@ module Nokogiri
   module XML
     class TestDocument < Nokogiri::TestCase
       describe Nokogiri::XML::Document do
-        class TrackingPathname < Pathname
-          attr_reader :opened_io
-
-          def expand_path
-            self
-          end
-
-          def open(*args, &block)
-            if block
-              super(*args) do |io|
-                @opened_io = io
-                block.call(io)
-              end
-            else
-              @opened_io = super(*args)
-            end
-          end
-        end
-
         URI = if URI.const_defined?(:DEFAULT_PARSER)
           ::URI::DEFAULT_PARSER
         else
@@ -807,7 +788,7 @@ module Nokogiri
         def test_parse_can_take_pathnames
           assert_operator(File.size(XML_ATOM_FILE), :>, 4096) # file must be big enough to trip the read callback more than once
 
-          pathname = TrackingPathname.new(XML_ATOM_FILE)
+          pathname = Nokogiri::TestHelpers::TrackingPathname.new(XML_ATOM_FILE)
           doc = Nokogiri::XML.parse(pathname)
 
           # an arbitrary assertion on the structure of the document


### PR DESCRIPTION
## Summary

- parse Pathname inputs through block-form Pathname#open
- preserve XML and HTML4 URL, encoding, parse options, and XML XInclude behavior
- add cross-platform regression coverage asserting the internally opened stream is closed
- document the fix in the unreleased changelog

Fixes #3682.

## Problem

XML::Document.parse and HTML4::Document.parse opened Pathname inputs without closing the internally owned streams. Repeated parsing could therefore retain file descriptors until garbage collection.

## Verification

- XML Pathname regression test: 1 run, 7 assertions, 0 failures
- HTML4 Pathname regression test: 1 run, 7 assertions, 0 failures
- Ruby syntax checks for both implementation and test files
- git diff --check

The focused tests loaded the patched current-main Ruby sources against the official Nokogiri 1.19.4 arm64-darwin native extension. The full native and cross-platform matrix is left to CI.