### PR TITLE
test: require json after bundler/setup in the VersionInfo subprocess

### DIFF
--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -107,7 +107,7 @@ class TestVersionInfo
   class Base < Nokogiri::TestCase
     let(:version_info) do
       version_info = Dir.chdir(ROOTDIR) do
-        %x(#{RUBYEXEC} -Ilib -rjson -e 'require "#{require_name}"; puts Nokogiri::VERSION_INFO.to_json')
+        %x(#{RUBYEXEC} -Ilib -e 'require "json"; require "#{require_name}"; puts Nokogiri::VERSION_INFO.to_json')
       end
       JSON.parse(version_info)
     end


### PR DESCRIPTION
**What problem is this PR intended to solve?**

The `upstream` workflow's `ruby-head` jobs have failed since [2026-08-12](https://github.com/sparklemotion/nokogiri/actions/runs/31578232075) (latest: [run 33851389892](https://github.com/sparklemotion/nokogiri/actions/runs/33851389892)). The four errors are all in `test/test_version.rb`, whose subprocess

    ruby -Ilib -rjson -e 'require "nokogiri"; puts Nokogiri::VERSION_INFO.to_json'

aborts with:

    You have already activated json 3.0.0.rc1, but your Gemfile requires json 2.21.2

Two ruby changes combine to cause this:

- [ruby/ruby@cadf8e7933](https://github.com/ruby/ruby/commit/cadf8e7933) ([Feature #21951](https://bugs.ruby-lang.org/issues/21951)): on Ruby 4.1 the RubyGems prelude no longer requires `bundler/setup`, so the `-rbundler/setup` in `RUBYOPT` now runs *after* the command line's `-rjson`, which activates the default json gem first.
- [ruby/ruby@f51515f39a](https://github.com/ruby/ruby/commit/f51515f39a): the default json gem became 3.0.0.rc1, while the lockfile resolves json 2.21.2 (a rubocop dependency). Bundler refuses the mismatch.

This PR drops `-rjson` and requires json inside the `-e` script, after Bundler has set up.

**Have you included adequate test coverage?**

This is a test-only change. With a locally built ruby master (`4.1.0dev e536482403`, default json 3.0.0.rc1), `test/test_version.rb` goes from 4 errors to 0; it still passes on Ruby 4.0.

**Does this change affect the behavior of either the C or the Java implementations?**

No.
